### PR TITLE
Run Jest sample on CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
 
-      - run: ./gradlew build :mosaic-runtime:dokkaHtml
+      - run: ./gradlew build :samples:jest:run :mosaic-runtime:dokkaHtml
 
       - run: ./gradlew publish
         if: ${{ github.ref == 'refs/heads/trunk' && github.repository == 'JakeWharton/mosaic' }}


### PR DESCRIPTION
The output is trash, but we aren't interested in the ANSI correctness so much as that its logic runs correctly.