### PR TITLE
Move dependencies to file sharable with fixtures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,5 @@
 buildscript {
-	ext.versions = [
-		'kotlin': '1.4.32',
-		'kotlinxCoroutines': '1.4.3',
-	]
-	ext.deps = [
-		'kotlinCompiler': "org.jetbrains.kotlin:kotlin-compiler:${versions.kotlin}",
-		'kotlinGradlePlugin': "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
-		'kotlinxCoroutinesCore': "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinxCoroutines}",
-		'kotlinxCoroutinesTest': "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinxCoroutines}",
-		'junit': 'junit:junit:4.13.2',
-		'truth': 'com.google.truth:truth:1.1',
-	]
+	apply from: 'dependencies.gradle'
 
 	dependencies {
 		classpath deps.kotlinGradlePlugin

--- a/compose/build.gradle
+++ b/compose/build.gradle
@@ -3,12 +3,18 @@ if (!file('upstream/.git').exists()) {
 		"Missing 'upstream' git submodule clone. Did you run 'git submodule update --init'?")
 }
 
-def upstreamDependencyVersions = file('upstream/gradle/libs.versions.toml').text
-if (!upstreamDependencyVersions.contains("kotlin = \"${versions.kotlin}\"")) {
+def upstreamToml = file('upstream/gradle/libs.versions.toml').text
+if (!upstreamToml.contains("kotlin = \"${versions.kotlin}\"")) {
 	throw new RuntimeException(
 		"Upstream git repository Kotlin version does not match project dependency version ${versions.kotlin}")
 }
-if (!upstreamDependencyVersions.contains("kotlinCoroutines = \"${versions.kotlinxCoroutines}\"")) {
+if (!upstreamToml.contains("kotlinCoroutines = \"${versions.kotlinxCoroutines}\"")) {
 	throw new RuntimeException(
 		"Upstream git repository Kotlin coroutines version does not match project dependency version ${versions.kotlinxCoroutines}")
+}
+
+def upstreamBuildGradle = file('upstream/compose/runtime/runtime/build.gradle').text
+if (!upstreamBuildGradle.contains(deps.kotlinxCollectionsImmutable)) {
+	throw new RuntimeException(
+		"Upstream git repository kotlinx-collections-immutable version does not match project version ${deps.kotlinxCollectionsImmutable}")
 }

--- a/compose/runtime/build.gradle
+++ b/compose/runtime/build.gradle
@@ -22,7 +22,7 @@ sourceSets {
 
 dependencies {
 	api deps.kotlinxCoroutinesCore
-	api 'org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.4'
+	implementation deps.kotlinxCollectionsImmutable
 
 	add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, project(':compose:compiler'))
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,16 @@
+buildscript {
+	ext.versions = [
+		'kotlin': '1.4.32',
+		'kotlinxCoroutines': '1.4.3',
+	]
+	ext.deps = [
+		'kotlinCompiler': "org.jetbrains.kotlin:kotlin-compiler:${versions.kotlin}",
+		'kotlinGradlePlugin': "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
+		'kotlinxCoroutinesCore': "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinxCoroutines}",
+		'kotlinxCoroutinesTest': "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinxCoroutines}",
+		'kotlinxCollectionsImmutable': 'org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.4',
+		'junit': 'junit:junit:4.13.2',
+		'truth': 'com.google.truth:truth:1.1.2',
+		'jansi': 'org.fusesource.jansi:jansi:2.0.1',
+	]
+}

--- a/mosaic-gradle/src/test/fixture/counter/build.gradle
+++ b/mosaic-gradle/src/test/fixture/counter/build.gradle
@@ -1,6 +1,8 @@
 buildscript {
+	apply from: "../../../../../dependencies.gradle"
+
 	dependencies {
-		classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32'
+		classpath deps.kotlinGradlePlugin
 		classpath "com.jakewharton.mosaic:gradle:${mosaicVersion}"
 	}
 	repositories {
@@ -15,7 +17,7 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.jakewharton.mosaic'
 
 dependencies {
-	testImplementation 'junit:junit:4.13.2'
+	testImplementation deps.junit
 }
 
 repositories {

--- a/mosaic/build.gradle
+++ b/mosaic/build.gradle
@@ -6,10 +6,10 @@ apply plugin: 'com.vanniktech.maven.publish'
 dependencies {
 	api project(':compose:runtime')
 	implementation project(':yoga')
-	implementation 'org.fusesource.jansi:jansi:2.0.1'
+	implementation deps.jansi
 
-	testImplementation 'junit:junit:4.13'
-	testImplementation 'com.google.truth:truth:1.0.1'
+	testImplementation deps.junit
+	testImplementation deps.truth
 
 	add(KotlinPluginKt.PLUGIN_CLASSPATH_CONFIGURATION_NAME, project(':compose:compiler'))
 }


### PR DESCRIPTION
This also fixes the scope of the kotlinx-collection-immutable dependency in the runtime to be internal. We also now validate our version matches upstream.

Closes #13 