### PR TITLE
Move Gradle plugin build directory when included

### DIFF
--- a/mosaic-gradle-plugin/build.gradle
+++ b/mosaic-gradle-plugin/build.gradle
@@ -9,6 +9,10 @@ apply plugin: 'com.github.gmazzo.buildconfig'
 // We only want to publish when it's being built in the root project.
 if (rootProject.name == 'mosaic') {
 	apply plugin: 'com.vanniktech.maven.publish'
+} else {
+	// Move the build directory when included in build-logic so as to not poison the real build.
+	// If we don't there's a chance incorrect build config values (configured below) will be used.
+	layout.buildDirectory = new File(rootDir, "build/mosaic-gradle-plugin")
 }
 
 dependencies {


### PR DESCRIPTION
This ensures we do not get stale build config used when publishing from the main build.