### PR TITLE
Add AnnotatedString with SpanStyle for text customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add `AnnotatedString` with `SpanStyle` for string customization.
+
 ## [0.9.1] - 2023-09-14
 
 New:

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/AnnotatedString.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/AnnotatedString.kt
@@ -1,0 +1,471 @@
+package com.jakewharton.mosaic.text
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import com.jakewharton.mosaic.text.AnnotatedString.Builder
+
+/**
+ * The basic data structure of text with multiple styles. To construct an [AnnotatedString] you
+ * can use [Builder].
+ */
+@Immutable
+public class AnnotatedString internal constructor(
+	public val text: String,
+	internal val spanStylesOrNull: List<Range<SpanStyle>>? = null,
+) : CharSequence {
+
+	/**
+	 * All [SpanStyle] that have been applied to a range of this String
+	 */
+	public val spanStyles: List<Range<SpanStyle>>
+		get() = spanStylesOrNull ?: emptyList()
+
+	override val length: Int
+		get() = text.length
+
+	override operator fun get(index: Int): Char = text[index]
+
+	/**
+	 * Return a substring for the AnnotatedString and include the styles in the range of [startIndex]
+	 * (inclusive) and [endIndex] (exclusive).
+	 *
+	 * @param startIndex the inclusive start offset of the range
+	 * @param endIndex the exclusive end offset of the range
+	 */
+	override fun subSequence(startIndex: Int, endIndex: Int): AnnotatedString {
+		require(startIndex <= endIndex) {
+			"start ($startIndex) should be less or equal to end ($endIndex)"
+		}
+		if (startIndex == 0 && endIndex == text.length) return this
+		val text = text.substring(startIndex, endIndex)
+		return AnnotatedString(
+			text = text,
+			spanStylesOrNull = filterRanges(spanStylesOrNull, startIndex, endIndex),
+		)
+	}
+
+	@Stable
+	public operator fun plus(other: AnnotatedString): AnnotatedString {
+		return with(Builder(this)) {
+			append(other)
+			toAnnotatedString()
+		}
+	}
+
+	override fun equals(other: Any?): Boolean {
+		if (this === other) return true
+		if (other !is AnnotatedString) return false
+		if (text != other.text) return false
+		if (spanStylesOrNull != other.spanStylesOrNull) return false
+		return true
+	}
+
+	override fun hashCode(): Int {
+		var result = text.hashCode()
+		result = 31 * result + (spanStylesOrNull?.hashCode() ?: 0)
+		return result
+	}
+
+	override fun toString(): String {
+		// AnnotatedString.toString has special value, it converts it into regular String
+		// rather than debug string.
+		return text
+	}
+
+	/**
+	 * The information attached on the text such as a [SpanStyle].
+	 *
+	 * @param item The object attached to [AnnotatedString]s.
+	 * @param start The start of the range where [item] takes effect. It's inclusive
+	 * @param end The end of the range where [item] takes effect. It's exclusive
+	 */
+	@Immutable
+	public data class Range<T>(val item: T, val start: Int, val end: Int) {
+
+		init {
+			require(start <= end) { "Reversed range is not supported" }
+		}
+	}
+
+	/**
+	 * Builder class for AnnotatedString. Enables construction of an [AnnotatedString] using
+	 * methods such as [append] and [addStyle].
+	 *
+	 * This class implements [Appendable] and can be used with other APIs that don't know about
+	 * [AnnotatedString]s:
+	 *
+	 * @param capacity initial capacity for the internal char buffer
+	 */
+	public class Builder(capacity: Int = 16) : Appendable {
+
+		private data class MutableRange<T>(
+			val item: T,
+			val start: Int,
+			var end: Int = Int.MIN_VALUE
+		) {
+			/**
+			 * Create an immutable [Range] object.
+			 *
+			 * @param defaultEnd if the end is not set yet, it will be set to this value.
+			 */
+			fun toRange(defaultEnd: Int = Int.MIN_VALUE): Range<T> {
+				val end = if (end == Int.MIN_VALUE) defaultEnd else end
+				check(end != Int.MIN_VALUE) { "Item.end should be set first" }
+				return Range(item = item, start = start, end = end)
+			}
+		}
+
+		private val text: StringBuilder = StringBuilder(capacity)
+		private val spanStyles: MutableList<MutableRange<SpanStyle>> = mutableListOf()
+		private val styleStack: MutableList<MutableRange<out Any>> = mutableListOf()
+
+		/**
+		 * Create an [Builder] instance using the given [String].
+		 */
+		public constructor(text: String) : this() {
+			append(text)
+		}
+
+		/**
+		 * Create an [Builder] instance using the given [AnnotatedString].
+		 */
+		public constructor(text: AnnotatedString) : this() {
+			append(text)
+		}
+
+		/**
+		 * Returns the length of the [String].
+		 */
+		public val length: Int get() = text.length
+
+		/**
+		 * Appends the given [String] to this [Builder].
+		 *
+		 * @param text the text to append
+		 */
+		public fun append(text: String) {
+			this.text.append(text)
+		}
+
+		/**
+		 * Appends [text] to this [Builder] if non-null, and returns this [Builder].
+		 *
+		 * If [text] is an [AnnotatedString], all spans and annotations will be copied over as well.
+		 * No other subtypes of [CharSequence] will be treated specially.
+		 */
+		@Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+		override fun append(text: CharSequence?): Builder {
+			if (text is AnnotatedString) {
+				append(text)
+			} else {
+				this.text.append(text)
+			}
+			return this
+		}
+
+		/**
+		 * Appends the range of [text] between [start] (inclusive) and [end] (exclusive) to this
+		 * [Builder] if non-null, and returns this [Builder].
+		 *
+		 * If [text] is an [AnnotatedString], all spans and annotations from [text] between
+		 * [start] and [end] will be copied over as well.
+		 * No other subtypes of [CharSequence] will be treated specially.
+		 *
+		 * @param start The index of the first character in [text] to copy over (inclusive).
+		 * @param end The index after the last character in [text] to copy over (exclusive).
+		 */
+		@Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+		override fun append(text: CharSequence?, start: Int, end: Int): Builder {
+			if (text is AnnotatedString) {
+				append(text, start, end)
+			} else {
+				this.text.append(text, start, end)
+			}
+			return this
+		}
+
+		// Kdoc comes from interface method.
+		@Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+		override fun append(char: Char): Builder {
+			this.text.append(char)
+			return this
+		}
+
+		/**
+		 * Appends the given [AnnotatedString] to this [Builder].
+		 *
+		 * @param text the text to append
+		 */
+		public fun append(text: AnnotatedString) {
+			val start = this.text.length
+			this.text.append(text.text)
+			// offset every style with start and add to the builder
+			text.spanStylesOrNull?.forEach {
+				addStyle(it.item, start + it.start, start + it.end)
+			}
+		}
+
+		/**
+		 * Appends the range of [text] between [start] (inclusive) and [end] (exclusive) to this
+		 * [Builder]. All spans and annotations from [text] between [start] and [end] will be copied
+		 * over as well.
+		 *
+		 * @param start The index of the first character in [text] to copy over (inclusive).
+		 * @param end The index after the last character in [text] to copy over (exclusive).
+		 */
+		public fun append(text: AnnotatedString, start: Int, end: Int) {
+			val insertionStart = this.text.length
+			this.text.append(text.text, start, end)
+			// offset every style with insertionStart and add to the builder
+			text.getLocalSpanStyles(start, end)?.forEach {
+				addStyle(it.item, insertionStart + it.start, insertionStart + it.end)
+			}
+		}
+
+		/**
+		 * Set a [SpanStyle] for the given range between [start] (inclusive)
+		 * and [end] (exclusive) to this [Builder].
+		 *
+		 * @param style [SpanStyle] to be applied
+		 * @param start the inclusive starting offset of the range
+		 * @param end the exclusive end offset of the range
+		 */
+		public fun addStyle(style: SpanStyle, start: Int, end: Int) {
+			spanStyles.add(MutableRange(item = style, start = start, end = end))
+		}
+
+		/**
+		 * Applies the given [SpanStyle] to any appended text until a corresponding [pop] is
+		 * called.
+		 *
+		 * @param style SpanStyle to be applied
+		 */
+		public fun pushStyle(style: SpanStyle): Int {
+			MutableRange(item = style, start = text.length).also {
+				styleStack.add(it)
+				spanStyles.add(it)
+			}
+			return styleStack.size - 1
+		}
+
+		/**
+		 * Ends the style or annotation that was added via a push operation before.
+		 *
+		 * @see pushStyle
+		 */
+		public fun pop() {
+			check(styleStack.isNotEmpty()) { "Nothing to pop." }
+			// pop the last element
+			val item = styleStack.removeAt(styleStack.size - 1)
+			item.end = text.length
+		}
+
+		/**
+		 * Ends the styles or annotation up to and `including` the [pushStyle]
+		 * that returned the given index.
+		 *
+		 * @param index the result of the a previous [pushStyle] in order to pop to
+		 *
+		 * @see pop
+		 * @see pushStyle
+		 */
+		public fun pop(index: Int) {
+			check(index < styleStack.size) { "$index should be less than ${styleStack.size}" }
+			while ((styleStack.size - 1) >= index) {
+				pop()
+			}
+		}
+
+		/**
+		 * Constructs an [AnnotatedString] based on the configurations applied to the [Builder].
+		 */
+		public fun toAnnotatedString(): AnnotatedString {
+			return AnnotatedString(
+				text = text.toString(),
+				spanStylesOrNull = spanStyles
+					.map { it.toRange(text.length) }
+					.ifEmpty { null },
+			)
+		}
+	}
+}
+
+/**
+ * Helper function used to find the [SpanStyle]s in the given range and also convert the
+ * range of those [SpanStyle]s to local range.
+ *
+ * @param start The start index of the range, inclusive
+ * @param end The end index of the range, exclusive
+ * @return The list of converted [SpanStyle]s in the given range
+ */
+private fun AnnotatedString.getLocalSpanStyles(
+	start: Int,
+	end: Int
+): List<AnnotatedString.Range<SpanStyle>>? {
+	if (start == end) return null
+	val spanStyles = spanStylesOrNull ?: return null
+	// If the given range covers the whole AnnotatedString, return SpanStyles without conversion.
+	if (start == 0 && end >= this.text.length) {
+		return spanStyles
+	}
+	return spanStyles.filter { intersect(start, end, it.start, it.end) }
+		.map {
+			AnnotatedString.Range(
+				it.item,
+				it.start.coerceIn(start, end) - start,
+				it.end.coerceIn(start, end) - start
+			)
+		}
+}
+
+/**
+ * Filter the range list based on [com.jakewharton.mosaic.text.AnnotatedString.Range.start]
+ * and [com.jakewharton.mosaic.text.AnnotatedString.Range.end] to include ranges only in the range
+ * of [start] (inclusive) and [end] (exclusive).
+ *
+ * @param start the inclusive start offset of the text range
+ * @param end the exclusive end offset of the text range
+ */
+private fun <T> filterRanges(
+	ranges: List<AnnotatedString.Range<out T>>?,
+	start: Int,
+	end: Int
+): List<AnnotatedString.Range<T>>? {
+	require(start <= end) { "start ($start) should be less than or equal to end ($end)" }
+	val nonNullRange = ranges ?: return null
+
+	return nonNullRange.filter { intersect(start, end, it.start, it.end) }.map {
+		AnnotatedString.Range(
+			item = it.item,
+			start = maxOf(start, it.start) - start,
+			end = minOf(end, it.end) - start,
+		)
+	}.ifEmpty { null }
+}
+
+/**
+ * Helper function used to find the [SpanStyle]s in the given range.
+ *
+ * @param start The start index of the range, inclusive
+ * @param end The end index of the range, exclusive
+ * @return The list of [SpanStyle]s in the given range
+ */
+internal fun AnnotatedString.getLocalRawSpanStyles(
+	start: Int,
+	end: Int
+): List<SpanStyle> {
+	require(start <= end) { "start ($start) should be less than or equal to end ($end)" }
+	val nonNullRange = spanStylesOrNull ?: return emptyList()
+
+	return nonNullRange.filter { intersect(start, end, it.start, it.end) }.map { it.item }
+}
+
+/**
+ * Splits this [AnnotatedString] to a list of [AnnotatedString]s around occurrences
+ * of the specified [delimiter].
+ * This is specialized version of split which receives single non-empty delimiter
+ * and offers better performance.
+ *
+ * @param delimiter String used as delimiter
+ * @param ignoreCase `true` to ignore character case when matching a delimiter. By default `false`.
+ * @param limit The maximum number of substrings to return.
+ */
+internal fun AnnotatedString.split(
+	delimiter: String,
+	ignoreCase: Boolean = false,
+	limit: Int = 0
+): List<AnnotatedString> {
+	require(limit >= 0) { "Limit must be non-negative, but was $limit" }
+
+	var currentOffset = 0
+	var nextIndex = indexOf(delimiter, currentOffset, ignoreCase)
+	if (nextIndex == -1 || limit == 1) {
+		return listOf(this)
+	}
+
+	val isLimited = limit > 0
+	val result = ArrayList<AnnotatedString>(if (isLimited) limit.coerceAtMost(10) else 10)
+	do {
+		result.add(subSequence(currentOffset, nextIndex))
+		currentOffset = nextIndex + delimiter.length
+		// Do not search for next occurrence if we're reaching limit
+		if (isLimited && result.size == limit - 1) break
+		nextIndex = indexOf(delimiter, currentOffset, ignoreCase)
+	} while (nextIndex != -1)
+
+	result.add(subSequence(currentOffset, length))
+	return result
+}
+
+/**
+ * Pushes [style] to the [AnnotatedString.Builder], executes [block] and then pops the [style].
+ *
+ * @param style [SpanStyle] to be applied
+ * @param block function to be executed
+ *
+ * @return result of the [block]
+ *
+ * @see AnnotatedString.Builder.pushStyle
+ * @see AnnotatedString.Builder.pop
+ */
+public inline fun <R : Any> Builder.withStyle(
+	style: SpanStyle,
+	block: Builder.() -> R
+): R {
+	val index = pushStyle(style)
+	return try {
+		block(this)
+	} finally {
+		pop(index)
+	}
+}
+
+/**
+ * Create an AnnotatedString with a [spanStyle] that will apply to the whole text.
+ *
+ * @param spanStyle [SpanStyle] to be applied to whole text
+ */
+public fun AnnotatedString(
+	text: String,
+	spanStyle: SpanStyle,
+): AnnotatedString = AnnotatedString(
+	text,
+	listOf(AnnotatedString.Range(spanStyle, 0, text.length)),
+)
+
+/**
+ * Build a new AnnotatedString by populating newly created [AnnotatedString.Builder] provided
+ * by [builder].
+ *
+ * @param builder lambda to modify [AnnotatedString.Builder]
+ */
+public inline fun buildAnnotatedString(builder: (Builder).() -> Unit): AnnotatedString =
+	Builder().apply(builder).toAnnotatedString()
+
+/**
+ * Helper function that checks if the range [baseStart, baseEnd) contains the range
+ * [targetStart, targetEnd).
+ *
+ * @return true if [baseStart, baseEnd) contains [targetStart, targetEnd), vice versa.
+ * When [baseStart]==[baseEnd] it return true iff [targetStart]==[targetEnd]==[baseStart].
+ */
+private fun contains(baseStart: Int, baseEnd: Int, targetStart: Int, targetEnd: Int) =
+	(baseStart <= targetStart && targetEnd <= baseEnd) &&
+		(baseEnd != targetEnd || (targetStart == targetEnd) == (baseStart == baseEnd))
+
+/**
+ * Helper function that checks if the range [lStart, lEnd) intersects with the range
+ * [rStart, rEnd).
+ *
+ * @return [lStart, lEnd) intersects with range [rStart, rEnd), vice versa.
+ */
+private fun intersect(lStart: Int, lEnd: Int, rStart: Int, rEnd: Int) =
+	maxOf(lStart, rStart) < minOf(lEnd, rEnd) ||
+		contains(lStart, lEnd, rStart, rEnd) || contains(rStart, rEnd, lStart, lEnd)
+
+private val EmptyAnnotatedString: AnnotatedString = AnnotatedString("")
+
+/**
+ * Returns an AnnotatedString with empty text and no annotations.
+ */
+internal fun emptyAnnotatedString() = EmptyAnnotatedString

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/SpanStyle.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/SpanStyle.kt
@@ -1,0 +1,79 @@
+package com.jakewharton.mosaic.text
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import com.jakewharton.mosaic.ui.Color
+import com.jakewharton.mosaic.ui.TextStyle
+
+@Immutable
+public class SpanStyle constructor(
+	public val color: Color? = null,
+	public val textStyle: TextStyle? = null,
+	public val background: Color? = null,
+) {
+
+	/**
+	 * Returns a new span style that is a combination of this style and the given [other] style.
+	 *
+	 * [other] span style's null or inherit properties are replaced with the non-null properties of
+	 * this span style. Another way to think of it is that the "missing" properties of the [other]
+	 * style are _filled_ by the properties of this style.
+	 *
+	 * If the given span style is null, returns this span style.
+	 */
+	@Stable
+	public fun merge(other: SpanStyle? = null): SpanStyle {
+		if (other == null) return this
+		return SpanStyle(
+			color = other.color ?: this.color,
+			textStyle = other.textStyle ?: this.textStyle,
+			background = other.background ?: this.background,
+		)
+	}
+
+	/**
+	 * Plus operator overload that applies a [merge].
+	 */
+	@Stable
+	public operator fun plus(other: SpanStyle): SpanStyle = this.merge(other)
+
+	public fun copy(
+		color: Color? = this.color,
+		textStyle: TextStyle? = this.textStyle,
+		background: Color? = this.background,
+	): SpanStyle {
+		return SpanStyle(
+			color = color,
+			textStyle = textStyle,
+			background = background,
+		)
+	}
+
+	override fun equals(other: Any?): Boolean {
+		if (this === other) return true
+		if (other == null || this::class != other::class) return false
+
+		other as SpanStyle
+
+		if (color != other.color) return false
+		if (textStyle != other.textStyle) return false
+		if (background != other.background) return false
+
+		return true
+	}
+
+	override fun hashCode(): Int {
+		var result = color?.hashCode() ?: 0
+		result = 31 * result + (textStyle?.hashCode() ?: 0)
+		result = 31 * result + (background?.hashCode() ?: 0)
+		return result
+	}
+
+	override fun toString(): String {
+		return "SpanStyle(" +
+			"color=$color, " +
+			"textStyle=$textStyle, " +
+			"background=$background, " +
+			")"
+	}
+}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/TextLayout.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/TextLayout.kt
@@ -2,9 +2,9 @@ package com.jakewharton.mosaic.text
 
 import de.cketti.codepoints.codePointCount
 
-public abstract class TextLayout<T : CharSequence>(initialValue: T) {
+internal abstract class TextLayout<T : CharSequence>(initialValue: T) {
 
-	public var value: T = initialValue
+	var value: T = initialValue
 		set(value) {
 			if (value != field) {
 				dirty = true
@@ -12,21 +12,21 @@ public abstract class TextLayout<T : CharSequence>(initialValue: T) {
 			}
 		}
 
-	public var width: Int = -1
+	var width: Int = -1
 		private set
 		get() {
 			check(!dirty) { "Missing call to measure()" }
 			return field
 		}
 
-	public var height: Int = -1
+	var height: Int = -1
 		private set
 		get() {
 			check(!dirty) { "Missing call to measure()" }
 			return field
 		}
 
-	public var lines: List<T> = emptyList()
+	var lines: List<T> = emptyList()
 		private set
 		get() {
 			check(!dirty) { "Missing call to measure()" }
@@ -35,7 +35,7 @@ public abstract class TextLayout<T : CharSequence>(initialValue: T) {
 
 	private var dirty = true
 
-	public fun measure() {
+	fun measure() {
 		if (!dirty) return
 
 		val lines = value.splitByLines()
@@ -48,14 +48,14 @@ public abstract class TextLayout<T : CharSequence>(initialValue: T) {
 	protected abstract fun T.splitByLines(): List<T>
 }
 
-public class StringTextLayout : TextLayout<String>(initialValue = "") {
+internal class StringTextLayout : TextLayout<String>(initialValue = "") {
 
 	override fun String.splitByLines(): List<String> {
 		return this.split("\n")
 	}
 }
 
-public class AnnotatedStringTextLayout : TextLayout<AnnotatedString>(
+internal class AnnotatedStringTextLayout : TextLayout<AnnotatedString>(
 	initialValue = emptyAnnotatedString()
 ) {
 

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/TextLayout.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/TextLayout.kt
@@ -2,8 +2,9 @@ package com.jakewharton.mosaic.text
 
 import de.cketti.codepoints.codePointCount
 
-internal class TextLayout {
-	var value: String = ""
+public abstract class TextLayout<T : CharSequence>(initialValue: T) {
+
+	public var value: T = initialValue
 		set(value) {
 			if (value != field) {
 				dirty = true
@@ -11,21 +12,21 @@ internal class TextLayout {
 			}
 		}
 
-	var width: Int = -1
+	public var width: Int = -1
 		private set
 		get() {
 			check(!dirty) { "Missing call to measure()" }
 			return field
 		}
 
-	var height: Int = -1
+	public var height: Int = -1
 		private set
 		get() {
 			check(!dirty) { "Missing call to measure()" }
 			return field
 		}
 
-	var lines: List<String> = emptyList()
+	public var lines: List<T> = emptyList()
 		private set
 		get() {
 			check(!dirty) { "Missing call to measure()" }
@@ -34,13 +35,31 @@ internal class TextLayout {
 
 	private var dirty = true
 
-	fun measure() {
+	public fun measure() {
 		if (!dirty) return
 
-		val lines = value.split('\n')
+		val lines = value.splitByLines()
 		width = lines.maxOf { it.codePointCount(0, it.length) }
 		height = lines.size
 		this.lines = lines
 		dirty = false
+	}
+
+	protected abstract fun T.splitByLines(): List<T>
+}
+
+public class StringTextLayout : TextLayout<String>(initialValue = "") {
+
+	override fun String.splitByLines(): List<String> {
+		return this.split("\n")
+	}
+}
+
+public class AnnotatedStringTextLayout : TextLayout<AnnotatedString>(
+	initialValue = emptyAnnotatedString()
+) {
+
+	override fun AnnotatedString.splitByLines(): List<AnnotatedString> {
+		return this.split("\n")
 	}
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Text.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Text.kt
@@ -6,7 +6,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.jakewharton.mosaic.layout.drawBehind
 import com.jakewharton.mosaic.modifier.Modifier
-import com.jakewharton.mosaic.text.TextLayout
+import com.jakewharton.mosaic.text.AnnotatedString
+import com.jakewharton.mosaic.text.AnnotatedStringTextLayout
+import com.jakewharton.mosaic.text.StringTextLayout
 import kotlin.jvm.JvmName
 
 @Composable
@@ -18,7 +20,34 @@ public fun Text(
 	background: Color? = null,
 	style: TextStyle? = null,
 ) {
-	val layout = remember { TextLayout() }
+	val layout = remember { StringTextLayout() }
+	layout.value = value
+
+	Layout(
+		debugInfo = {
+			"""Text("$value")"""
+		},
+		measurePolicy = {
+			layout.measure()
+			layout(layout.width, layout.height)
+		},
+		modifiers = modifier.drawBehind {
+			layout.lines.forEachIndexed { row, line ->
+				drawText(row, 0, line, color, background, style)
+			}
+		},
+	)
+}
+
+@Composable
+public fun Text(
+	value: AnnotatedString,
+	modifier: Modifier = Modifier,
+	color: Color? = null,
+	background: Color? = null,
+	style: TextStyle? = null,
+) {
+	val layout = remember { AnnotatedStringTextLayout() }
 	layout.value = value
 
 	Layout(

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Text.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Text.kt
@@ -40,6 +40,7 @@ public fun Text(
 }
 
 @Composable
+@MosaicComposable
 public fun Text(
 	value: AnnotatedString,
 	modifier: Modifier = Modifier,

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/text/AnnotatedStringBuilderTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/text/AnnotatedStringBuilderTest.kt
@@ -1,0 +1,599 @@
+package com.jakewharton.mosaic.text
+
+import com.jakewharton.mosaic.text.AnnotatedString.Range
+import com.jakewharton.mosaic.ui.Color
+import com.jakewharton.mosaic.ui.TextStyle
+import com.varabyte.truthish.assertThat
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class AnnotatedStringBuilderTest {
+
+	@Test fun defaultConstructor() {
+		val annotatedString = AnnotatedString.Builder().toAnnotatedString()
+
+		assertThat(annotatedString.text).isEmpty()
+		assertThat(annotatedString.spanStyles).isEmpty()
+	}
+
+	@Test fun constructorWithString() {
+		val text = "a"
+		val annotatedString = AnnotatedString.Builder(text).toAnnotatedString()
+
+		assertThat(annotatedString.text).isEqualTo(text)
+		assertThat(annotatedString.spanStyles).isEmpty()
+	}
+
+	@Test fun constructorWithAnnotatedString_hasSameAnnotatedStringAttributes() {
+		val text = createAnnotatedString(text = "a")
+		val annotatedString = AnnotatedString.Builder(text).toAnnotatedString()
+
+		assertThat(annotatedString.text).isEqualTo(text.text)
+		assertThat(annotatedString.spanStyles).isEqualTo(text.spanStyles)
+	}
+
+	@Test fun addStyle_withSpanStyle_addsStyle() {
+		val style = SpanStyle(color = Color.Red)
+		val start = 0
+		val end = 1
+		val annotatedString = with(AnnotatedString.Builder("ab")) {
+			addStyle(style, start, end)
+			toAnnotatedString()
+		}
+
+		val expectedSpanStyles = listOf(
+			Range(style, start, end)
+		)
+
+		assertThat(annotatedString.spanStyles).isEqualTo(expectedSpanStyles)
+	}
+
+	@Test fun append_withString_appendsTheText() {
+		val text = "a"
+		val appendedText = "b"
+		val annotatedString = with(AnnotatedString.Builder(text)) {
+			append(appendedText)
+			toAnnotatedString()
+		}
+
+		val expectedString = "$text$appendedText"
+
+		assertThat(annotatedString.text).isEqualTo(expectedString)
+		assertThat(annotatedString.spanStyles).isEmpty()
+	}
+
+	@Test fun append_withString_andMultipleCalls_appendsAllOfTheText() {
+		val annotatedString = with(AnnotatedString.Builder("a")) {
+			append("b")
+			append("c")
+			toAnnotatedString()
+		}
+
+		assertThat(annotatedString.text).isEqualTo("abc")
+	}
+
+	@Test fun append_withAnnotatedString_appendsTheText() {
+		val color = Color.Red
+		val text = "a"
+		val annotatedString = createAnnotatedString(
+			text = text,
+			color = color,
+		)
+
+		val appendedColor = Color.Blue
+		val appendedText = "b"
+		val appendedAnnotatedString = createAnnotatedString(
+			text = appendedText,
+			color = appendedColor,
+		)
+
+		val buildResult = with(AnnotatedString.Builder(annotatedString)) {
+			append(appendedAnnotatedString)
+			toAnnotatedString()
+		}
+
+		val expectedString = "$text$appendedText"
+		val expectedSpanStyles = listOf(
+			Range(
+				item = SpanStyle(color),
+				start = 0,
+				end = text.length
+			),
+			Range(
+				item = SpanStyle(appendedColor),
+				start = text.length,
+				end = expectedString.length
+			)
+		)
+
+		assertThat(buildResult.text).isEqualTo(expectedString)
+		assertThat(buildResult.spanStyles).isEqualTo(expectedSpanStyles)
+	}
+
+	@Test fun append_withAnnotatedStringAndRange_appendsTheText() {
+		val text = "a"
+		val annotatedString = AnnotatedString(
+			text = text,
+			spanStylesOrNull = listOf(
+				text.inclusiveRangeOf('a', 'a', item = SpanStyle(color = Color.Red))
+			),
+		)
+
+		// We want to test the cross product of the following cases:
+		// - Range beginning at start, ending at end-1, completely overlapping [start,end), and
+		//   completely inside (start, end-1).
+		// - SpanStyle, ParagraphStyle, annotation
+		val appendedText = "bcdef"
+		val appendedSpanStyles = listOf(
+			appendedText.inclusiveRangeOf('b', 'f', item = SpanStyle(color = Color.Blue)),
+			appendedText.inclusiveRangeOf('c', 'f', item = SpanStyle(color = Color.Green)),
+			appendedText.inclusiveRangeOf('b', 'e', item = SpanStyle(color = Color.Yellow)),
+			appendedText.inclusiveRangeOf('c', 'e', item = SpanStyle(color = Color.Magenta)),
+		)
+		val appendedAnnotatedString = AnnotatedString(
+			text = appendedText,
+			spanStylesOrNull = appendedSpanStyles,
+		)
+
+		val buildResult = with(AnnotatedString.Builder(annotatedString)) {
+			// Append everything but the first and last characters of the appended string.
+			append(
+				appendedAnnotatedString,
+				start = appendedText.indexOf('c'),
+				end = appendedText.indexOf('e') + 1
+			)
+			toAnnotatedString()
+		}
+
+		val expectedString = "acde"
+		val expectedSpanStyles = listOf(
+			expectedString.inclusiveRangeOf('a', 'a', item = SpanStyle(color = Color.Red)),
+			expectedString.inclusiveRangeOf('c', 'e', item = SpanStyle(color = Color.Blue)),
+			expectedString.inclusiveRangeOf('c', 'e', item = SpanStyle(color = Color.Green)),
+			expectedString.inclusiveRangeOf('c', 'e', item = SpanStyle(color = Color.Yellow)),
+			expectedString.inclusiveRangeOf('c', 'e', item = SpanStyle(color = Color.Magenta)),
+		)
+
+		assertThat(buildResult.text).isEqualTo(expectedString)
+		assertThat(buildResult.spanStyles).isEqualTo(expectedSpanStyles)
+	}
+
+	@Test fun append_withCharSequence_appendsTheText_whenAnnotatedString() {
+		val color = Color.Red
+		val text = "a"
+		val annotatedString = createAnnotatedString(
+			text = text,
+			color = color,
+		)
+
+		val appendedColor = Color.Blue
+		val appendedText = "b"
+		val appendedAnnotatedString = createAnnotatedString(
+			text = appendedText,
+			color = appendedColor
+		)
+
+		val buildResult = with(AnnotatedString.Builder(annotatedString)) {
+			// Cast forces dispatch to the more general method, using the return value ensures
+			// the right method was selected.
+			append(appendedAnnotatedString as CharSequence)
+				.toAnnotatedString()
+		}
+
+		val expectedString = "$text$appendedText"
+		val expectedSpanStyles = listOf(
+			Range(
+				item = SpanStyle(color),
+				start = 0,
+				end = text.length
+			),
+			Range(
+				item = SpanStyle(appendedColor),
+				start = text.length,
+				end = expectedString.length
+			)
+		)
+
+		assertThat(buildResult.text).isEqualTo(expectedString)
+		assertThat(buildResult.spanStyles).isEqualTo(expectedSpanStyles)
+	}
+
+	@Test fun append_withCharSequence_appendsTheText_whenNotAnnotatedString() {
+		val text = "a"
+		val appendedText: CharSequence = "bc"
+		val annotatedString = with(AnnotatedString.Builder(text)) {
+			append(appendedText)
+			toAnnotatedString()
+		}
+
+		val expectedString = "abc"
+
+		assertThat(annotatedString.text).isEqualTo(expectedString)
+		assertThat(annotatedString.spanStyles).isEmpty()
+	}
+
+	@Test fun append_withCharSequenceAndRange_appendsTheText_whenNotAnnotatedString() {
+		val text = "a"
+		val appendedText: CharSequence = "bcde"
+		val annotatedString = with(AnnotatedString.Builder(text)) {
+			append(appendedText, 1, 3)
+			toAnnotatedString()
+		}
+
+		val expectedString = "acd"
+
+		assertThat(annotatedString.text).isEqualTo(expectedString)
+		assertThat(annotatedString.spanStyles).isEmpty()
+	}
+
+	@Test fun pushStyle() {
+		val text = "Test"
+		val style = SpanStyle(color = Color.Red)
+		val buildResult = AnnotatedString.Builder().apply {
+			pushStyle(style)
+			append(text)
+			pop()
+		}.toAnnotatedString()
+
+		assertThat(buildResult.text).isEqualTo(text)
+		assertThat(buildResult.spanStyles).hasSize(1)
+		assertThat(buildResult.spanStyles[0].item).isEqualTo(style)
+		assertThat(buildResult.spanStyles[0].start).isEqualTo(0)
+		assertThat(buildResult.spanStyles[0].end).isEqualTo(buildResult.length)
+	}
+
+	@Test fun pushStyle_without_pop() {
+		val styles = arrayOf(
+			SpanStyle(color = Color.Red),
+			SpanStyle(background = Color.Blue),
+			SpanStyle(textStyle = TextStyle.Underline),
+		)
+
+		val buildResult = with(AnnotatedString.Builder()) {
+			styles.forEachIndexed { index, spanStyle ->
+				// pop is intentionally not called here
+				pushStyle(spanStyle)
+				append("Style$index")
+			}
+			toAnnotatedString()
+		}
+
+		assertThat(buildResult.text).isEqualTo("Style0Style1Style2")
+		assertThat(buildResult.spanStyles).hasSize(3)
+
+		styles.forEachIndexed { index, spanStyle ->
+			assertThat(buildResult.spanStyles[index].item).isEqualTo(spanStyle)
+			assertThat(buildResult.spanStyles[index].end).isEqualTo(buildResult.length)
+		}
+
+		assertThat(buildResult.spanStyles[0].start).isEqualTo(0)
+		assertThat(buildResult.spanStyles[1].start).isEqualTo("Style0".length)
+		assertThat(buildResult.spanStyles[2].start).isEqualTo("Style0Style1".length)
+	}
+
+	@Test fun pushStyle_with_multiple_styles() {
+		val spanStyle1 = SpanStyle(color = Color.Red)
+		val spanStyle2 = SpanStyle(background = Color.Blue)
+
+		val buildResult = with(AnnotatedString.Builder()) {
+			pushStyle(spanStyle1)
+			append("Test")
+			pushStyle(spanStyle2)
+			append(" me")
+			pop()
+			pop()
+			toAnnotatedString()
+		}
+
+		assertThat(buildResult.text).isEqualTo("Test me")
+		assertThat(buildResult.spanStyles).hasSize(2)
+
+		assertThat(buildResult.spanStyles[0].item).isEqualTo(spanStyle1)
+		assertThat(buildResult.spanStyles[0].start).isEqualTo(0)
+		assertThat(buildResult.spanStyles[0].end).isEqualTo(buildResult.length)
+
+		assertThat(buildResult.spanStyles[1].item).isEqualTo(spanStyle2)
+		assertThat(buildResult.spanStyles[1].start).isEqualTo("Test".length)
+		assertThat(buildResult.spanStyles[1].end).isEqualTo(buildResult.length)
+	}
+
+	@Test fun pushStyle_with_multiple_styles_on_top_of_each_other() {
+		val styles = arrayOf(
+			SpanStyle(color = Color.Red),
+			SpanStyle(background = Color.Blue),
+			SpanStyle(textStyle = TextStyle.Underline),
+		)
+
+		val buildResult = with(AnnotatedString.Builder()) {
+			styles.forEach { spanStyle ->
+				// pop is intentionally not called here
+				pushStyle(spanStyle)
+			}
+			toAnnotatedString()
+		}
+
+		assertThat(buildResult.text).isEmpty()
+		assertThat(buildResult.spanStyles).hasSize(3)
+		styles.forEachIndexed { index, spanStyle ->
+			assertThat(buildResult.spanStyles[index].item).isEqualTo(spanStyle)
+			assertThat(buildResult.spanStyles[index].start).isEqualTo(buildResult.length)
+			assertThat(buildResult.spanStyles[index].end).isEqualTo(buildResult.length)
+		}
+	}
+
+	@Test fun pushStyle_with_multiple_stacks_should_construct_styles_in_the_same_order() {
+		val styles = arrayOf(
+			SpanStyle(color = Color.Red),
+			SpanStyle(background = Color.Blue),
+			SpanStyle(textStyle = TextStyle.Underline),
+			SpanStyle(color = Color.Green),
+		)
+
+		val buildResult = with(AnnotatedString.Builder()) {
+			pushStyle(styles[0])
+			append("layer1-1")
+			pushStyle(styles[1])
+			append("layer2-1")
+			pushStyle(styles[2])
+			append("layer3-1")
+			pop()
+			pushStyle(styles[3])
+			append("layer3-2")
+			pop()
+			append("layer2-2")
+			pop()
+			append("layer1-2")
+			toAnnotatedString()
+		}
+
+		assertThat(buildResult.spanStyles).hasSize(4)
+		styles.forEachIndexed { index, spanStyle ->
+			assertThat(buildResult.spanStyles[index].item).isEqualTo(spanStyle)
+		}
+	}
+
+	@Test fun pushStyle_with_multiple_nested_styles_should_return_styles_in_same_order() {
+		val styles = arrayOf(
+			SpanStyle(color = Color.Red),
+			SpanStyle(background = Color.Blue),
+			SpanStyle(textStyle = TextStyle.Underline),
+			SpanStyle(color = Color.Green),
+		)
+
+		val buildResult = with(AnnotatedString.Builder()) {
+			pushStyle(styles[0])
+			append("layer1-1")
+			pushStyle(styles[1])
+			append("layer2-1")
+			pop()
+			pushStyle(styles[2])
+			append("layer2-2")
+			pushStyle(styles[3])
+			append("layer3-1")
+			pop()
+			append("layer2-3")
+			pop()
+			append("layer1-2")
+			pop()
+			toAnnotatedString()
+		}
+
+		assertThat(buildResult.spanStyles).hasSize(4)
+		styles.forEachIndexed { index, spanStyle ->
+			assertThat(buildResult.spanStyles[index].item).isEqualTo(spanStyle)
+		}
+	}
+
+	@Test fun pop_when_empty_does_not_throw_exception() {
+		assertFailsWith<IllegalStateException> {
+			AnnotatedString.Builder().pop()
+		}
+	}
+
+	@Test fun pop_in_the_middle() {
+		val spanStyle1 = SpanStyle(color = Color.Red)
+		val spanStyle2 = SpanStyle(color = Color.Blue)
+
+		val buildResult = with(AnnotatedString.Builder()) {
+			append("Style0")
+			pushStyle(spanStyle1)
+			append("Style1")
+			pop()
+			pushStyle(spanStyle2)
+			append("Style2")
+			pop()
+			append("Style3")
+			toAnnotatedString()
+		}
+
+		assertThat(buildResult.text).isEqualTo("Style0Style1Style2Style3")
+		assertThat(buildResult.spanStyles).hasSize(2)
+
+		// the order is first applied is in the second
+		assertThat(buildResult.spanStyles[0].item).isEqualTo((spanStyle1))
+		assertThat(buildResult.spanStyles[0].start).isEqualTo(("Style0".length))
+		assertThat(buildResult.spanStyles[0].end).isEqualTo(("Style0Style1".length))
+
+		assertThat(buildResult.spanStyles[1].item).isEqualTo((spanStyle2))
+		assertThat(buildResult.spanStyles[1].start).isEqualTo(("Style0Style1".length))
+		assertThat(buildResult.spanStyles[1].end).isEqualTo(("Style0Style1Style2".length))
+	}
+
+	@Test fun push_increments_the_style_index() {
+		val style = SpanStyle(color = Color.Red)
+		with(AnnotatedString.Builder()) {
+			val styleIndex0 = pushStyle(style)
+			val styleIndex1 = pushStyle(style)
+			val styleIndex2 = pushStyle(style)
+
+			assertThat(styleIndex0).isEqualTo(0)
+			assertThat(styleIndex1).isEqualTo(1)
+			assertThat(styleIndex2).isEqualTo(2)
+		}
+	}
+
+	@Test fun push_reduces_the_style_index_after_pop() {
+		val spanStyle = SpanStyle(color = Color.Red)
+
+		with(AnnotatedString.Builder()) {
+			val styleIndex0 = pushStyle(spanStyle)
+			val styleIndex1 = pushStyle(spanStyle)
+
+			assertThat(styleIndex0).isEqualTo(0)
+			assertThat(styleIndex1).isEqualTo(1)
+
+			// a pop should reduce the next index to one
+			pop()
+
+			val styleIndex = pushStyle(spanStyle)
+			assertThat(styleIndex).isEqualTo(1)
+		}
+	}
+
+	@Test fun pop_until_throws_exception_for_invalid_index() {
+		val style = SpanStyle(color = Color.Red)
+		with(AnnotatedString.Builder()) {
+			val styleIndex = pushStyle(style)
+
+			assertFailsWith<IllegalStateException> {
+				// should throw exception
+				pop(styleIndex + 1)
+			}
+		}
+	}
+
+	@Test fun pop_until_index_pops_correctly() {
+		val style = SpanStyle(color = Color.Red)
+		with(AnnotatedString.Builder()) {
+			pushStyle(style)
+			// store the index of second push
+			val styleIndex = pushStyle(style)
+			pushStyle(style)
+			// pop up to and including styleIndex
+			pop(styleIndex)
+			// push again to get a new index to compare
+			val newStyleIndex = pushStyle(style)
+
+			assertThat(newStyleIndex).isEqualTo(styleIndex)
+		}
+	}
+
+	@Test fun withStyle_applies_style_to_block() {
+		val style = SpanStyle(color = Color.Red)
+		val buildResult = with(AnnotatedString.Builder()) {
+			withStyle(style) {
+				append("Style")
+			}
+			toAnnotatedString()
+		}
+
+		assertThat(buildResult.spanStyles).isEqualTo(
+			listOf(Range(style, 0, buildResult.length))
+		)
+	}
+
+	@Test fun append_char_appends() {
+		val buildResult = with(AnnotatedString.Builder("a")) {
+			append('b')
+			append('c')
+			toAnnotatedString()
+		}
+
+		assertThat(buildResult).isEqualTo(AnnotatedString("abc"))
+	}
+
+	@Test fun builderLambda() {
+		val text1 = "Hello"
+		val text2 = "World"
+		val spanStyle1 = SpanStyle(color = Color.Red)
+		val spanStyle2 = SpanStyle(background = Color.Green)
+		val spanStyle3 = SpanStyle(color = Color.Blue)
+
+		val buildResult = buildAnnotatedString {
+			withStyle(spanStyle1) {
+				withStyle(spanStyle2) {
+					append(text1)
+				}
+			}
+			append(" ")
+			pushStyle(spanStyle3)
+			append(text2)
+			pop()
+		}
+
+		val expectedString = "$text1 $text2"
+		val expectedSpanStyles = listOf(
+			Range(spanStyle1, 0, text1.length),
+			Range(spanStyle2, 0, text1.length),
+			Range(spanStyle3, text1.length + 1, expectedString.length)
+		)
+
+		assertThat(buildResult.text).isEqualTo(expectedString)
+		assertThat(buildResult.spanStyles).isEqualTo(expectedSpanStyles)
+	}
+
+	@Test fun toAnnotatedString_calling_twice_creates_equal_annotated_strings() {
+		val builder = AnnotatedString.Builder().apply {
+			// pushed styles not popped on purpose
+			pushStyle(SpanStyle(color = Color.Red))
+			append("Hello")
+			pushStyle(SpanStyle(color = Color.Blue))
+			append("World")
+		}
+
+		assertThat(builder.toAnnotatedString()).isEqualTo(builder.toAnnotatedString())
+	}
+
+	@Test fun can_call_other_functions_after_toAnnotatedString() {
+		val builder = AnnotatedString.Builder().apply {
+			// pushed styles not popped on purpose
+			pushStyle(SpanStyle(color = Color.Red))
+			append("Hello")
+			pushStyle(SpanStyle(color = Color.Blue))
+			append("World")
+		}
+
+		val buildResult1 = builder.toAnnotatedString()
+		val buildResult2 = with(builder) {
+			pop()
+			pop()
+			pushStyle(SpanStyle(color = Color.Green))
+			append("!")
+			toAnnotatedString()
+		}
+
+		// buildResult2 should be the same as creating a new AnnotatedString based on the first
+		// result and appending the same values
+		val expectedResult = with(AnnotatedString.Builder(buildResult1)) {
+			withStyle(SpanStyle(color = Color.Green)) {
+				append("!")
+			}
+			toAnnotatedString()
+		}
+
+		assertThat(buildResult2).isEqualTo(expectedResult)
+	}
+
+	private fun createAnnotatedString(
+		text: String,
+		color: Color = Color.Red
+	): AnnotatedString {
+		return AnnotatedString(
+			text = text,
+			spanStyle = SpanStyle(color)
+		)
+	}
+
+	/**
+	 * Returns a [Range] from the index of [start] to the index of [end], both inclusive.
+	 */
+	private fun <T> String.inclusiveRangeOf(
+		start: Char,
+		end: Char,
+		item: T,
+	) = Range(
+		item = item,
+		start = indexOf(start),
+		end = indexOf(end) + 1
+	)
+}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/text/AnnotatedStringTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/text/AnnotatedStringTest.kt
@@ -1,0 +1,233 @@
+package com.jakewharton.mosaic.text
+
+import com.jakewharton.mosaic.text.AnnotatedString.Range
+import com.jakewharton.mosaic.ui.Color
+import com.varabyte.truthish.assertThat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AnnotatedStringTest {
+
+	@Test fun length_returns_text_length() {
+		val text = "abc"
+		val annotatedString = AnnotatedString(text)
+		assertThat(annotatedString.length).isEqualTo(text.length)
+	}
+
+	@Test fun plus_operator_creates_a_new_annotated_string() {
+		val text1 = "Hello"
+		val spanStyles1 = listOf(
+			Range(SpanStyle(color = Color.Red), 0, 3),
+			Range(SpanStyle(color = Color.Blue), 2, 4)
+		)
+		val annotatedString1 = AnnotatedString(
+			text = text1,
+			spanStylesOrNull = spanStyles1,
+		)
+
+		val text2 = "World"
+		val spanStyle = SpanStyle(color = Color.Cyan)
+		val annotatedString2 = AnnotatedString(
+			text = text2,
+			spanStylesOrNull = listOf(Range(spanStyle, 0, text2.length)),
+		)
+
+		assertThat(annotatedString1 + annotatedString2).isEqualTo(
+			AnnotatedString(
+				"$text1$text2",
+				spanStyles1 + listOf(
+					Range(spanStyle, text1.length, text1.length + text2.length)
+				),
+			)
+		)
+	}
+
+	@Test fun subSequence_returns_the_correct_string() {
+		val annotatedString = AnnotatedString.Builder("abcd").toAnnotatedString()
+
+		assertThat(annotatedString.subSequence(1, 3).text).isEqualTo("bc")
+	}
+
+	@Test fun subSequence_returns_empty_text_for_start_equals_end() {
+		val annotatedString = with(AnnotatedString.Builder()) {
+			withStyle(SpanStyle(color = Color.Red)) {
+				append("a")
+			}
+			withStyle(SpanStyle(color = Color.Red)) {
+				append("b")
+			}
+			append("c")
+			toAnnotatedString()
+		}.subSequence(1, 1)
+
+		assertThat(annotatedString).isEqualTo(
+			AnnotatedString("", listOf(Range(SpanStyle(color = Color.Red), 0, 0)))
+		)
+	}
+
+	@Test fun subSequence_returns_original_text_for_text_range_is_full_range() {
+		val annotatedString = with(AnnotatedString.Builder()) {
+			withStyle(SpanStyle(color = Color.Red)) {
+				append("a")
+			}
+			withStyle(SpanStyle(color = Color.Blue)) {
+				append("b")
+			}
+			append("c")
+			toAnnotatedString()
+		}
+
+		assertThat(annotatedString.subSequence(0, 3)).isSameAs(annotatedString)
+	}
+
+	@Test fun subSequence_doesNot_include_styles_before_the_start() {
+		val annotatedString = with(AnnotatedString.Builder()) {
+			withStyle(SpanStyle(color = Color.Red)) {
+				append("a")
+			}
+			append("b")
+			append("c")
+			toAnnotatedString()
+		}
+
+		assertThat(annotatedString.subSequence("ab".length, annotatedString.length)).isEqualTo(
+			AnnotatedString("c")
+		)
+	}
+
+	@Test fun subSequence_doesNot_include_styles_after_the_end() {
+		val annotatedString = with(AnnotatedString.Builder()) {
+			append("a")
+			withStyle(SpanStyle(color = Color.Red)) {
+				append("b")
+			}
+			append("c")
+			toAnnotatedString()
+		}
+
+		assertThat(annotatedString.subSequence(0, "a".length)).isEqualTo(
+			AnnotatedString("a")
+		)
+	}
+
+	@Test fun subSequence_collapsed_item_with_itemStart_equalTo_rangeStart() {
+		val style = SpanStyle(color = Color.Red)
+		val annotatedString = with(AnnotatedString.Builder()) {
+			append("abc")
+			// add collapsed item at the beginning of b
+			addStyle(style, 1, 1)
+			toAnnotatedString()
+		}
+
+		assertThat(annotatedString.subSequence(1, 2)).isEqualTo(
+			AnnotatedString("b", listOf(Range(style, 0, 0)))
+		)
+	}
+
+	@Test fun subSequence_collapses_included_item() {
+		val style = SpanStyle(color = Color.Red)
+		val annotatedString = with(AnnotatedString.Builder()) {
+			append("a")
+			// will collapse this style in subsequence
+			withStyle(style) {
+				append("b")
+			}
+			append("c")
+			toAnnotatedString()
+		}
+
+		// subsequence with 1,1 will remove text, but include the style
+		assertThat(annotatedString.subSequence(1, 1)).isEqualTo(
+			AnnotatedString("", listOf(Range(style, 0, 0)))
+		)
+	}
+
+	@Test fun subSequence_collapses_covering_item() {
+		val style = SpanStyle(color = Color.Red)
+		val annotatedString = with(AnnotatedString.Builder()) {
+			withStyle(style) {
+				append("abc")
+			}
+			toAnnotatedString()
+		}
+
+		assertThat(annotatedString.subSequence(1, 1)).isEqualTo(
+			AnnotatedString("", listOf(Range(style, 0, 0)))
+		)
+	}
+
+	@Test fun subSequence_with_collapsed_range_with_collapsed_item() {
+		val style = SpanStyle(color = Color.Red)
+		val annotatedString = with(AnnotatedString.Builder()) {
+			append("abc")
+			// add collapsed item at the beginning of b
+			addStyle(style, 1, 1)
+			toAnnotatedString()
+		}
+
+		assertThat(annotatedString.subSequence(1, 1)).isEqualTo(
+			AnnotatedString("", listOf(Range(style, 0, 0)))
+		)
+	}
+
+	@Test fun subSequence_includes_partial_matches() {
+		val annotatedString = with(AnnotatedString.Builder()) {
+			withStyle(SpanStyle(color = Color.Red)) {
+				append("ab")
+			}
+			withStyle(SpanStyle(color = Color.Blue)) {
+				append("c")
+			}
+			append("de")
+			toAnnotatedString()
+		}
+
+		val expectedString = with(AnnotatedString.Builder()) {
+			withStyle(SpanStyle(color = Color.Red)) {
+				append("b")
+			}
+			withStyle(SpanStyle(color = Color.Blue)) {
+				append("c")
+			}
+			append("d")
+			toAnnotatedString()
+		}
+
+		val subSequence = annotatedString.subSequence("a".length, "abcd".length)
+
+		assertThat(subSequence).isEqualTo(expectedString)
+	}
+
+	@Test fun subSequence_throws_exception_for_start_greater_than_end() {
+		assertFailsWith<IllegalArgumentException> {
+			AnnotatedString("ab").subSequence(1, 0)
+		}
+	}
+
+	@Test fun creating_item_with_start_greater_than_end_throws_exception() {
+		assertFailsWith<IllegalArgumentException> {
+			Range(SpanStyle(color = Color.Red), 1, 0)
+		}
+	}
+
+	@Test fun creating_item_with_start_equal_to_end_does_not_throw_exception() {
+		Range(SpanStyle(color = Color.Red), 1, 1)
+	}
+
+	@Test fun constructor_function_with_single_spanStyle() {
+		val text = "a"
+		val spanStyle = SpanStyle(color = Color.Red)
+
+		assertThat(
+			AnnotatedString(text, spanStyle)
+		).isEqualTo(
+			AnnotatedString(text, listOf(Range(spanStyle, 0, text.length)))
+		)
+	}
+
+	@Test fun toString_returns_the_plain_string() {
+		val text = "abc"
+		assertEquals(text, AnnotatedString(text).toString())
+	}
+}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/text/SpanStyleTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/text/SpanStyleTest.kt
@@ -1,0 +1,118 @@
+package com.jakewharton.mosaic.text
+
+import com.jakewharton.mosaic.ui.Color
+import com.jakewharton.mosaic.ui.TextStyle
+import com.varabyte.truthish.assertThat
+import kotlin.test.Test
+
+class SpanStyleTest {
+
+	@Test fun constructorWithDefaultValues() {
+		val style = SpanStyle()
+
+		assertThat(style.color).isNull()
+		assertThat(style.textStyle).isNull()
+		assertThat(style.background).isNull()
+	}
+
+	@Test fun constructorWithCustomizedColor() {
+		val color = Color.Red
+
+		val style = SpanStyle(color = color)
+
+		assertThat(style.color).isEqualTo(color)
+	}
+
+	@Test fun constructorWithCustomizedTextStyle() {
+		val textStyle = TextStyle.Underline
+
+		val style = SpanStyle(textStyle = textStyle)
+
+		assertThat(style.textStyle).isEqualTo(textStyle)
+	}
+
+	@Test fun constructorWithCustomizedBackground() {
+		val color = Color.Red
+
+		val style = SpanStyle(background = color)
+
+		assertThat(style.background).isEqualTo(color)
+	}
+
+	@Test fun mergeWithEmptyOtherShouldReturnThis() {
+		val style = SpanStyle()
+
+		val newSpanStyle = style.merge()
+
+		assertThat(newSpanStyle).isEqualTo(style)
+	}
+
+	@Test fun mergeWithOthersColorIsNullShouldUseThisColor() {
+		val style = SpanStyle(color = Color.Red)
+
+		val newSpanStyle = style.merge(SpanStyle(color = null))
+
+		assertThat(newSpanStyle.color).isEqualTo(style.color)
+	}
+
+	@Test fun mergeWithOthersColorIsSetShouldUseOthersColor() {
+		val style = SpanStyle(color = Color.Red)
+		val otherStyle = SpanStyle(color = Color.Green)
+
+		val newSpanStyle = style.merge(otherStyle)
+
+		assertThat(newSpanStyle.color).isEqualTo(otherStyle.color)
+	}
+
+	@Test fun mergeWithOthersTextStyleIsNullShouldUseThisTextStyle() {
+		val style = SpanStyle(textStyle = TextStyle.Underline)
+
+		val newSpanStyle = style.merge(SpanStyle(textStyle = null))
+
+		assertThat(newSpanStyle.textStyle).isEqualTo(style.textStyle)
+	}
+
+	@Test fun mergeWithOthersTextStyleIsSetShouldUseOthersTextStyle() {
+		val style = SpanStyle(textStyle = TextStyle.Underline)
+		val otherStyle = SpanStyle(textStyle = TextStyle.Strikethrough)
+
+		val newSpanStyle = style.merge(otherStyle)
+
+		assertThat(newSpanStyle.textStyle).isEqualTo(otherStyle.textStyle)
+	}
+
+	@Test fun mergeWithOthersBackgroundIsNullShouldUseThisBackground() {
+		val style = SpanStyle(background = Color.Red)
+
+		val newSpanStyle = style.merge(SpanStyle(background = null))
+
+		assertThat(newSpanStyle.background).isEqualTo(style.background)
+	}
+
+	@Test fun mergeWithOthersBackgroundIsSetShouldUseOthersBackground() {
+		val style = SpanStyle(background = Color.Red)
+		val otherStyle = SpanStyle(background = Color.Green)
+
+		val newSpanStyle = style.merge(otherStyle)
+
+		assertThat(newSpanStyle.background).isEqualTo(otherStyle.background)
+	}
+
+	@Test fun plusOperatorMerges() {
+		val style = SpanStyle(
+			color = Color.Red,
+			textStyle = TextStyle.Strikethrough
+		) + SpanStyle(
+			color = Color.Green,
+			background = Color.Blue
+		)
+
+		assertThat(style).isEqualTo(
+			SpanStyle(
+				color = Color.Green, // overridden by RHS
+				textStyle = TextStyle.Strikethrough, // from LHS,
+				background = Color.Blue // from RHS
+			)
+		)
+	}
+}

--- a/samples/jest/src/main/kotlin/example/jest.kt
+++ b/samples/jest/src/main/kotlin/example/jest.kt
@@ -14,6 +14,9 @@ import com.jakewharton.mosaic.layout.background
 import com.jakewharton.mosaic.layout.padding
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.runMosaicBlocking
+import com.jakewharton.mosaic.text.SpanStyle
+import com.jakewharton.mosaic.text.buildAnnotatedString
+import com.jakewharton.mosaic.text.withStyle
 import com.jakewharton.mosaic.ui.Color.Companion.Black
 import com.jakewharton.mosaic.ui.Color.Companion.BrightBlack
 import com.jakewharton.mosaic.ui.Color.Companion.Green
@@ -27,10 +30,10 @@ import com.jakewharton.mosaic.ui.TextStyle.Companion.Bold
 import example.TestState.Fail
 import example.TestState.Pass
 import example.TestState.Running
-import kotlin.random.Random
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.random.Random
 
 fun main() = runMosaicBlocking {
 	val paths = ArrayDeque(
@@ -114,8 +117,14 @@ fun TestRow(test: Test) {
 
 		val dir = test.path.substringBeforeLast('/')
 		val name = test.path.substringAfterLast('/')
-		Text(" $dir/")
-		Text(name, style = Bold)
+		Text(
+			buildAnnotatedString {
+				append(" $dir/")
+				withStyle(SpanStyle(textStyle = Bold)) {
+					append(name)
+				}
+			}
+		)
 	}
 }
 
@@ -170,26 +179,34 @@ private fun Summary(totalTests: Int, tests: List<Test>) {
 		}
 	}
 
-	Row {
-		Text("Tests: ")
+	Text(
+		buildAnnotatedString {
+			append("Tests: ")
 
-		if (failed > 0) {
-			Text("$failed failed", color = Red)
-			Text(", ")
+			if (failed > 0) {
+				withStyle(SpanStyle(color = Red)) {
+					append("$failed failed")
+				}
+				append(", ")
+			}
+
+			if (passed > 0) {
+				withStyle(SpanStyle(color = Green)) {
+					append("$passed passed")
+				}
+				append(", ")
+			}
+
+			if (running > 0) {
+				withStyle(SpanStyle(color = Yellow)) {
+					append("$running running")
+				}
+				append(", ")
+			}
+
+			append("$totalTests total")
 		}
-
-		if (passed > 0) {
-			Text("$passed passed", color = Green)
-			Text(", ")
-		}
-
-		if (running > 0) {
-			Text("$running running", color = Yellow)
-			Text(", ")
-		}
-
-		Text("$totalTests total")
-	}
+	)
 
 	Text("Time:  ${elapsed}s")
 
@@ -215,12 +232,22 @@ fun TestProgress(totalTests: Int, passed: Int, failed: Int, running: Int) {
 	val passedWidth = (passed.toDouble() * totalWidth / totalTests).toInt()
 	val runningWidth = if (showRunning) (running.toDouble() * totalWidth / totalTests).toInt() else 0
 
-	Row {
-		Text(" ".repeat(failedWidth), background = Red)
-		Text(" ".repeat(passedWidth), background = Green)
-		Text(" ".repeat(runningWidth), background = Yellow)
-		Text(" ".repeat(totalWidth - failedWidth - passedWidth - runningWidth), background = BrightBlack)
-	}
+	Text(
+		buildAnnotatedString {
+			withStyle(SpanStyle(background = Red)) {
+				append(" ".repeat(failedWidth))
+			}
+			withStyle(SpanStyle(background = Green)) {
+				append(" ".repeat(passedWidth))
+			}
+			withStyle(SpanStyle(background = Yellow)) {
+				append(" ".repeat(runningWidth))
+			}
+			withStyle(SpanStyle(background = BrightBlack)) {
+				append(" ".repeat(totalWidth - failedWidth - passedWidth - runningWidth))
+			}
+		}
+	)
 }
 
 data class Test(


### PR DESCRIPTION
This is a simplified version of AnnotatedString and SpanStyle from Jetpack Compose. There is no ParagraphStyle support. SpanStyle contains fewer properties. The API has been saved for using AnnotatedString and creating and styling it, for quick understanding if you know Jetpack Compose.

The tests are also taken from Jetpack Compose, but simplified.

The code has two Compose Text functions, two DrawScope.drawText methods, two TextLayout inheritors, in which the difference is only in the accepted value - either String or AnnotatedString. This is done for optimization, but in theory it may be unnecessary.

Update the jest example using AnnotatedString.

This is an attempt to implement a full-featured AnnotatedString, but with the functionality currently available 🙂

Closes #9