### PR TITLE
CompositionLocal for terminal size by Mordant

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ dokka-gradlePlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.9.10"
 buildconfig-gradlePlugin = "com.github.gmazzo:gradle-buildconfig-plugin:3.1.0"
 
 jansi = "org.fusesource.jansi:jansi:2.4.1"
+mordant = "com.github.ajalt.mordant:mordant:2.2.0"
 codepoints = "de.cketti.unicode:kotlin-codepoints:0.6.1"
 
 junit4 = "junit:junit:4.13.2"

--- a/mosaic-runtime/build.gradle
+++ b/mosaic-runtime/build.gradle
@@ -15,6 +15,7 @@ kotlin {
 			dependencies {
 				api libs.compose.runtime
 				api libs.kotlinx.coroutines.core
+				implementation libs.mordant
 				implementation libs.codepoints
 			}
 		}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -4,11 +4,13 @@ import androidx.compose.runtime.AbstractApplier
 import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Recomposer
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.Snapshot
+import com.github.ajalt.mordant.terminal.Terminal
 import com.jakewharton.mosaic.layout.MosaicNode
 import com.jakewharton.mosaic.ui.BoxMeasurePolicy
-import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
@@ -17,6 +19,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
+import kotlin.time.ExperimentalTime
 
 /**
  * True for a debug-like output that renders each "frame" on its own with a timestamp delta.
@@ -92,10 +95,35 @@ public suspend fun runMosaic(body: suspend MosaicScope.() -> Unit): Unit = corou
 		}
 	}
 
+	val terminal = Terminal()
+	val terminalInfo = mutableStateOf(
+		TerminalInfo(
+			size = TerminalInfo.Size(terminal.info.width, terminal.info.height)
+		)
+	)
+
+	launch(context = composeContext) {
+		while (true) {
+			if (terminal.info.updateTerminalSize()
+				&& (terminalInfo.value.size.width != terminal.info.width
+					|| terminalInfo.value.size.height != terminal.info.height)
+			) {
+				terminalInfo.value = terminalInfo.value.copy(
+					size = TerminalInfo.Size(terminal.info.width, terminal.info.height)
+				)
+			}
+			delay(50)
+		}
+	}
+
 	coroutineScope {
 		val scope = object : MosaicScope, CoroutineScope by this {
 			override fun setContent(content: @Composable () -> Unit) {
-				composition.setContent(content)
+				composition.setContent {
+					CompositionLocalProvider(Terminal provides terminalInfo.value) {
+						content()
+					}
+				}
 			}
 		}
 

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -104,11 +104,12 @@ public suspend fun runMosaic(body: suspend MosaicScope.() -> Unit): Unit = corou
 
 	launch(context = composeContext) {
 		while (true) {
+      val currentTerminalInfo = terminalInfo.value
 			if (terminal.info.updateTerminalSize()
-				&& (terminalInfo.value.size.width != terminal.info.width
-					|| terminalInfo.value.size.height != terminal.info.height)
+				&& (currentTerminalInfo.size.width != terminal.info.width
+					|| currentTerminalInfo.size.height != terminal.info.height)
 			) {
-				terminalInfo.value = terminalInfo.value.copy(
+				terminalInfo.value = currentTerminalInfo.copy(
 					size = TerminalInfo.Size(terminal.info.width, terminal.info.height)
 				)
 			}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/terminal.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/terminal.kt
@@ -1,0 +1,17 @@
+package com.jakewharton.mosaic
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+
+public val Terminal: ProvidableCompositionLocal<TerminalInfo> = compositionLocalOf {
+	error("No terminal info")
+}
+
+public data class TerminalInfo(
+	val size: Size,
+) {
+	public data class Size(
+		val width: Int,
+		val height: Int,
+	)
+}


### PR DESCRIPTION
The Mordant KMP library has been added to the mosaic-runtime module in commonMain, which allows you to interact with the cli.

This makes it possible to get the size of the terminal via `CompositionLocal` - `Terminal.current.size`.

I think it was **not** the best solution for https://github.com/JakeWharton/mosaic/issues/72 :(

Advantages:
- we use Mordant - this is a KMP library, that is, we quickly get a working solution with the size of the terminal
- it is possible to replace `platformDisplay` with `com.github.ajalt.mordant.terminal.Terminal::rawPrint`
- probably now will help to implement Constraints (https://github.com/JakeWharton/mosaic/issues/133 )

Disadvantages:
- another loop is added to check the size of the terminal, instead of using callbacks, which are not in the library
- in the future, it will not be possible to make `onKeyEvent`, because the library does not provide such an API
- in the future, we will probably have to switch to our own solution for updating the size of the terminal via callback and the same for `onKeyEvent` (it's also interesting to think about text input)

I think such a solution may be enough at the moment, since the size of the terminal seems to be very necessary for further development, and working with it in general for Compose code via CompositionLocal will not differ depending on the provider.

Part of the idea is taken from https://github.com/JakeWharton/mosaic/pull/75 😊

Closes #75. Closes #72.