### PR TITLE
Merge `MeasurePolicy` and `LayoutPolicy` into a single thing

### DIFF
--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/NodeApplierTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/NodeApplierTest.kt
@@ -187,7 +187,6 @@ class NodeApplierTest {
 	private fun TextNode(name: String): MosaicNode {
 		return MosaicNode(
 			measurePolicy = { throw AssertionError() },
-			layoutPolicy = { throw AssertionError() },
 			drawPolicy = { throw AssertionError() },
 			staticDrawPolicy = { throw AssertionError() },
 			debugPolicy = { name },

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/NodeApplierTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/NodeApplierTest.kt
@@ -185,11 +185,8 @@ class NodeApplierTest {
 	}
 
 	private fun TextNode(name: String): MosaicNode {
-		return MosaicNode(
-			measurePolicy = { throw AssertionError() },
-			drawPolicy = { throw AssertionError() },
-			staticDrawPolicy = { throw AssertionError() },
-			debugPolicy = { name },
-		)
+		return MosaicNode.Factory().apply {
+			debugPolicy = DebugPolicy { name }
+		}
 	}
 }


### PR DESCRIPTION
This set of interfaces and scopes more closely mirrors how Compose UI works, and should be suitable to expose publicly through a `Layout` composable.