### PR TITLE
Use a single node type in the tree

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -26,7 +26,7 @@ internal fun mosaicNodes(content: @Composable () -> Unit): MosaicNode {
 	val job = Job()
 	val composeContext = clock + job
 
-	val rootNode = RootNode()
+	val rootNode = MosaicNode.root()
 	val recomposer = Recomposer(composeContext)
 	val composition = Composition(MosaicNodeApplier(rootNode), recomposer)
 
@@ -64,7 +64,7 @@ public suspend fun runMosaic(body: suspend MosaicScope.() -> Unit): Unit = corou
 	val job = Job(coroutineContext[Job])
 	val composeContext = coroutineContext + clock + job
 
-	val rootNode = RootNode()
+	val rootNode = MosaicNode.root()
 	val recomposer = Recomposer(composeContext)
 	val composition = Composition(MosaicNodeApplier(rootNode), recomposer)
 

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -32,12 +32,12 @@ public fun renderMosaic(content: @Composable () -> Unit): String {
 
 	composition.setContent(content)
 
+	job.cancel()
+	composition.dispose()
+
 	val canvas = rootNode.draw()
 	val statics = rootNode.drawStatics()
 	val render = AnsiRendering().render(canvas, statics)
-
-	job.cancel()
-	composition.dispose()
 
 	return render.toString()
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -26,7 +26,7 @@ public fun renderMosaic(content: @Composable () -> Unit): String {
 	val job = Job()
 	val composeContext = clock + job
 
-	val rootNode = BoxNode()
+	val rootNode = RootNode()
 	val recomposer = Recomposer(composeContext)
 	val composition = Composition(MosaicNodeApplier(rootNode), recomposer)
 
@@ -62,7 +62,7 @@ public suspend fun runMosaic(body: suspend MosaicScope.() -> Unit): Unit = corou
 	val job = Job(coroutineContext[Job])
 	val composeContext = coroutineContext + clock + job
 
-	val rootNode = BoxNode()
+	val rootNode = RootNode()
 	val recomposer = Recomposer(composeContext)
 	val composition = Composition(MosaicNodeApplier(rootNode), recomposer)
 

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.yield
  */
 private const val debugOutput = false
 
-public fun renderMosaic(content: @Composable () -> Unit): String {
+internal fun mosaicNodes(content: @Composable () -> Unit): MosaicNode {
 	val clock = BroadcastFrameClock()
 	val job = Job()
 	val composeContext = clock + job
@@ -35,10 +35,12 @@ public fun renderMosaic(content: @Composable () -> Unit): String {
 	job.cancel()
 	composition.dispose()
 
-	val canvas = rootNode.draw()
-	val statics = rootNode.drawStatics()
-	val render = AnsiRendering().render(canvas, statics)
+	return rootNode
+}
 
+public fun renderMosaic(content: @Composable () -> Unit): String {
+	val rootNode = mosaicNodes(content)
+	val render = AnsiRendering().render(rootNode)
 	return render.toString()
 }
 
@@ -78,9 +80,7 @@ public suspend fun runMosaic(body: suspend MosaicScope.() -> Unit): Unit = corou
 				hasFrameWaiters = false
 				clock.sendFrame(0L) // Frame time value is not used by Compose runtime.
 
-				val canvas = rootNode.draw()
-				val statics = rootNode.drawStatics()
-				val render = rendering.render(canvas, statics)
+				val render = rendering.render(rootNode)
 				platformDisplay(render)
 
 				displaySignal?.complete(Unit)

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nodes.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nodes.kt
@@ -1,262 +1,184 @@
 package com.jakewharton.mosaic
 
 import androidx.compose.runtime.AbstractApplier
-import de.cketti.codepoints.codePointCount
+import androidx.compose.runtime.Applier
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReusableComposeNode
 
-internal sealed class MosaicNode {
-	// These two values are set by a call to `measure`.
+internal fun interface MeasurePolicy {
+	fun MosaicNode.performMeasure()
+}
+
+internal fun interface LayoutPolicy {
+	fun MosaicNode.performLayout()
+}
+
+internal fun interface DrawPolicy {
+	fun MosaicNode.performDraw(canvas: TextCanvas)
+
+	companion object {
+		val Children = DrawPolicy { canvas ->
+			for (child in children) {
+				if (child.width != 0 && child.height != 0) {
+					val left = child.x
+					val top = child.y
+					val right = left + child.width - 1
+					val bottom = top + child.height - 1
+					child.drawTo(canvas[top..bottom, left..right])
+				} else {
+					child.drawTo(canvas.empty())
+				}
+			}
+		}
+	}
+}
+
+internal fun interface StaticDrawPolicy {
+	fun MosaicNode.performDrawStatics(): List<TextCanvas>
+
+	companion object {
+		val Children = StaticDrawPolicy {
+			var statics: MutableList<TextCanvas>? = null
+			for (child in children) {
+				val childStatics = child.drawStatics()
+				if (childStatics.isNotEmpty()) {
+					if (statics == null) {
+						statics = mutableListOf()
+					}
+					statics += childStatics
+				}
+			}
+			statics ?: emptyList()
+		}
+	}
+}
+
+internal fun interface DebugPolicy {
+	fun MosaicNode.renderDebug(): String
+}
+
+internal class MosaicNode(
+	var measurePolicy: MeasurePolicy,
+	var layoutPolicy: LayoutPolicy,
+	var drawPolicy: DrawPolicy,
+	var staticDrawPolicy: StaticDrawPolicy,
+	var debugPolicy: DebugPolicy,
+) {
+	val children: MutableList<MosaicNode> = mutableListOf()
+
+	// These two values are set by a call to `measurePolicy`.
 	var width = 0
 	var height = 0
 
-	// These two values are set by a call to `layout` on the parent node.
+	// These two values are set by a call to `layoutPolicy` on the parent node.
 	/** Pixels right relative to parent at which this node will draw. */
 	var x = 0
 	/** Pixels down relative to parent at which this node will draw. */
 	var y = 0
 
 	/** Measure this node (and any children) and update [width] and [height]. */
-	abstract fun measure()
+	fun measure() = measurePolicy.run { performMeasure() }
 	/** Layout any children nodes and update their [x] and [y] relative to this node. */
-	abstract fun layout()
-	abstract fun drawTo(canvas: TextCanvas)
+	fun layout() = layoutPolicy.run { performLayout() }
+
+	fun drawTo(canvas: TextCanvas) = drawPolicy.run { performDraw(canvas) }
 
 	fun draw(): TextCanvas {
 		measure()
 		layout()
-		val canvas = TextSurface(width, height)
-		drawTo(canvas)
-		return canvas
+		val surface = TextSurface(width, height)
+		drawTo(surface)
+		return surface
 	}
 
-	abstract fun drawStatics(): List<TextCanvas>
-}
+	fun drawStatics() = staticDrawPolicy.run { performDrawStatics() }
 
-internal class TextNode(initialValue: String = "") : MosaicNode() {
-	private var sizeInvalidated = true
-	var value: String = initialValue
-		set(value) {
-			field = value
-			sizeInvalidated = true
+	override fun toString() = debugPolicy.run { renderDebug() }
+
+	companion object {
+		val Factory: () -> MosaicNode = {
+			MosaicNode(
+				measurePolicy = ThrowingPolicy,
+				layoutPolicy = ThrowingPolicy,
+				drawPolicy = ThrowingPolicy,
+				staticDrawPolicy = ThrowingPolicy,
+				debugPolicy = ThrowingPolicy,
+			)
 		}
 
-	var foreground: Color? = null
-	var background: Color? = null
-	var style: TextStyle? = null
-
-	override fun measure() {
-		if (sizeInvalidated) {
-			val lines = value.split('\n')
-			width = lines.maxOf { it.codePointCount(0, it.length) }
-			height = lines.size
-			sizeInvalidated = false
+		fun root(): MosaicNode {
+			return MosaicNode(
+				measurePolicy = {
+					var width = 0
+					var height = 0
+					for (child in children) {
+						child.measure()
+						width = maxOf(width, child.width)
+						height = maxOf(height, child.height)
+					}
+					this.width = width
+					this.height = height
+				},
+				layoutPolicy = {
+					for (child in children) {
+						child.layout()
+					}
+				},
+				drawPolicy = DrawPolicy.Children,
+				staticDrawPolicy = StaticDrawPolicy.Children,
+				debugPolicy = {
+					children.joinToString(separator = "\n")
+				}
+			)
 		}
-	}
 
-	override fun layout() {
-		// No children.
-	}
-
-	override fun drawTo(canvas: TextCanvas) {
-		value.split('\n').forEachIndexed { index, line ->
-			canvas.write(index, 0, line, foreground, background, style)
+		private val ThrowingPolicy = object : MeasurePolicy, LayoutPolicy, DrawPolicy, StaticDrawPolicy, DebugPolicy {
+			override fun MosaicNode.performMeasure() = throw AssertionError()
+			override fun MosaicNode.performLayout() = throw AssertionError()
+			override fun MosaicNode.performDraw(canvas: TextCanvas) = throw AssertionError()
+			override fun MosaicNode.performDrawStatics() = throw AssertionError()
+			override fun MosaicNode.renderDebug() = throw AssertionError()
 		}
-	}
-
-	override fun drawStatics() = emptyList<TextCanvas>()
-
-	override fun toString() = "Text(\"$value\", x=$x, y=$y, width=$width, height=$height)"
-}
-
-internal sealed class ContainerNode : MosaicNode() {
-	abstract val children: MutableList<MosaicNode>
-}
-
-internal class RootNode : ContainerNode() {
-	override val children = mutableListOf<MosaicNode>()
-
-	override fun measure() {
-		var width = 0
-		var height = 0
-		for (child in children) {
-			child.measure()
-			width = maxOf(width, child.width)
-			height = maxOf(height, child.height)
-		}
-		this.width = width
-		this.height = height
-	}
-
-	override fun layout() {
-		for (child in children) {
-			child.layout()
-		}
-	}
-
-	override fun drawTo(canvas: TextCanvas) {
-		for (child in children) {
-			if (child.width != 0 && child.height != 0) {
-				child.drawTo(canvas[0 until child.height, 0 until child.width])
-			} else {
-				child.drawTo(canvas.empty())
-			}
-		}
-	}
-
-	override fun drawStatics(): List<TextCanvas> {
-		return children.flatMap(MosaicNode::drawStatics)
-	}
-
-	override fun toString() = children.joinToString(separator = "\n")
-}
-
-internal class LinearNode(var isRow: Boolean = true) : ContainerNode() {
-	override val children = mutableListOf<MosaicNode>()
-
-	override fun measure() {
-		if (isRow) {
-			measureRow()
-		} else {
-			measureColumn()
-		}
-	}
-
-	private fun measureRow() {
-		var width = 0
-		var height = 0
-		for (child in children) {
-			child.measure()
-			width += child.width
-			height = maxOf(height, child.height)
-		}
-		this.width = width
-		this.height = height
-	}
-
-	private fun measureColumn() {
-		var width = 0
-		var height = 0
-		for (child in children) {
-			child.measure()
-			width = maxOf(width, child.width)
-			height += child.height
-		}
-		this.width = width
-		this.height = height
-	}
-
-	override fun layout() {
-		if (isRow) {
-			layoutRow()
-		} else {
-			layoutColumn()
-		}
-	}
-
-	private fun layoutRow() {
-		var childX = 0
-		for (child in children) {
-			child.x = childX
-			child.y = 0
-			child.layout()
-			childX += child.width
-		}
-	}
-
-	private fun layoutColumn() {
-		var childY = 0
-		for (child in children) {
-			child.x = 0
-			child.y = childY
-			child.layout()
-			childY += child.height
-		}
-	}
-
-	override fun drawTo(canvas: TextCanvas) {
-		for (child in children) {
-			if (child.width != 0 && child.height != 0) {
-				val left = child.x
-				val top = child.y
-				val right = left + child.width - 1
-				val bottom = top + child.height - 1
-				child.drawTo(canvas[top..bottom, left..right])
-			} else {
-				child.drawTo(canvas.empty())
-			}
-		}
-	}
-
-	override fun drawStatics(): List<TextCanvas> {
-		return children.flatMap(MosaicNode::drawStatics)
-	}
-
-	override fun toString() = buildString {
-		append(if (isRow) "Row" else "Column")
-		children.joinTo(this, prefix = "()") { "\n" + it.toString().prependIndent("  ") }
 	}
 }
 
-internal class StaticNode(
-	private val onPostDraw: () -> Unit,
-) : ContainerNode() {
-	// Delegate container column for static content.
-	private val box = LinearNode(isRow = false)
-
-	override val children: MutableList<MosaicNode>
-		get() = box.children
-
-	override fun measure() {
-		// Not visible.
-	}
-
-	override fun layout() {
-		// Not visible.
-	}
-
-	override fun drawTo(canvas: TextCanvas) {
-		// No content.
-	}
-
-	override fun drawStatics(): List<TextCanvas> {
-		val statics = mutableListOf<TextCanvas>()
-
-		// Draw contents of static node to a separate node hierarchy.
-		val static = box.draw()
-
-		// Add display canvas to static canvases if it is not empty.
-		if (static.width > 0 && static.height > 0) {
-			statics.add(static)
-		}
-
-		// Propagate any static content of this static node.
-		statics.addAll(box.drawStatics())
-
-		onPostDraw()
-
-		return statics
-	}
-
-	override fun toString() = box.children.joinToString(prefix = "Static()") { "\n" + it.toString().prependIndent("  ") }
+@Composable
+internal inline fun Node(
+	content: @Composable () -> Unit = {},
+	measurePolicy: MeasurePolicy,
+	layoutPolicy: LayoutPolicy,
+	drawPolicy: DrawPolicy,
+	staticDrawPolicy: StaticDrawPolicy,
+	debugPolicy: DebugPolicy,
+) {
+	ReusableComposeNode<MosaicNode, Applier<Any>>(
+		factory = MosaicNode.Factory,
+		update = {
+			set(measurePolicy) { this.measurePolicy = measurePolicy }
+			set(layoutPolicy) { this.layoutPolicy = layoutPolicy }
+			set(drawPolicy) { this.drawPolicy = drawPolicy }
+			set(staticDrawPolicy) { this.staticDrawPolicy = staticDrawPolicy }
+			set(debugPolicy) { this.debugPolicy = debugPolicy }
+		},
+		content = content,
+	)
 }
 
-internal class MosaicNodeApplier(root: RootNode) : AbstractApplier<MosaicNode>(root) {
+internal class MosaicNodeApplier(root: MosaicNode) : AbstractApplier<MosaicNode>(root) {
 	override fun insertTopDown(index: Int, instance: MosaicNode) {
 		// Ignored, we insert bottom-up.
 	}
 
 	override fun insertBottomUp(index: Int, instance: MosaicNode) {
-		val boxNode = current as ContainerNode
-		boxNode.children.add(index, instance)
+		current.children.add(index, instance)
 	}
 
 	override fun remove(index: Int, count: Int) {
-		val boxNode = current as ContainerNode
-		boxNode.children.remove(index, count)
+		current.children.remove(index, count)
 	}
 
 	override fun move(from: Int, to: Int, count: Int) {
-		val boxNode = current as ContainerNode
-		boxNode.children.move(from, to, count)
+		current.children.move(from, to, count)
 	}
 
 	override fun onClear() {}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nodes.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nodes.kt
@@ -106,7 +106,7 @@ internal class RootNode : ContainerNode() {
 		return children.flatMap(MosaicNode::drawStatics)
 	}
 
-	override fun toString() = children.joinToString(prefix = "Box(", postfix = ")")
+	override fun toString() = children.joinToString(separator = "\n")
 }
 
 internal class LinearNode(var isRow: Boolean = true) : ContainerNode() {
@@ -192,7 +192,7 @@ internal class LinearNode(var isRow: Boolean = true) : ContainerNode() {
 
 	override fun toString() = buildString {
 		append(if (isRow) "Row" else "Column")
-		children.joinTo(this, prefix = "(", postfix = ")")
+		children.joinTo(this, prefix = "()") { "\n" + it.toString().prependIndent("  ") }
 	}
 }
 
@@ -236,7 +236,7 @@ internal class StaticNode(
 		return statics
 	}
 
-	override fun toString() = box.children.joinToString(prefix = "Static(", postfix = ")")
+	override fun toString() = box.children.joinToString(prefix = "Static()") { "\n" + it.toString().prependIndent("  ") }
 }
 
 internal class MosaicNodeApplier(root: RootNode) : AbstractApplier<MosaicNode>(root) {

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nodes.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nodes.kt
@@ -71,7 +71,7 @@ internal sealed class ContainerNode : MosaicNode() {
 	abstract val children: MutableList<MosaicNode>
 }
 
-internal class BoxNode : ContainerNode() {
+internal class RootNode : ContainerNode() {
 	override val children = mutableListOf<MosaicNode>()
 
 	override fun measure() {
@@ -239,7 +239,7 @@ internal class StaticNode(
 	override fun toString() = box.children.joinToString(prefix = "Static(", postfix = ")")
 }
 
-internal class MosaicNodeApplier(root: MosaicNode) : AbstractApplier<MosaicNode>(root) {
+internal class MosaicNodeApplier(root: RootNode) : AbstractApplier<MosaicNode>(root) {
 	override fun insertTopDown(index: Int, instance: MosaicNode) {
 		// Ignored, we insert bottom-up.
 	}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nodes.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nodes.kt
@@ -259,8 +259,5 @@ internal class MosaicNodeApplier(root: MosaicNode) : AbstractApplier<MosaicNode>
 		boxNode.children.move(from, to, count)
 	}
 
-	override fun onClear() {
-		val boxNode = root as ContainerNode
-		boxNode.children.clear()
-	}
+	override fun onClear() {}
 }

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
@@ -7,9 +7,11 @@ class AnsiRenderingTest {
 	private val rendering = AnsiRendering()
 
 	@Test fun firstRender() {
-		val helloCanvas = TextSurface(6, 2).apply {
-			write(0, 0, "Hello")
-			write(1, 0, "World!")
+		val hello = mosaicNodes {
+			Column {
+				Text("Hello")
+				Text("World!")
+			}
 		}
 
 		// TODO We should not draw trailing whitespace.
@@ -18,14 +20,16 @@ class AnsiRenderingTest {
 			|Hello$s
 			|World!
 			|""".trimMargin(),
-			rendering.render(helloCanvas).toString(),
+			rendering.render(hello).toString(),
 		)
 	}
 
 	@Test fun subsequentLongerRenderClearsRenderedLines() {
-		val firstCanvas = TextSurface(6, 2).apply {
-			write(0, 0, "Hello")
-			write(1, 0, "World!")
+		val first = mosaicNodes {
+			Column {
+				Text("Hello")
+				Text("World!")
+			}
 		}
 
 		assertEquals(
@@ -33,14 +37,16 @@ class AnsiRenderingTest {
 			|Hello$s
 			|World!
 			|""".trimMargin(),
-			rendering.render(firstCanvas).toString(),
+			rendering.render(first).toString(),
 		)
 
-		val secondCanvas = TextSurface(3, 4).apply {
-			write(0, 0, "Hel")
-			write(1, 0, "lo")
-			write(2, 0, "Wor")
-			write(3, 0, "ld!")
+		val second = mosaicNodes {
+			Column {
+				Text("Hel")
+				Text("lo")
+				Text("Wor")
+				Text("ld!")
+			}
 		}
 
 		assertEquals(
@@ -50,16 +56,18 @@ class AnsiRenderingTest {
 			|Wor
 			|ld!
 			|""".trimMargin(),
-			rendering.render(secondCanvas).toString(),
+			rendering.render(second).toString(),
 		)
 	}
 
 	@Test fun subsequentShorterRenderClearsRenderedLines() {
-		val firstCanvas = TextSurface(3, 4).apply {
-			write(0, 0, "Hel")
-			write(1, 0, "lo")
-			write(2, 0, "Wor")
-			write(3, 0, "ld!")
+		val first = mosaicNodes {
+			Column {
+				Text("Hel")
+				Text("lo")
+				Text("Wor")
+				Text("ld!")
+			}
 		}
 
 		assertEquals(
@@ -69,12 +77,14 @@ class AnsiRenderingTest {
 			|Wor
 			|ld!
 			|""".trimMargin(),
-			rendering.render(firstCanvas).toString(),
+			rendering.render(first).toString(),
 		)
 
-		val secondCanvas = TextSurface(6, 2).apply {
-			write(0, 0, "Hello")
-			write(1, 0, "World!")
+		val second = mosaicNodes {
+			Column {
+				Text("Hello")
+				Text("World!")
+			}
 		}
 
 		assertEquals(
@@ -84,7 +94,7 @@ class AnsiRenderingTest {
 			|$clearLine
 			|$clearLine$cursorUp
 			""".trimMargin(),
-			rendering.render(secondCanvas).toString(),
+			rendering.render(second).toString(),
 		)
 	}
 }

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/NodeApplierTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/NodeApplierTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class NodeApplierTest {
-	private val root = LinearNode()
+	private val root = RootNode()
 	private val applier = MosaicNodeApplier(root)
 
 	private fun <T> Applier<T>.insert(index: Int, instance: T) {

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/NodeApplierTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/NodeApplierTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class NodeApplierTest {
-	private val root = RootNode()
+	private val root = MosaicNode.root()
 	private val applier = MosaicNodeApplier(root)
 
 	private fun <T> Applier<T>.insert(index: Int, instance: T) {
@@ -182,5 +182,15 @@ class NodeApplierTest {
 
 	private fun assertChildren(vararg nodes: MosaicNode) {
 		assertEquals(nodes.toList(), root.children)
+	}
+
+	private fun TextNode(name: String): MosaicNode {
+		return MosaicNode(
+			measurePolicy = { throw AssertionError() },
+			layoutPolicy = { throw AssertionError() },
+			drawPolicy = { throw AssertionError() },
+			staticDrawPolicy = { throw AssertionError() },
+			debugPolicy = { name },
+		)
 	}
 }


### PR DESCRIPTION
This moves behavior into policy lambdas. It should allow refactoring to Compose UI-style Layout lambdas which are exposed publicly. It also should allow the creation of a global modifier system like Compose UI.