### PR TITLE
Move static rendering to node side-channel

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/Static.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/Static.kt
@@ -86,18 +86,26 @@ internal class StaticNode : ContainerNode() {
 	}
 
 	override fun renderTo(canvas: TextCanvas) {
+		// No content.
+	}
+
+	override fun renderStatics(): List<TextCanvas> {
+		val statics = mutableListOf<TextCanvas>()
+
 		// Render contents of static node to a separate display.
-		val other = box.render()
+		val static = box.render()
 
 		// Add display canvas to static canvases if it is not empty.
-		if (other.width > 0 && other.height > 0) {
-			canvas.static.add(other)
+		if (static.width > 0 && static.height > 0) {
+			statics.add(static)
 		}
 
 		// Propagate any static content of the display.
-		canvas.static.addAll(other.static)
+		statics.addAll(box.renderStatics())
 
 		postRender()
+
+		return statics
 	}
 
 	override fun toString() = box.children.joinToString(prefix = "Static(", postfix = ")")

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/canvas.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/canvas.kt
@@ -15,9 +15,6 @@ internal interface TextCanvas {
 	val width: Int
 	val height: Int
 
-	/** Separate canvases for [static][StaticNode] content. */
-	val static: MutableList<TextCanvas>
-
 	operator fun get(row: Int, column: Int): TextCodepoint
 
 	operator fun get(row: Int, columns: IntRange) = get(row..row, columns)
@@ -97,9 +94,6 @@ internal class ClippedTextCanvas(
 	override val width = right - left + 1
 	override val height = bottom - top + 1
 
-	override val static: MutableList<TextCanvas>
-		get() = delegate.static
-
 	override fun get(row: Int, column: Int): TextCodepoint {
 		require(row in 0 until height) { "Row value out of range [0,$height): $row"}
 		require(column in 0 until width) { "Column value out of range [0,$width): $column"}
@@ -125,8 +119,6 @@ internal class TextSurface(
 	override val height: Int,
 ) : TextCanvas {
 	private val rows = Array(height) { Array(width) { TextCodepoint(' ') } }
-
-	override val static = mutableListOf<TextCanvas>()
 
 	override operator fun get(row: Int, column: Int) = rows[row][column]
 

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -51,7 +51,10 @@ suspend fun runMosaic(body: suspend MosaicScope.() -> Unit) = coroutineScope {
 				hasFrameWaiters = false
 				clock.sendFrame(0L) // Frame time value is not used by Compose runtime.
 
-				output.display(rootNode.render())
+				val canvas = rootNode.render()
+				val statics = rootNode.renderStatics()
+				output.display(canvas, statics)
+
 				displaySignal?.complete(Unit)
 			}
 			delay(50)

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nodes.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nodes.kt
@@ -27,6 +27,8 @@ internal sealed class MosaicNode {
 		renderTo(canvas)
 		return canvas
 	}
+
+	abstract fun renderStatics(): List<TextCanvas>
 }
 
 internal class TextNode(initialValue: String = "") : MosaicNode() {
@@ -59,6 +61,8 @@ internal class TextNode(initialValue: String = "") : MosaicNode() {
 			canvas.write(index, 0, line, foreground, background, style)
 		}
 	}
+
+	override fun renderStatics() = emptyList<TextCanvas>()
 
 	override fun toString() = "Text(\"$value\", x=$x, y=$y, width=$width, height=$height)"
 }
@@ -142,6 +146,10 @@ internal class LinearNode(var isRow: Boolean = true) : ContainerNode() {
 				child.renderTo(canvas.empty())
 			}
 		}
+	}
+
+	override fun renderStatics(): List<TextCanvas> {
+		return children.flatMap(MosaicNode::renderStatics)
 	}
 
 	override fun toString() = children.joinToString(prefix = "Box(", postfix = ")")

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/output.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/output.kt
@@ -5,7 +5,7 @@ import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 
 internal interface Output {
-	fun display(canvas: TextCanvas)
+	fun display(canvas: TextCanvas, statics: List<TextCanvas>)
 }
 
 @OptIn(ExperimentalTime::class) // Not used in production.
@@ -13,7 +13,7 @@ internal object DebugOutput : Output {
 	private val systemClock = TimeSource.Monotonic
 	private var lastRender: TimeMark? = null
 
-	override fun display(canvas: TextCanvas) {
+	override fun display(canvas: TextCanvas, statics: List<TextCanvas>) {
 		println(buildString {
 			lastRender?.let { lastRender ->
 				repeat(50) { append('~') }
@@ -22,7 +22,7 @@ internal object DebugOutput : Output {
 			}
 			lastRender = systemClock.markNow()
 
-			for (static in canvas.static) {
+			for (static in statics) {
 				appendLine(static.render())
 			}
 
@@ -35,7 +35,7 @@ internal object AnsiOutput : Output {
 	private val stringBuilder = StringBuilder(100)
 	private var lastHeight = 0
 
-	override fun display(canvas: TextCanvas) {
+	override fun display(canvas: TextCanvas, statics: List<TextCanvas>) {
 		stringBuilder.apply {
 			clear()
 
@@ -43,7 +43,7 @@ internal object AnsiOutput : Output {
 				append("\u001B[F") // Cursor up line.
 			}
 
-			val staticLines = canvas.static.flatMap { it.render().split("\n") }
+			val staticLines = statics.flatMap { it.render().split("\n") }
 			val lines = canvas.render().split("\n")
 			for (line in staticLines + lines) {
 				append(line)


### PR DESCRIPTION
This is a bit cleaner than having the side-channel be within a `TextCanvas`. It also frees us up to experiment with different rendering backends more easily.