### PR TITLE
Use full wildcards for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,9 +4,9 @@ on:
   pull_request: {}
   push:
     branches:
-      - '*'
+      - '**'
     tags-ignore:
-      - '*'
+      - '**'
 
 jobs:
   build:


### PR DESCRIPTION
This fixes branch builds which contain slashes, as mine do.