### PR TITLE
Give node ownership over drawing children

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/components.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/components.kt
@@ -22,7 +22,10 @@ public fun Text(
 	background: Color? = null,
 	style: TextStyle? = null,
 ) {
-	Node(
+	Layout(
+		debugInfo = {
+			"""Text("$value")"""
+		},
 		measurePolicy = {
 			val lines = value.split('\n')
 			val width = lines.maxOf { it.codePointCount(0, it.length) }
@@ -36,10 +39,6 @@ public fun Text(
 				canvas.write(index, 0, line, color, background, style)
 			}
 		},
-		staticDrawPolicy = { emptyList() },
-		debugPolicy = {
-			"""Text("$value", x=$x, y=$y, width=$width, height=$height)"""
-		}
 	)
 }
 
@@ -193,7 +192,9 @@ public fun <T> Static(
 				// Nothing to do. Children rendered separately.
 			}
 		},
-		drawPolicy = {},
+		drawPolicy = {
+			// Nothing to do. Children rendered separately.
+		},
 		staticDrawPolicy = {
 			val statics = if (children.isNotEmpty()) {
 				buildList {

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout.kt
@@ -5,6 +5,20 @@ import com.jakewharton.mosaic.Measurable.MeasureScope
 import com.jakewharton.mosaic.Placeable.PlacementScope
 
 @Composable
+internal fun Layout(
+	debugInfo: () -> String = { "Layout()" },
+	measurePolicy: MeasurePolicy,
+	drawPolicy: DrawPolicy,
+) {
+	Node(
+		measurePolicy = measurePolicy,
+		drawPolicy = drawPolicy,
+		staticDrawPolicy = StaticDrawPolicy.None,
+		debugPolicy = { debugInfo() + " x=$x y=$y w=$width h=$height" },
+	)
+}
+
+@Composable
 public fun Layout(
 	content: @Composable () -> Unit,
 	debugInfo: () -> String = { "Layout()" },
@@ -13,11 +27,15 @@ public fun Layout(
 	Node(
 		content = content,
 		measurePolicy = measurePolicy,
-		drawPolicy = DrawPolicy.Children,
+		drawPolicy = null,
 		staticDrawPolicy = StaticDrawPolicy.Children,
 		debugPolicy = {
-			children.joinToString(prefix = debugInfo(), separator = "") {
-				"\n" + it.toString().prependIndent("  ")
+			buildString {
+				append(debugInfo())
+				append(" x=$x y=$y w=$width h=$height")
+				children.joinTo(this, separator = "") {
+					"\n" + it.toString().prependIndent("  ")
+				}
 			}
 		},
 	)

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/DebugRenderingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/DebugRenderingTest.kt
@@ -23,9 +23,9 @@ class DebugRenderingTest {
 		assertEquals(
 			"""
 			|NODES:
-			|Text("Hello", x=0, y=0, width=5, height=1)
+			|Text("Hello") x=0 y=0 w=5 h=1
 			|Static()
-			|  Text("Static", x=0, y=0, width=6, height=1)
+			|  Text("Static") x=0 y=0 w=6 h=1
 			|
 			|STATIC:
 			|Static
@@ -45,7 +45,7 @@ class DebugRenderingTest {
 		assertEquals(
 			"""
 			|NODES:
-			|Text("Hello", x=0, y=0, width=5, height=1)
+			|Text("Hello") x=0 y=0 w=5 h=1
 			|
 			|OUTPUT:
 			|Hello
@@ -58,7 +58,7 @@ class DebugRenderingTest {
 			"""
 			|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ +100ms
 			|NODES:
-			|Text("Hello", x=0, y=0, width=5, height=1)
+			|Text("Hello") x=0 y=0 w=5 h=1
 			|
 			|OUTPUT:
 			|Hello

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/LayoutTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/LayoutTest.kt
@@ -6,18 +6,21 @@ import kotlin.test.assertEquals
 class LayoutTest {
 	@Test fun layoutDebugInfo() {
 		val node = mosaicNodes {
-			Layout({
-				Text("Hi!")
-				Text("Hey!")
-			}, { "Custom()" }) {
+			Layout(
+				content = {
+					Text("Hi!")
+					Text("Hey!")
+				},
+				debugInfo = { "Custom()" },
+			) {
 				layout(0, 0) {
 				}
 			}
 		}
 		val expected = """
-			|Custom()
-			|  Text("Hi!", x=0, y=0, width=0, height=0)
-			|  Text("Hey!", x=0, y=0, width=0, height=0)
+			|Custom() x=0 y=0 w=0 h=0
+			|  Text("Hi!") x=0 y=0 w=0 h=0
+			|  Text("Hey!") x=0 y=0 w=0 h=0
 			""".trimMargin()
 		assertEquals(expected, node.toString())
 	}


### PR DESCRIPTION
For now, we still selectively draw children based on whether there's a draw policy.

Migrate Text to talk through a no-content Layout rather than be a Node.