### PR TITLE
Add MosaicComposable annotation

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Layout.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Layout.kt
@@ -33,6 +33,7 @@ internal sealed class NoContentMeasureScope {
 }
 
 @Composable
+@MosaicComposable
 internal fun Layout(
 	modifiers: Modifier = Modifier,
 	debugInfo: () -> String = { "Layout()" },

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/MosaicComposable.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/MosaicComposable.kt
@@ -1,0 +1,21 @@
+package com.jakewharton.mosaic.ui
+
+import androidx.compose.runtime.ComposableTargetMarker
+
+/**
+ * An annotation that can be used to mark an composable function as being expected to be use in a
+ * composable function that is also marked or inferred to be marked as a [MosaicComposable].
+ *
+ * Using this annotation explicitly is rarely necessary as the Compose compiler plugin will infer
+ * the necessary equivalent annotations automatically. See
+ * [androidx.compose.runtime.ComposableTarget] for details.
+ */
+@Retention(AnnotationRetention.BINARY)
+@ComposableTargetMarker(description = "Mosaic Composable")
+@Target(
+	AnnotationTarget.FUNCTION,
+	AnnotationTarget.PROPERTY_GETTER,
+	AnnotationTarget.TYPE,
+	AnnotationTarget.TYPE_PARAMETER,
+)
+public annotation class MosaicComposable

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Node.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Node.kt
@@ -11,8 +11,9 @@ import com.jakewharton.mosaic.layout.MosaicNode
 import com.jakewharton.mosaic.modifier.Modifier
 
 @Composable
+@MosaicComposable
 internal inline fun Node(
-	content: @Composable () -> Unit = {},
+	content: @Composable @MosaicComposable () -> Unit = {},
 	modifiers: Modifier,
 	measurePolicy: MeasurePolicy,
 	debugPolicy: DebugPolicy,

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Text.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Text.kt
@@ -10,6 +10,7 @@ import com.jakewharton.mosaic.text.TextLayout
 import kotlin.jvm.JvmName
 
 @Composable
+@MosaicComposable
 public fun Text(
 	value: String,
 	modifier: Modifier = Modifier,


### PR DESCRIPTION
The annotation is used to mark Mosaic Compose functions that cannot be used in other Compose code or for other compositions.

Closes https://github.com/JakeWharton/mosaic/issues/51