### PR TITLE
Revert "Update dependency de.cketti.unicode:kotlin-codepoints to v0.6.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ dokka-gradlePlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.7.20"
 buildconfig-gradlePlugin = "com.github.gmazzo:gradle-buildconfig-plugin:3.1.0"
 
 jansi = "org.fusesource.jansi:jansi:2.4.0"
-codepoints = "de.cketti.unicode:kotlin-codepoints:0.6.0"
+codepoints = "de.cketti.unicode:kotlin-codepoints:0.5.0"
 
 junit4 = "junit:junit:4.13.2"
 truth = "com.google.truth:truth:1.1.3"


### PR DESCRIPTION
Reverts JakeWharton/mosaic#137 due to https://github.com/cketti/kotlin-codepoints/issues/24. At least unblocks work on the JVM.