### PR TITLE
Drop google repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ subprojects {
 
 	repositories {
 		mavenCentral()
-		google()
 	}
 
 	tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {


### PR DESCRIPTION
Now that we build our own compiler, we do not need theirs.