### PR TITLE
Remove superfluous remember

### DIFF
--- a/examples/robot/src/main/kotlin/example/robot.kt
+++ b/examples/robot/src/main/kotlin/example/robot.kt
@@ -2,7 +2,7 @@ package example
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import com.jakewharton.mosaic.Column
 import com.jakewharton.mosaic.Text
 import com.jakewharton.mosaic.runMosaic
@@ -15,13 +15,10 @@ private const val height = 10
 
 fun main() = runMosaic {
 	// TODO https://github.com/JakeWharton/mosaic/issues/3
-	val xValue = mutableStateOf(0)
-	val yValue = mutableStateOf(0)
+	var x by mutableStateOf(0)
+	var y by mutableStateOf(0)
 
 	setContent {
-		val x by remember { xValue }
-		val y by remember { yValue }
-
 		Column {
 			Text("Use arrow keys to move the face. Press “q” to exit.")
 			Text("Position: $x, $y   World: $width, $height")
@@ -51,10 +48,10 @@ fun main() = runMosaic {
 					when (reader.read()) {
 						91 -> {
 							when (reader.read()) {
-								65 -> yValue.value = (yValue.value - 1).coerceAtLeast(0)
-								66 -> yValue.value = (yValue.value + 1).coerceAtMost(height)
-								67 -> xValue.value = (xValue.value + 1).coerceAtMost(width)
-								68 -> xValue.value = (xValue.value - 1).coerceAtLeast(0)
+								65 -> y = (y - 1).coerceAtLeast(0)
+								66 -> y = (y + 1).coerceAtMost(height)
+								67 -> x = (x + 1).coerceAtMost(width)
+								68 -> x = (x - 1).coerceAtLeast(0)
 							}
 						}
 					}


### PR DESCRIPTION
These were probably left over from attempting to migrate to LaunchedEffect. Until that change, they are not needed since the state objects are captured.