### PR TITLE
Do not clip the canvas for each child

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/MeasureScope.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/MeasureScope.kt
@@ -2,22 +2,21 @@ package com.jakewharton.mosaic.layout
 
 import com.jakewharton.mosaic.layout.Placeable.PlacementScope
 
-public sealed class MeasureScope {
+public interface MeasureScope {
 	public fun layout(
 		width: Int,
 		height: Int,
 		placementBlock: PlacementScope.() -> Unit,
 	): MeasureResult {
-		return LayoutResult(width, height, placementBlock)
+		return LayoutResult(this as PlacementScope, width, height, placementBlock)
 	}
 
 	private class LayoutResult(
+		private val placementScope: PlacementScope,
 		override val width: Int,
 		override val height: Int,
 		private val placementBlock: PlacementScope.() -> Unit,
 	) : MeasureResult {
-		override fun placeChildren() = PlacementScope.placementBlock()
+		override fun placeChildren() = placementScope.placementBlock()
 	}
-
-	internal companion object : MeasureScope()
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Placeable.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Placeable.kt
@@ -6,11 +6,12 @@ public abstract class Placeable {
 
 	protected abstract fun placeAt(x: Int, y: Int)
 
-	public sealed class PlacementScope {
-		public fun Placeable.place(x: Int, y: Int) {
-			placeAt(x, y)
-		}
+	public interface PlacementScope {
+		public val x: Int
+		public val y: Int
 
-		internal companion object : PlacementScope()
+		public fun Placeable.place(x: Int, y: Int) {
+			placeAt(this@PlacementScope.x + x, this@PlacementScope.y + y)
+		}
 	}
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Text.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Text.kt
@@ -25,8 +25,8 @@ public fun Text(
 			layout(width, height)
 		},
 		drawPolicy = { canvas ->
-			value.split('\n').forEachIndexed { index, line ->
-				canvas.write(index, 0, line, color, background, style)
+			value.split('\n').forEachIndexed { row, line ->
+				canvas.write(row, 0, line, color, background, style)
 			}
 		},
 	)

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/LayoutTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/LayoutTest.kt
@@ -2,6 +2,8 @@ package com.jakewharton.mosaic
 
 import com.jakewharton.mosaic.layout.Layout
 import com.jakewharton.mosaic.layout.Measurable
+import com.jakewharton.mosaic.ui.Column
+import com.jakewharton.mosaic.ui.Row
 import com.jakewharton.mosaic.ui.Text
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -84,6 +86,42 @@ class LayoutTest {
 			|     CCC
 			|  BB   $s
 			|A      $s
+			|""".trimMargin()
+		assertEquals(expected, actual)
+	}
+
+	@Test fun canvasIsNotClipped() {
+		val actual = renderMosaic {
+			Column {
+				Row {
+					// Force the width of the canvas to be 6.
+					Text("123456")
+				}
+				Row {
+					Text("..")
+					Layout(drawPolicy = {
+						repeat(4) { row ->
+							it.write(row, 0, "XXXX")
+						}
+					}) {
+						layout(2, 2)
+					}
+					Text(".")
+				}
+				Row {
+					Text("...")
+				}
+				Row {
+					Text(".....")
+				}
+			}
+		}
+		val expected = """
+			|123456
+			|..XX.X
+			|  XXXX
+			|...XXX
+			|.....X
 			|""".trimMargin()
 		assertEquals(expected, actual)
 	}


### PR DESCRIPTION
Compose UI does not clip. It's easier to make clip opt-in than to make it opt-out.

Closes #152. Refs #153.