### PR TITLE
Add Constraints and intrinsics to layout system

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/IntrinsicMeasurable.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/IntrinsicMeasurable.kt
@@ -9,4 +9,28 @@ public interface IntrinsicMeasurable {
 	 * Data provided by the `ParentData`
 	 */
 	public val parentData: Any?
+
+	/**
+	 * Calculates the minimum width that the layout can be such that
+	 * the content of the layout will be painted correctly.
+	 */
+	public fun minIntrinsicWidth(height: Int): Int
+
+	/**
+	 * Calculates the smallest width beyond which increasing the width never
+	 * decreases the height.
+	 */
+	public fun maxIntrinsicWidth(height: Int): Int
+
+	/**
+	 * Calculates the minimum height that the layout can be such that
+	 * the content of the layout will be painted correctly.
+	 */
+	public fun minIntrinsicHeight(width: Int): Int
+
+	/**
+	 * Calculates the smallest height beyond which increasing the height never
+	 * decreases the width.
+	 */
+	public fun maxIntrinsicHeight(width: Int): Int
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/LayoutModifier.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/LayoutModifier.kt
@@ -17,15 +17,17 @@
 package com.jakewharton.mosaic.layout
 
 import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.IntrinsicsMeasureScope
+import com.jakewharton.mosaic.ui.unit.Constraints
 
 /**
  * A [Modifier.Element] that changes how its wrapped content is measured and laid out.
- * It has the same measurement and layout functionality as the [com.jakewharton.mosaic.layout.Layout]
+ * It has the same measurement and layout functionality as the [com.jakewharton.mosaic.ui.Layout]
  * component, while wrapping exactly one layout due to it being a modifier. In contrast,
- * the [com.jakewharton.mosaic.layout.Layout] component is used to define the layout behavior of
+ * the [com.jakewharton.mosaic.ui.Layout] component is used to define the layout behavior of
  * multiple children.
  *
- * @see com.jakewharton.mosaic.layout.Layout
+ * @see com.jakewharton.mosaic.ui.Layout
  */
 public interface LayoutModifier : Modifier.Element {
 	/**
@@ -40,15 +42,171 @@ public interface LayoutModifier : Modifier.Element {
 	 * is to use the [MeasureScope.layout] factory function.
 	 *
 	 * A [LayoutModifier] uses the same measurement and layout concepts and principles as a
-	 * [Layout], the only difference is that they apply to exactly one child. For a more detailed
-	 * explanation of measurement and layout, see [MeasurePolicy].
+	 * [com.jakewharton.mosaic.ui.Layout], the only difference is that they apply to exactly one child.
+	 * For a more detailed explanation of measurement and layout, see [MeasurePolicy].
 	 */
 	public fun MeasureScope.measure(
 		measurable: Measurable,
+		constraints: Constraints,
 	): MeasureResult
+
+	/**
+	 * The function used to calculate [IntrinsicMeasurable.minIntrinsicWidth].
+	 */
+	public fun minIntrinsicWidth(
+		measurable: IntrinsicMeasurable,
+		height: Int
+	): Int = MeasuringIntrinsics.minWidth(this, measurable, height)
+
+	/**
+	 * The lambda used to calculate [IntrinsicMeasurable.minIntrinsicHeight].
+	 */
+	public fun minIntrinsicHeight(
+		measurable: IntrinsicMeasurable,
+		width: Int
+	): Int = MeasuringIntrinsics.minHeight(this, measurable, width)
+
+	/**
+	 * The function used to calculate [IntrinsicMeasurable.maxIntrinsicWidth].
+	 */
+	public fun maxIntrinsicWidth(
+		measurable: IntrinsicMeasurable,
+		height: Int
+	): Int = MeasuringIntrinsics.maxWidth(this, measurable, height)
+
+	/**
+	 * The lambda used to calculate [IntrinsicMeasurable.maxIntrinsicHeight].
+	 */
+	public fun maxIntrinsicHeight(
+		measurable: IntrinsicMeasurable,
+		width: Int
+	): Int = MeasuringIntrinsics.maxHeight(this, measurable, width)
 
 	// Force subclasses to add a debugging implementation.
 	override fun toString(): String
+}
+
+private object MeasuringIntrinsics {
+	fun minWidth(
+		modifier: LayoutModifier,
+		intrinsicMeasurable: IntrinsicMeasurable,
+		h: Int
+	): Int {
+		val measurable = DefaultIntrinsicMeasurable(
+			intrinsicMeasurable,
+			IntrinsicMinMax.Min,
+			IntrinsicWidthHeight.Width
+		)
+		val constraints = Constraints(maxHeight = h)
+		val layoutResult = with(modifier) {
+			IntrinsicsMeasureScope.measure(measurable, constraints)
+		}
+		return layoutResult.width
+	}
+
+	fun minHeight(
+		modifier: LayoutModifier,
+		intrinsicMeasurable: IntrinsicMeasurable,
+		w: Int
+	): Int {
+		val measurable = DefaultIntrinsicMeasurable(
+			intrinsicMeasurable,
+			IntrinsicMinMax.Min,
+			IntrinsicWidthHeight.Height
+		)
+		val constraints = Constraints(maxWidth = w)
+		val layoutResult = with(modifier) {
+			IntrinsicsMeasureScope.measure(measurable, constraints)
+		}
+		return layoutResult.height
+	}
+
+	fun maxWidth(
+		modifier: LayoutModifier,
+		intrinsicMeasurable: IntrinsicMeasurable,
+		h: Int
+	): Int {
+		val measurable = DefaultIntrinsicMeasurable(
+			intrinsicMeasurable,
+			IntrinsicMinMax.Max,
+			IntrinsicWidthHeight.Width
+		)
+		val constraints = Constraints(maxHeight = h)
+		val layoutResult = with(modifier) {
+			IntrinsicsMeasureScope.measure(measurable, constraints)
+		}
+		return layoutResult.width
+	}
+
+	fun maxHeight(
+		modifier: LayoutModifier,
+		intrinsicMeasurable: IntrinsicMeasurable,
+		w: Int
+	): Int {
+		val measurable = DefaultIntrinsicMeasurable(
+			intrinsicMeasurable,
+			IntrinsicMinMax.Max,
+			IntrinsicWidthHeight.Height
+		)
+		val constraints = Constraints(maxWidth = w)
+		val layoutResult = with(modifier) {
+			IntrinsicsMeasureScope.measure(measurable, constraints)
+		}
+		return layoutResult.height
+	}
+
+	private class DefaultIntrinsicMeasurable(
+		val measurable: IntrinsicMeasurable,
+		val minMax: IntrinsicMinMax,
+		val widthHeight: IntrinsicWidthHeight
+	) : Measurable {
+		override val parentData: Any?
+			get() = measurable.parentData
+
+		override fun measure(constraints: Constraints): Placeable {
+			if (widthHeight == IntrinsicWidthHeight.Width) {
+				val width = if (minMax == IntrinsicMinMax.Max) {
+					measurable.maxIntrinsicWidth(constraints.maxHeight)
+				} else {
+					measurable.minIntrinsicWidth(constraints.maxHeight)
+				}
+				return EmptyPlaceable(width, constraints.maxHeight)
+			}
+			val height = if (minMax == IntrinsicMinMax.Max) {
+				measurable.maxIntrinsicHeight(constraints.maxWidth)
+			} else {
+				measurable.minIntrinsicHeight(constraints.maxWidth)
+			}
+			return EmptyPlaceable(constraints.maxWidth, height)
+		}
+
+		override fun minIntrinsicWidth(height: Int): Int {
+			return measurable.minIntrinsicWidth(height)
+		}
+
+		override fun maxIntrinsicWidth(height: Int): Int {
+			return measurable.maxIntrinsicWidth(height)
+		}
+
+		override fun minIntrinsicHeight(width: Int): Int {
+			return measurable.minIntrinsicHeight(width)
+		}
+
+		override fun maxIntrinsicHeight(width: Int): Int {
+			return measurable.maxIntrinsicHeight(width)
+		}
+	}
+
+	private class EmptyPlaceable(
+		override val width: Int,
+		override val height: Int,
+	) : Placeable() {
+
+		override fun placeAt(x: Int, y: Int) {}
+	}
+
+	private enum class IntrinsicMinMax { Min, Max }
+	private enum class IntrinsicWidthHeight { Width, Height }
 }
 
 /**
@@ -58,18 +216,19 @@ public interface LayoutModifier : Modifier.Element {
  * create a class or an object that implements the [LayoutModifier] interface. The intrinsic
  * measurements follow the default logic provided by the [LayoutModifier].
  *
- * @see com.jakewharton.mosaic.layout.LayoutModifier
+ * @see com.jakewharton.mosaic.ui.Layout
  */
 public fun Modifier.layout(
-	measure: MeasureScope.(Measurable) -> MeasureResult
+	measure: MeasureScope.(Measurable, Constraints) -> MeasureResult
 ): Modifier = this then LayoutModifierElement(measure)
 
 private class LayoutModifierElement(
-	var measureBlock: MeasureScope.(Measurable) -> MeasureResult
+	var measureBlock: MeasureScope.(Measurable, Constraints) -> MeasureResult
 ) : LayoutModifier {
 	override fun MeasureScope.measure(
 		measurable: Measurable,
-	) = measureBlock(measurable)
+		constraints: Constraints
+	): MeasureResult = measureBlock(measurable, constraints)
 
 	override fun toString(): String {
 		return "LayoutModifierImpl(measureBlock=$measureBlock)"

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Measurable.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Measurable.kt
@@ -1,5 +1,7 @@
 package com.jakewharton.mosaic.layout
 
+import com.jakewharton.mosaic.ui.unit.Constraints
+
 public interface Measurable : IntrinsicMeasurable {
-	public fun measure(): Placeable
+	public fun measure(constraints: Constraints): Placeable
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/MeasurePolicy.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/MeasurePolicy.kt
@@ -1,5 +1,85 @@
 package com.jakewharton.mosaic.layout
 
+import com.jakewharton.mosaic.ui.DefaultIntrinsicMeasurable
+import com.jakewharton.mosaic.ui.IntrinsicMinMax
+import com.jakewharton.mosaic.ui.IntrinsicWidthHeight
+import com.jakewharton.mosaic.ui.IntrinsicsMeasureScope
+import com.jakewharton.mosaic.ui.unit.Constraints
+
 public fun interface MeasurePolicy {
-	public fun MeasureScope.measure(measurables: List<Measurable>): MeasureResult
+
+	public fun MeasureScope.measure(
+		measurables: List<Measurable>,
+		constraints: Constraints
+	): MeasureResult
+
+	/**
+	 * The function used to calculate [IntrinsicMeasurable.minIntrinsicWidth]. It represents
+	 * the minimum width this layout can take, given a specific height, such that the content
+	 * of the layout can be painted correctly.
+	 */
+	public fun minIntrinsicWidth(
+		measurables: List<IntrinsicMeasurable>,
+		height: Int
+	): Int {
+		val mapped = measurables.map {
+			DefaultIntrinsicMeasurable(it, IntrinsicMinMax.Min, IntrinsicWidthHeight.Width)
+		}
+		val constraints = Constraints(maxHeight = height)
+		val layoutReceiver = IntrinsicsMeasureScope
+		val layoutResult = layoutReceiver.measure(mapped, constraints)
+		return layoutResult.width
+	}
+
+	/**
+	 * The function used to calculate [IntrinsicMeasurable.minIntrinsicHeight]. It represents
+	 * the minimum height this layout can take, given a specific width, such that the content
+	 * of the layout will be painted correctly.
+	 */
+	public fun minIntrinsicHeight(
+		measurables: List<IntrinsicMeasurable>,
+		width: Int
+	): Int {
+		val mapped = measurables.map {
+			DefaultIntrinsicMeasurable(it, IntrinsicMinMax.Min, IntrinsicWidthHeight.Height)
+		}
+		val constraints = Constraints(maxWidth = width)
+		val layoutReceiver = IntrinsicsMeasureScope
+		val layoutResult = layoutReceiver.measure(mapped, constraints)
+		return layoutResult.height
+	}
+
+	/**
+	 * The function used to calculate [IntrinsicMeasurable.maxIntrinsicWidth]. It represents the
+	 * minimum width such that increasing it further will not decrease the minimum intrinsic height.
+	 */
+	public fun maxIntrinsicWidth(
+		measurables: List<IntrinsicMeasurable>,
+		height: Int
+	): Int {
+		val mapped = measurables.map {
+			DefaultIntrinsicMeasurable(it, IntrinsicMinMax.Max, IntrinsicWidthHeight.Width)
+		}
+		val constraints = Constraints(maxHeight = height)
+		val layoutReceiver = IntrinsicsMeasureScope
+		val layoutResult = layoutReceiver.measure(mapped, constraints)
+		return layoutResult.width
+	}
+
+	/**
+	 * The function used to calculate [IntrinsicMeasurable.maxIntrinsicHeight]. It represents the
+	 * minimum height such that increasing it further will not decrease the minimum intrinsic width.
+	 */
+	public fun maxIntrinsicHeight(
+		measurables: List<IntrinsicMeasurable>,
+		width: Int
+	): Int {
+		val mapped = measurables.map {
+			DefaultIntrinsicMeasurable(it, IntrinsicMinMax.Max, IntrinsicWidthHeight.Height)
+		}
+		val constraints = Constraints(maxWidth = width)
+		val layoutReceiver = IntrinsicsMeasureScope
+		val layoutResult = layoutReceiver.measure(mapped, constraints)
+		return layoutResult.height
+	}
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Padding.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Padding.kt
@@ -18,6 +18,10 @@ package com.jakewharton.mosaic.layout
 
 import androidx.compose.runtime.Stable
 import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.unit.Constraints
+import com.jakewharton.mosaic.ui.unit.constrainHeight
+import com.jakewharton.mosaic.ui.unit.constrainWidth
+import com.jakewharton.mosaic.ui.unit.offset
 
 @Stable
 public fun Modifier.padding(
@@ -70,14 +74,17 @@ private class PaddingModifier(
 		}
 	}
 
-	override fun MeasureScope.measure(measurable: Measurable): MeasureResult {
+	override fun MeasureScope.measure(
+		measurable: Measurable,
+		constraints: Constraints
+	): MeasureResult {
 		val horizontal = left + right
 		val vertical = top + bottom
 
-		val placeable = measurable.measure()
+		val placeable = measurable.measure(constraints.offset(-horizontal, -vertical))
 
-		val width = placeable.width + horizontal
-		val height = placeable.height + vertical
+		val width = constraints.constrainWidth(placeable.width + horizontal)
+		val height = constraints.constrainHeight(placeable.height + vertical)
 		return layout(width, height) {
 			placeable.place(left, top)
 		}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Placeable.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Placeable.kt
@@ -1,5 +1,7 @@
 package com.jakewharton.mosaic.layout
 
+import com.jakewharton.mosaic.ui.unit.IntOffset
+
 public abstract class Placeable {
 	public abstract val width: Int
 	public abstract val height: Int
@@ -12,6 +14,10 @@ public abstract class Placeable {
 
 		public fun Placeable.place(x: Int, y: Int) {
 			placeAt(this@PlacementScope.x + x, this@PlacementScope.y + y)
+		}
+
+		public fun Placeable.place(position: IntOffset) {
+			placeAt(this@PlacementScope.x + position.x, this@PlacementScope.y + position.y)
 		}
 	}
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Size.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Size.kt
@@ -1,0 +1,470 @@
+package com.jakewharton.mosaic.layout
+
+import androidx.compose.runtime.Stable
+import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.unit.Constraints
+import com.jakewharton.mosaic.ui.unit.IntSize
+import com.jakewharton.mosaic.ui.unit.constrain
+import com.jakewharton.mosaic.ui.unit.constrainHeight
+import com.jakewharton.mosaic.ui.unit.constrainWidth
+
+/**
+ * Declare the preferred width of the content to be exactly [width]. The incoming measurement
+ * [Constraints] may override this value, forcing the content to be either smaller or larger.
+ *
+ * For a modifier that sets the width of the content regardless of the incoming constraints see
+ * [Modifier.requiredWidth]. See [height] or [size] to set other preferred dimensions.
+ * See [widthIn], [heightIn] or [sizeIn] to set a preferred size range.
+ */
+@Stable
+public fun Modifier.width(width: Int): Modifier = this.then(
+	SizeModifier(
+		minWidth = width,
+		maxWidth = width,
+		enforceIncoming = true,
+	)
+)
+
+/**
+ * Declare the preferred height of the content to be exactly [height]. The incoming measurement
+ * [Constraints] may override this value, forcing the content to be either smaller or larger.
+ *
+ * For a modifier that sets the height of the content regardless of the incoming constraints see
+ * [Modifier.requiredHeight]. See [width] or [size] to set other preferred dimensions.
+ * See [widthIn], [heightIn] or [sizeIn] to set a preferred size range.
+ */
+@Stable
+public fun Modifier.height(height: Int): Modifier = this.then(
+	SizeModifier(
+		minHeight = height,
+		maxHeight = height,
+		enforceIncoming = true,
+	)
+)
+
+/**
+ * Declare the preferred size of the content to be exactly [size] square. The incoming measurement
+ * [Constraints] may override this value, forcing the content to be either smaller or larger.
+ *
+ * For a modifier that sets the size of the content regardless of the incoming constraints, see
+ * [Modifier.requiredSize]. See [width] or [height] to set width or height alone.
+ * See [widthIn], [heightIn] or [sizeIn] to set a preferred size range.
+ */
+@Stable
+public fun Modifier.size(size: Int): Modifier = this.then(
+	SizeModifier(
+		minWidth = size,
+		maxWidth = size,
+		minHeight = size,
+		maxHeight = size,
+		enforceIncoming = true,
+	)
+)
+
+/**
+ * Declare the preferred size of the content to be exactly [width] by [height]. The incoming
+ * measurement [Constraints] may override this value, forcing the content to be either smaller or
+ * larger.
+ *
+ * For a modifier that sets the size of the content regardless of the incoming constraints, see
+ * [Modifier.requiredSize]. See [width] or [height] to set width or height alone.
+ * See [widthIn], [heightIn] or [sizeIn] to set a preferred size range.
+ */
+@Stable
+public fun Modifier.size(width: Int, height: Int): Modifier = this.then(
+	SizeModifier(
+		minWidth = width,
+		maxWidth = width,
+		minHeight = height,
+		maxHeight = height,
+		enforceIncoming = true,
+	)
+)
+
+/**
+ * Declare the preferred size of the content to be exactly [size]. The incoming
+ * measurement [Constraints] may override this value, forcing the content to be either smaller or
+ * larger.
+ *
+ * For a modifier that sets the size of the content regardless of the incoming constraints, see
+ * [Modifier.requiredSize]. See [width] or [height] to set width or height alone.
+ * See [widthIn], [heightIn] or [sizeIn] to set a preferred size range.
+ */
+@Stable
+public fun Modifier.size(size: IntSize): Modifier = size(size.width, size.height)
+
+/**
+ * Constrain the width of the content to be between [min] and [max] as permitted
+ * by the incoming measurement [Constraints]. If the incoming constraints are more restrictive
+ * the requested size will obey the incoming constraints and attempt to be as close as possible
+ * to the preferred size.
+ */
+@Stable
+public fun Modifier.widthIn(
+	min: Int = Unspecified,
+	max: Int = Unspecified
+): Modifier = this.then(
+	SizeModifier(
+		minWidth = min,
+		maxWidth = max,
+		enforceIncoming = true,
+	)
+)
+
+/**
+ * Constrain the height of the content to be between [min] and [max] as permitted
+ * by the incoming measurement [Constraints]. If the incoming constraints are more restrictive
+ * the requested size will obey the incoming constraints and attempt to be as close as possible
+ * to the preferred size.
+ */
+@Stable
+public fun Modifier.heightIn(
+	min: Int = Unspecified,
+	max: Int = Unspecified
+): Modifier = this.then(
+	SizeModifier(
+		minHeight = min,
+		maxHeight = max,
+		enforceIncoming = true,
+	)
+)
+
+/**
+ * Constrain the width of the content to be between [minWidth] and [maxWidth] and the height
+ * of the content to be between [minHeight] and [maxHeight] as permitted by the incoming
+ * measurement [Constraints]. If the incoming constraints are more restrictive the requested size
+ * will obey the incoming constraints and attempt to be as close as possible to the preferred size.
+ */
+@Stable
+public fun Modifier.sizeIn(
+	minWidth: Int = Unspecified,
+	minHeight: Int = Unspecified,
+	maxWidth: Int = Unspecified,
+	maxHeight: Int = Unspecified
+): Modifier = this.then(
+	SizeModifier(
+		minWidth = minWidth,
+		minHeight = minHeight,
+		maxWidth = maxWidth,
+		maxHeight = maxHeight,
+		enforceIncoming = true,
+	)
+)
+
+/**
+ * Declare the width of the content to be exactly [width]. The incoming measurement
+ * [Constraints] will not override this value. If the content chooses a size that does not
+ * satisfy the incoming [Constraints], the parent layout will be reported a size coerced
+ * in the [Constraints], and the position of the content will be automatically offset to be
+ * centered on the space assigned to the child by the parent layout under the assumption that
+ * [Constraints] were respected.
+ *
+ * See [requiredWidthIn] and [requiredSizeIn] to set a size range.
+ * See [width] to set a preferred width, which is only respected when the incoming
+ * constraints allow it.
+ */
+@Stable
+public fun Modifier.requiredWidth(width: Int): Modifier = this.then(
+	SizeModifier(
+		minWidth = width,
+		maxWidth = width,
+		enforceIncoming = false,
+	)
+)
+
+/**
+ * Declare the height of the content to be exactly [height]. The incoming measurement
+ * [Constraints] will not override this value. If the content chooses a size that does not
+ * satisfy the incoming [Constraints], the parent layout will be reported a size coerced
+ * in the [Constraints], and the position of the content will be automatically offset to be
+ * centered on the space assigned to the child by the parent layout under the assumption that
+ * [Constraints] were respected.
+ *
+ * See [requiredHeightIn] and [requiredSizeIn] to set a size range.
+ * See [height] to set a preferred height, which is only respected when the incoming
+ * constraints allow it.
+ */
+@Stable
+public fun Modifier.requiredHeight(height: Int): Modifier = this.then(
+	SizeModifier(
+		minHeight = height,
+		maxHeight = height,
+		enforceIncoming = false,
+	)
+)
+
+/**
+ * Declare the size of the content to be exactly [size] width and height. The incoming measurement
+ * [Constraints] will not override this value. If the content chooses a size that does not
+ * satisfy the incoming [Constraints], the parent layout will be reported a size coerced
+ * in the [Constraints], and the position of the content will be automatically offset to be
+ * centered on the space assigned to the child by the parent layout under the assumption that
+ * [Constraints] were respected.
+ *
+ * See [requiredSizeIn] to set a size range.
+ * See [size] to set a preferred size, which is only respected when the incoming
+ * constraints allow it.
+ */
+@Stable
+public fun Modifier.requiredSize(size: Int): Modifier = this.then(
+	SizeModifier(
+		minWidth = size,
+		maxWidth = size,
+		minHeight = size,
+		maxHeight = size,
+		enforceIncoming = false,
+	)
+)
+
+/**
+ * Declare the size of the content to be exactly [width] and [height]. The incoming measurement
+ * [Constraints] will not override this value. If the content chooses a size that does not
+ * satisfy the incoming [Constraints], the parent layout will be reported a size coerced
+ * in the [Constraints], and the position of the content will be automatically offset to be
+ * centered on the space assigned to the child by the parent layout under the assumption that
+ * [Constraints] were respected.
+ *
+ * See [requiredSizeIn] to set a size range.
+ * See [size] to set a preferred size, which is only respected when the incoming
+ * constraints allow it.
+ */
+@Stable
+public fun Modifier.requiredSize(width: Int, height: Int): Modifier = this.then(
+	SizeModifier(
+		minWidth = width,
+		maxWidth = width,
+		minHeight = height,
+		maxHeight = height,
+		enforceIncoming = false,
+	)
+)
+
+/**
+ * Declare the size of the content to be exactly [size]. The incoming measurement
+ * [Constraints] will not override this value. If the content chooses a size that does not
+ * satisfy the incoming [Constraints], the parent layout will be reported a size coerced
+ * in the [Constraints], and the position of the content will be automatically offset to be
+ * centered on the space assigned to the child by the parent layout under the assumption that
+ * [Constraints] were respected.
+ *
+ * See [requiredSizeIn] to set a size range.
+ * See [size] to set a preferred size, which is only respected when the incoming
+ * constraints allow it.
+ */
+@Stable
+public fun Modifier.requiredSize(size: IntSize): Modifier = requiredSize(size.width, size.height)
+
+/**
+ * Constrain the width of the content to be between [min] and [max].
+ * If the content chooses a size that does not satisfy the incoming [Constraints], the
+ * parent layout will be reported a size coerced in the [Constraints], and the position
+ * of the content will be automatically offset to be centered on the space assigned to
+ * the child by the parent layout under the assumption that [Constraints] were respected.
+ */
+@Stable
+public fun Modifier.requiredWidthIn(
+	min: Int = Unspecified,
+	max: Int = Unspecified
+): Modifier = this.then(
+	SizeModifier(
+		minWidth = min,
+		maxWidth = max,
+		enforceIncoming = false,
+	)
+)
+
+/**
+ * Constrain the height of the content to be between [min] and [max].
+ * If the content chooses a size that does not satisfy the incoming [Constraints], the
+ * parent layout will be reported a size coerced in the [Constraints], and the position
+ * of the content will be automatically offset to be centered on the space assigned to
+ * the child by the parent layout under the assumption that [Constraints] were respected.
+ */
+@Stable
+public fun Modifier.requiredHeightIn(
+	min: Int = Unspecified,
+	max: Int = Unspecified
+): Modifier = this.then(
+	SizeModifier(
+		minHeight = min,
+		maxHeight = max,
+		enforceIncoming = false,
+	)
+)
+
+/**
+ * Constrain the width of the content to be between [minWidth] and [maxWidth], and the
+ * height of the content to be between [minHeight] and [maxHeight].
+ * If the content chooses a size that does not satisfy the incoming [Constraints], the
+ * parent layout will be reported a size coerced in the [Constraints], and the position
+ * of the content will be automatically offset to be centered on the space assigned to
+ * the child by the parent layout under the assumption that [Constraints] were respected.
+ */
+@Stable
+public fun Modifier.requiredSizeIn(
+	minWidth: Int = Unspecified,
+	minHeight: Int = Unspecified,
+	maxWidth: Int = Unspecified,
+	maxHeight: Int = Unspecified
+): Modifier = this.then(
+	SizeModifier(
+		minWidth = minWidth,
+		minHeight = minHeight,
+		maxWidth = maxWidth,
+		maxHeight = maxHeight,
+		enforceIncoming = false,
+	)
+)
+
+private class SizeModifier(
+	private val minWidth: Int = Unspecified,
+	private val minHeight: Int = Unspecified,
+	private val maxWidth: Int = Unspecified,
+	private val maxHeight: Int = Unspecified,
+	private val enforceIncoming: Boolean,
+) : LayoutModifier {
+	private val targetConstraints: Constraints
+		get() {
+			val maxWidth = if (maxWidth != Unspecified) {
+				maxWidth.coerceAtLeast(0)
+			} else {
+				Constraints.Infinity
+			}
+			val maxHeight = if (maxHeight != Unspecified) {
+				maxHeight.coerceAtLeast(0)
+			} else {
+				Constraints.Infinity
+			}
+			val minWidth = if (minWidth != Unspecified) {
+				minWidth.coerceAtMost(maxWidth).coerceAtLeast(0).let {
+					if (it != Constraints.Infinity) it else 0
+				}
+			} else {
+				0
+			}
+			val minHeight = if (minHeight != Unspecified) {
+				minHeight.coerceAtMost(maxHeight).coerceAtLeast(0).let {
+					if (it != Constraints.Infinity) it else 0
+				}
+			} else {
+				0
+			}
+			return Constraints(
+				minWidth = minWidth,
+				minHeight = minHeight,
+				maxWidth = maxWidth,
+				maxHeight = maxHeight
+			)
+		}
+
+	override fun MeasureScope.measure(
+		measurable: Measurable,
+		constraints: Constraints
+	): MeasureResult {
+		val wrappedConstraints = targetConstraints.let { targetConstraints ->
+			if (enforceIncoming) {
+				constraints.constrain(targetConstraints)
+			} else {
+				val resolvedMinWidth = if (minWidth != Unspecified) {
+					targetConstraints.minWidth
+				} else {
+					constraints.minWidth.coerceAtMost(targetConstraints.maxWidth)
+				}
+				val resolvedMaxWidth = if (maxWidth != Unspecified) {
+					targetConstraints.maxWidth
+				} else {
+					constraints.maxWidth.coerceAtLeast(targetConstraints.minWidth)
+				}
+				val resolvedMinHeight = if (minHeight != Unspecified) {
+					targetConstraints.minHeight
+				} else {
+					constraints.minHeight.coerceAtMost(targetConstraints.maxHeight)
+				}
+				val resolvedMaxHeight = if (maxHeight != Unspecified) {
+					targetConstraints.maxHeight
+				} else {
+					constraints.maxHeight.coerceAtLeast(targetConstraints.minHeight)
+				}
+				Constraints(
+					resolvedMinWidth,
+					resolvedMaxWidth,
+					resolvedMinHeight,
+					resolvedMaxHeight
+				)
+			}
+		}
+		val placeable = measurable.measure(wrappedConstraints)
+		return layout(placeable.width, placeable.height) {
+			placeable.place(0, 0)
+		}
+	}
+
+	override fun minIntrinsicWidth(
+		measurable: IntrinsicMeasurable,
+		height: Int
+	): Int {
+		val constraints = targetConstraints
+		return if (constraints.hasFixedWidth) {
+			constraints.maxWidth
+		} else {
+			constraints.constrainWidth(measurable.minIntrinsicWidth(height))
+		}
+	}
+
+	override fun minIntrinsicHeight(
+		measurable: IntrinsicMeasurable,
+		width: Int
+	): Int {
+		val constraints = targetConstraints
+		return if (constraints.hasFixedHeight) {
+			constraints.maxHeight
+		} else {
+			constraints.constrainHeight(measurable.minIntrinsicHeight(width))
+		}
+	}
+
+	override fun maxIntrinsicWidth(
+		measurable: IntrinsicMeasurable,
+		height: Int
+	): Int {
+		val constraints = targetConstraints
+		return if (constraints.hasFixedWidth) {
+			constraints.maxWidth
+		} else {
+			constraints.constrainWidth(measurable.maxIntrinsicWidth(height))
+		}
+	}
+
+	override fun maxIntrinsicHeight(
+		measurable: IntrinsicMeasurable,
+		width: Int
+	): Int {
+		val constraints = targetConstraints
+		return if (constraints.hasFixedHeight) {
+			constraints.maxHeight
+		} else {
+			constraints.constrainHeight(measurable.maxIntrinsicHeight(width))
+		}
+	}
+
+	override fun toString(): String {
+		val params = buildList {
+			if (minWidth != Unspecified) {
+				add("minW=$minWidth")
+			}
+			if (minHeight != Unspecified) {
+				add("minH=$minHeight")
+			}
+			if (maxWidth != Unspecified) {
+				add("maxW=$maxWidth")
+			}
+			if (maxHeight != Unspecified) {
+				add("maxH=$maxHeight")
+			}
+			add("enforceIncoming=$enforceIncoming")
+		}
+		return "SizeModifier(${params.joinToString(", ")})"
+	}
+}
+
+private const val Unspecified = Int.MIN_VALUE

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Alignment.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Alignment.kt
@@ -133,6 +133,10 @@ public data class BiasAlignment(
 		return IntOffset(x.roundToInt(), y.roundToInt())
 	}
 
+	override fun toString(): String {
+		return "Alignment(horizontalBias=${horizontalBias.toInt()}, verticalBias=${verticalBias.toInt()})"
+	}
+
 	/**
 	 * An [Alignment.Horizontal] specified by bias: for example, a bias of -1 represents alignment
 	 * to the start, a bias of 0 will represent centering, and a bias of 1 will represent end.
@@ -149,6 +153,10 @@ public data class BiasAlignment(
 			// calculating the new positions.
 			val center = (space - size).toFloat() / 2f
 			return (center * (1 + bias)).roundToInt()
+		}
+
+		override fun toString(): String {
+			return "Horizontal(bias=${bias.toInt()})"
 		}
 	}
 
@@ -168,6 +176,10 @@ public data class BiasAlignment(
 			// calculating the new positions.
 			val center = (space - size).toFloat() / 2f
 			return (center * (1 + bias)).roundToInt()
+		}
+
+		override fun toString(): String {
+			return "Vertical(bias=${bias.toInt()})"
 		}
 	}
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Box.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Box.kt
@@ -187,6 +187,7 @@ private object BoxScopeInstance : BoxScope {
 		)
 	)
 
+	@Stable
 	override fun Modifier.matchParentSize(): Modifier = this.then(
 		AlignModifier(
 			alignment = Alignment.Center,

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Box.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Box.kt
@@ -5,51 +5,147 @@ package com.jakewharton.mosaic.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
 import com.jakewharton.mosaic.layout.Measurable
 import com.jakewharton.mosaic.layout.MeasurePolicy
 import com.jakewharton.mosaic.layout.MeasureResult
 import com.jakewharton.mosaic.layout.MeasureScope
 import com.jakewharton.mosaic.layout.ParentDataModifier
+import com.jakewharton.mosaic.layout.Placeable
 import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.unit.Constraints
 import com.jakewharton.mosaic.ui.unit.IntSize
 import kotlin.jvm.JvmName
+import kotlin.math.max
 
 @Composable
 public fun Box(
 	modifier: Modifier = Modifier,
 	contentAlignment: Alignment = Alignment.TopStart,
+	propagateMinConstraints: Boolean = false,
 	content: @Composable BoxScope.() -> Unit,
 ) {
+	val measurePolicy = rememberBoxMeasurePolicy(contentAlignment, propagateMinConstraints)
 	Layout(
 		content = { BoxScopeInstance.content() },
 		modifiers = modifier,
-		debugInfo = { "Box()" },
-		measurePolicy = BoxMeasurePolicy(contentAlignment),
+		debugInfo = { "Box(alignment=$contentAlignment, propagateMinConstraints=$propagateMinConstraints)" },
+		measurePolicy = measurePolicy,
 	)
 }
 
-internal class BoxMeasurePolicy(
-	private val contentAlignment: Alignment = Alignment.TopStart,
-) : MeasurePolicy {
+@Composable
+internal fun rememberBoxMeasurePolicy(
+	alignment: Alignment,
+	propagateMinConstraints: Boolean
+): MeasurePolicy = if (alignment == Alignment.TopStart && !propagateMinConstraints) {
+	DefaultBoxMeasurePolicy
+} else {
+	remember(alignment, propagateMinConstraints) {
+		BoxMeasurePolicy(alignment, propagateMinConstraints)
+	}
+}
 
-	override fun MeasureScope.measure(measurables: List<Measurable>): MeasureResult {
-		var width = 0
-		var height = 0
-		val placeables = measurables.map { measurable ->
-			measurable.measure().also {
-				width = maxOf(width, it.width)
-				height = maxOf(height, it.height)
+private val DefaultBoxMeasurePolicy: MeasurePolicy = BoxMeasurePolicy(Alignment.TopStart, false)
+
+internal class BoxMeasurePolicy(
+	private val alignment: Alignment = Alignment.TopStart,
+	private val propagateMinConstraints: Boolean = false,
+) : MeasurePolicy {
+	override fun MeasureScope.measure(
+		measurables: List<Measurable>,
+		constraints: Constraints,
+	): MeasureResult {
+		if (measurables.isEmpty()) {
+			return layout(
+				constraints.minWidth,
+				constraints.minHeight
+			) {}
+		}
+
+		val contentConstraints = if (propagateMinConstraints) {
+			constraints
+		} else {
+			constraints.copy(minWidth = 0, minHeight = 0)
+		}
+
+		if (measurables.size == 1) {
+			val measurable = measurables[0]
+			val boxWidth: Int
+			val boxHeight: Int
+			val placeable: Placeable
+			if (!measurable.matchesParentSize) {
+				placeable = measurable.measure(contentConstraints)
+				boxWidth = max(constraints.minWidth, placeable.width)
+				boxHeight = max(constraints.minHeight, placeable.height)
+			} else {
+				boxWidth = constraints.minWidth
+				boxHeight = constraints.minHeight
+				placeable = measurable.measure(
+					Constraints.fixed(constraints.minWidth, constraints.minHeight)
+				)
+			}
+			return layout(boxWidth, boxHeight) {
+				placeInBox(placeable, measurable, boxWidth, boxHeight, alignment)
 			}
 		}
-		return layout(width, height) {
+
+		val placeables = arrayOfNulls<Placeable>(measurables.size)
+		// First measure non match parent size children to get the size of the Box.
+		var hasMatchParentSizeChildren = false
+		var boxWidth = constraints.minWidth
+		var boxHeight = constraints.minHeight
+		measurables.forEachIndexed { index, measurable ->
+			if (!measurable.matchesParentSize) {
+				val placeable = measurable.measure(contentConstraints)
+				placeables[index] = placeable
+				boxWidth = max(boxWidth, placeable.width)
+				boxHeight = max(boxHeight, placeable.height)
+			} else {
+				hasMatchParentSizeChildren = true
+			}
+		}
+
+		// Now measure match parent size children, if any.
+		if (hasMatchParentSizeChildren) {
+			// The infinity check is needed for default intrinsic measurements.
+			val matchParentSizeConstraints = Constraints(
+				minWidth = if (boxWidth != Constraints.Infinity) boxWidth else 0,
+				minHeight = if (boxHeight != Constraints.Infinity) boxHeight else 0,
+				maxWidth = boxWidth,
+				maxHeight = boxHeight
+			)
+			measurables.forEachIndexed { index, measurable ->
+				if (measurable.matchesParentSize) {
+					placeables[index] = measurable.measure(matchParentSizeConstraints)
+				}
+			}
+		}
+
+		// Specify the size of the Box and position its children.
+		return layout(boxWidth, boxHeight) {
 			placeables.forEachIndexed { index, placeable ->
-				val alignment = measurables[index].boxParentData?.alignment ?: contentAlignment
-				val offset =
-					alignment.align(IntSize(placeable.width, placeable.height), IntSize(width, height))
-				placeable.place(offset.x, offset.y)
+				placeable as Placeable
+				val measurable = measurables[index]
+				placeInBox(placeable, measurable, boxWidth, boxHeight, alignment)
 			}
 		}
 	}
+}
+
+private fun Placeable.PlacementScope.placeInBox(
+	placeable: Placeable,
+	measurable: Measurable,
+	boxWidth: Int,
+	boxHeight: Int,
+	alignment: Alignment
+) {
+	val childAlignment = measurable.boxParentData?.alignment ?: alignment
+	val position = childAlignment.align(
+		IntSize(placeable.width, placeable.height),
+		IntSize(boxWidth, boxHeight)
+	)
+	placeable.place(position)
 }
 
 /**
@@ -64,32 +160,63 @@ public interface BoxScope {
 	 */
 	@Stable
 	public fun Modifier.align(alignment: Alignment): Modifier
+
+	/**
+	 * Size the element to match the size of the [Box] after all other content elements have
+	 * been measured.
+	 *
+	 * The element using this modifier does not take part in defining the size of the [Box].
+	 * Instead, it matches the size of the [Box] after all other children (not using
+	 * matchParentSize() modifier) have been measured to obtain the [Box]'s size.
+	 * In contrast, a general-purpose [Modifier.fillMaxSize] modifier, which makes an element
+	 * occupy all available space, will take part in defining the size of the [Box]. Consequently,
+	 * using it for an element inside a [Box] will make the [Box] itself always fill the
+	 * available space.
+	 */
+	@Stable
+	public fun Modifier.matchParentSize(): Modifier
 }
 
 private object BoxScopeInstance : BoxScope {
 
 	@Stable
-	override fun Modifier.align(alignment: Alignment) = this.then(
-		AlignModifier(alignment = alignment)
+	override fun Modifier.align(alignment: Alignment): Modifier = this.then(
+		AlignModifier(
+			alignment = alignment,
+			matchParentSize = false,
+		)
+	)
+
+	override fun Modifier.matchParentSize(): Modifier = this.then(
+		AlignModifier(
+			alignment = Alignment.Center,
+			matchParentSize = true,
+		)
 	)
 }
 
 private class AlignModifier(
 	private val alignment: Alignment,
+	private val matchParentSize: Boolean,
 ) : ParentDataModifier {
 
 	override fun modifyParentData(parentData: Any?): Any {
-		return ((parentData as? BoxParentData) ?: BoxParentData()).also {
+		return (parentData as? BoxParentData)?.also {
 			it.alignment = alignment
-		}
+			it.matchParentSize = matchParentSize
+		} ?: BoxParentData(alignment, matchParentSize)
 	}
 
 	override fun toString(): String = "Align($alignment)"
 }
 
 private data class BoxParentData(
-	var alignment: Alignment = Alignment.TopStart,
+	var alignment: Alignment,
+	var matchParentSize: Boolean,
 )
 
 private val Measurable.boxParentData: BoxParentData?
 	get() = this.parentData as? BoxParentData
+
+private val Measurable.matchesParentSize: Boolean
+	get() = boxParentData?.matchParentSize ?: false

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Column.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Column.kt
@@ -11,6 +11,7 @@ import com.jakewharton.mosaic.layout.MeasureResult
 import com.jakewharton.mosaic.layout.MeasureScope
 import com.jakewharton.mosaic.layout.ParentDataModifier
 import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.unit.Constraints
 import kotlin.jvm.JvmName
 
 @Composable
@@ -22,7 +23,7 @@ public fun Column(
 	Layout(
 		content = { ColumnScopeInstance.content() },
 		modifiers = modifier,
-		debugInfo = { "Column()" },
+		debugInfo = { "Column(alignment=$horizontalAlignment)" },
 		measurePolicy = ColumnMeasurePolicy(horizontalAlignment),
 	)
 }
@@ -30,12 +31,14 @@ public fun Column(
 private class ColumnMeasurePolicy(
 	private val horizontalAlignment: Alignment.Horizontal,
 ) : MeasurePolicy {
-
-	override fun MeasureScope.measure(measurables: List<Measurable>): MeasureResult {
+	override fun MeasureScope.measure(
+		measurables: List<Measurable>,
+		constraints: Constraints,
+	): MeasureResult {
 		var width = 0
 		var height = 0
 		val placeables = measurables.map { measurable ->
-			measurable.measure().also { placeable ->
+			measurable.measure(constraints).also { placeable ->
 				width = maxOf(width, placeable.width)
 				height += placeable.height
 			}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Layout.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Layout.kt
@@ -3,11 +3,14 @@
 package com.jakewharton.mosaic.ui
 
 import androidx.compose.runtime.Composable
+import com.jakewharton.mosaic.layout.IntrinsicMeasurable
 import com.jakewharton.mosaic.layout.Measurable
 import com.jakewharton.mosaic.layout.MeasurePolicy
 import com.jakewharton.mosaic.layout.MeasureResult
 import com.jakewharton.mosaic.layout.MeasureScope
+import com.jakewharton.mosaic.layout.Placeable
 import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.unit.Constraints
 import kotlin.jvm.JvmName
 
 internal fun interface NoContentMeasurePolicy {
@@ -50,7 +53,10 @@ internal fun Layout(
 private class NoContentMeasurePolicyMeasurePolicy(
 	private val noContentMeasurePolicy: NoContentMeasurePolicy,
 ) : MeasurePolicy {
-	override fun MeasureScope.measure(measurables: List<Measurable>): MeasureResult {
+	override fun MeasureScope.measure(
+		measurables: List<Measurable>,
+		constraints: Constraints,
+	): MeasureResult {
 		check(measurables.isEmpty())
 		return noContentMeasurePolicy.run { NoContentMeasureScope.measure() }
 	}
@@ -85,5 +91,101 @@ private fun Modifier.toDebugString(): String {
 		""
 	} else {
 		" " + toString()
+	}
+}
+
+/**
+ * Identifies an [IntrinsicMeasurable] as a min or max intrinsic measurement.
+ */
+internal enum class IntrinsicMinMax {
+	Min, Max
+}
+
+/**
+ * Identifies an [IntrinsicMeasurable] as a width or height intrinsic measurement.
+ */
+internal enum class IntrinsicWidthHeight {
+	Width, Height
+}
+
+/**
+ * Used to return a fixed sized item for intrinsics measurements in [Layout]
+ */
+private class FixedSizeIntrinsicsPlaceable(
+	override val width: Int,
+	override val height: Int,
+) : Placeable() {
+	override fun placeAt(x: Int, y: Int) {}
+}
+
+/**
+ * A wrapper around a [Measurable] for intrinsic measurements in [Layout]. Consumers of
+ * [Layout] don't identify intrinsic methods, but we can give a reasonable implementation
+ * by using their [measure], substituting the intrinsics gathering method
+ * for the [Measurable.measure] call.
+ */
+internal class DefaultIntrinsicMeasurable(
+	val measurable: IntrinsicMeasurable,
+	private val minMax: IntrinsicMinMax,
+	private val widthHeight: IntrinsicWidthHeight
+) : Measurable {
+	override val parentData: Any?
+		get() = measurable.parentData
+
+	override fun measure(constraints: Constraints): Placeable {
+		if (widthHeight == IntrinsicWidthHeight.Width) {
+			val width = if (minMax == IntrinsicMinMax.Max) {
+				measurable.maxIntrinsicWidth(constraints.maxHeight)
+			} else {
+				measurable.minIntrinsicWidth(constraints.maxHeight)
+			}
+			return FixedSizeIntrinsicsPlaceable(width, constraints.maxHeight)
+		}
+		val height = if (minMax == IntrinsicMinMax.Max) {
+			measurable.maxIntrinsicHeight(constraints.maxWidth)
+		} else {
+			measurable.minIntrinsicHeight(constraints.maxWidth)
+		}
+		return FixedSizeIntrinsicsPlaceable(constraints.maxWidth, height)
+	}
+
+	override fun minIntrinsicWidth(height: Int): Int {
+		return measurable.minIntrinsicWidth(height)
+	}
+
+	override fun maxIntrinsicWidth(height: Int): Int {
+		return measurable.maxIntrinsicWidth(height)
+	}
+
+	override fun minIntrinsicHeight(width: Int): Int {
+		return measurable.minIntrinsicHeight(width)
+	}
+
+	override fun maxIntrinsicHeight(width: Int): Int {
+		return measurable.maxIntrinsicHeight(width)
+	}
+}
+
+/**
+ * Receiver scope for [Layout]'s and [LayoutModifier]'s layout lambda when used in an intrinsics
+ * call.
+ */
+internal object IntrinsicsMeasureScope : MeasureScope {
+
+	override fun layout(
+		width: Int,
+		height: Int,
+		placementBlock: Placeable.PlacementScope.() -> Unit
+	): MeasureResult {
+		return object : MeasureResult {
+			override val width: Int
+				get() = width
+			override val height: Int
+				get() = height
+
+			override fun placeChildren() {
+				// Intrinsics should never be placed
+			}
+		}
 	}
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Node.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Node.kt
@@ -6,9 +6,11 @@ import androidx.compose.runtime.ComposeNode
 import com.jakewharton.mosaic.layout.DebugPolicy
 import com.jakewharton.mosaic.layout.Measurable
 import com.jakewharton.mosaic.layout.MeasurePolicy
+import com.jakewharton.mosaic.layout.MeasureResult
 import com.jakewharton.mosaic.layout.MeasureScope
 import com.jakewharton.mosaic.layout.MosaicNode
 import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.unit.Constraints
 
 @Composable
 @MosaicComposable
@@ -47,6 +49,10 @@ internal fun StaticNodeFactory(onDraw: () -> Unit): () -> MosaicNode = {
 }
 
 private val ThrowingPolicy = object : MeasurePolicy, DebugPolicy {
-	override fun MeasureScope.measure(measurables: List<Measurable>) = throw AssertionError()
+	override fun MeasureScope.measure(
+		measurables: List<Measurable>,
+		constraints: Constraints,
+	): MeasureResult = throw AssertionError()
+
 	override fun MosaicNode.renderDebug() = throw AssertionError()
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Row.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Row.kt
@@ -11,6 +11,7 @@ import com.jakewharton.mosaic.layout.MeasureResult
 import com.jakewharton.mosaic.layout.MeasureScope
 import com.jakewharton.mosaic.layout.ParentDataModifier
 import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.unit.Constraints
 import kotlin.jvm.JvmName
 
 @Composable
@@ -22,7 +23,7 @@ public fun Row(
 	Layout(
 		content = { RowScopeInstance.content() },
 		modifiers = modifier,
-		debugInfo = { "Row()" },
+		debugInfo = { "Row(alignment=$verticalAlignment)" },
 		measurePolicy = RowMeasurePolicy(verticalAlignment),
 	)
 }
@@ -31,11 +32,14 @@ private class RowMeasurePolicy(
 	private val verticalAlignment: Alignment.Vertical
 ) : MeasurePolicy {
 
-	override fun MeasureScope.measure(measurables: List<Measurable>): MeasureResult {
+	override fun MeasureScope.measure(
+		measurables: List<Measurable>,
+		constraints: Constraints
+	): MeasureResult {
 		var width = 0
 		var height = 0
 		val placeables = measurables.map { measurable ->
-			measurable.measure().also { placeable ->
+			measurable.measure(constraints).also { placeable ->
 				width += placeable.width
 				height = maxOf(height, placeable.height)
 			}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Spacer.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Spacer.kt
@@ -1,0 +1,42 @@
+package com.jakewharton.mosaic.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonRestartableComposable
+import com.jakewharton.mosaic.layout.Measurable
+import com.jakewharton.mosaic.layout.MeasurePolicy
+import com.jakewharton.mosaic.layout.MeasureResult
+import com.jakewharton.mosaic.layout.MeasureScope
+import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.unit.Constraints
+
+/**
+ * Component that represents an empty space layout, whose size can be defined using
+ * [Modifier.width], [Modifier.height] and [Modifier.size] modifiers.
+ *
+ * @param modifier modifiers to set to this spacer
+ */
+@Composable
+@NonRestartableComposable
+public fun Spacer(modifier: Modifier) {
+	Layout(
+		content = EmptySpacerContent,
+		measurePolicy = SpacerMeasurePolicy,
+		modifiers = modifier,
+		debugInfo = { "Spacer()" }
+	)
+}
+
+private val EmptySpacerContent: @Composable () -> Unit = {}
+
+private object SpacerMeasurePolicy : MeasurePolicy {
+	override fun MeasureScope.measure(
+		measurables: List<Measurable>,
+		constraints: Constraints,
+	): MeasureResult {
+		return with(constraints) {
+			val width = if (hasFixedWidth) maxWidth else 0
+			val height = if (hasFixedHeight) maxHeight else 0
+			layout(width, height) {}
+		}
+	}
+}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Static.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Static.kt
@@ -31,9 +31,9 @@ public fun <T> Static(
 			}
 			lastRendered = items.size
 		},
-		measurePolicy = { measurables ->
+		measurePolicy = { measurables, constraints ->
 			val placeables = measurables.map { measurable ->
-				measurable.measure()
+				measurable.measure(constraints)
 			}
 
 			layout(0, 0) {

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/unit/Constraints.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/unit/Constraints.kt
@@ -1,0 +1,484 @@
+package com.jakewharton.mosaic.ui.unit
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import kotlin.jvm.JvmInline
+
+/**
+ * Immutable constraints for measuring layouts, used by [layouts][com.jakewharton.mosaic.ui.Layout]
+ * or [layout modifiers][com.jakewharton.mosaic.layout.LayoutModifier] to measure their layout
+ * children. The parent chooses the [Constraints] defining a range, in pixels, within which
+ * the measured layout should choose a size:
+ *
+ * - `minWidth` <= `chosenWidth` <= `maxWidth`
+ * - `minHeight` <= `chosenHeight` <= `maxHeight`
+ *
+ * For more details about how layout measurement works, see
+ * [com.jakewharton.mosaic.layout.MeasurePolicy] or
+ * [com.jakewharton.mosaic.layout.LayoutModifier.measure].
+ *
+ * A set of [Constraints] can have infinite maxWidth and/or maxHeight. This is a trick often
+ * used by parents to ask their children for their preferred size: unbounded constraints force
+ * children whose default behavior is to fill the available space (always size to
+ * maxWidth/maxHeight) to have an opinion about their preferred size. Most commonly, when measured
+ * with unbounded [Constraints], these children will fallback to size themselves to wrap their
+ * content, instead of expanding to fill the available space (this is not always true
+ * as it depends on the child layout model, but is a common behavior for core layout components).
+ *
+ * [Constraints] uses a [Long] to represent four values, [minWidth], [minHeight], [maxWidth],
+ * and [maxHeight]. The range of the values varies to allow for at most 256K in one dimension.
+ * There are four possible maximum ranges, 13 bits/18 bits, and 15 bits/16 bits for either width
+ * or height, depending on the needs. For example, a width could range up to 18 bits
+ * and the height up to 13 bits. Alternatively, the width could range up to 16 bits and the height
+ * up to 15 bits. The height and width requirements can be reversed, with a height of up to 18 bits
+ * and width of 13 bits or height of 16 bits and width of 15 bits. Any constraints exceeding
+ * this range will fail.
+ */
+@Immutable
+@JvmInline
+public value class Constraints(
+	@PublishedApi internal val value: Long
+) {
+	/**
+	 * Indicates how the bits are assigned. One of:
+	 * * MinFocusWidth
+	 * * MaxFocusWidth
+	 * * MinFocusHeight
+	 * * MaxFocusHeight
+	 */
+	private val focusIndex
+		get() = (value and FocusMask).toInt()
+
+	/**
+	 * The minimum width that the measurement can take, in pixels.
+	 */
+	public val minWidth: Int
+		get() {
+			val mask = WidthMask[focusIndex]
+			return ((value shr 2).toInt() and mask)
+		}
+
+	/**
+	 * The maximum width that the measurement can take, in pixels. This will either be
+	 * a positive value greater than or equal to [minWidth] or [Constraints.Infinity].
+	 */
+	public val maxWidth: Int
+		get() {
+			val mask = WidthMask[focusIndex]
+			val width = ((value shr 33).toInt() and mask)
+			return if (width == 0) Infinity else width - 1
+		}
+
+	/**
+	 * The minimum height that the measurement can take, in pixels.
+	 */
+	public val minHeight: Int
+		get() {
+			val focus = focusIndex
+			val mask = HeightMask[focus]
+			val offset = MinHeightOffsets[focus]
+			return (value shr offset).toInt() and mask
+		}
+
+	/**
+	 * The maximum height that the measurement can take, in pixels. This will either be
+	 * a positive value greater than or equal to [minHeight] or [Constraints.Infinity].
+	 */
+	public val maxHeight: Int
+		get() {
+			val focus = focusIndex
+			val mask = HeightMask[focus]
+			val offset = MinHeightOffsets[focus] + 31
+			val height = (value shr offset).toInt() and mask
+			return if (height == 0) Infinity else height - 1
+		}
+
+	/**
+	 * `false` when [maxWidth] is [Infinity] and `true` if [maxWidth] is a non-[Infinity] value.
+	 * @see hasBoundedHeight
+	 */
+	public val hasBoundedWidth: Boolean
+		get() {
+			val mask = WidthMask[focusIndex]
+			return ((value shr 33).toInt() and mask) != 0
+		}
+
+	/**
+	 * `false` when [maxHeight] is [Infinity] and `true` if [maxHeight] is a non-[Infinity] value.
+	 * @see hasBoundedWidth
+	 */
+	public val hasBoundedHeight: Boolean
+		get() {
+			val focus = focusIndex
+			val mask = HeightMask[focus]
+			val offset = MinHeightOffsets[focus] + 31
+			return ((value shr offset).toInt() and mask) != 0
+		}
+
+	/**
+	 * Whether there is exactly one width value that satisfies the constraints.
+	 */
+	@Stable
+	public val hasFixedWidth: Boolean get() = maxWidth == minWidth
+
+	/**
+	 * Whether there is exactly one height value that satisfies the constraints.
+	 */
+	@Stable
+	public val hasFixedHeight: Boolean get() = maxHeight == minHeight
+
+	/**
+	 * Whether the area of a component respecting these constraints will definitely be 0.
+	 * This is true when at least one of maxWidth and maxHeight are 0.
+	 */
+	@Stable
+	public val isZero: Boolean get() = maxWidth == 0 || maxHeight == 0
+
+	/**
+	 * Copies the existing [Constraints], replacing some of [minWidth], [minHeight], [maxWidth],
+	 * or [maxHeight] as desired. [minWidth] and [minHeight] must be positive and
+	 * [maxWidth] and [maxHeight] must be greater than or equal to [minWidth] and [minHeight],
+	 * respectively, or [Infinity].
+	 */
+	public fun copy(
+		minWidth: Int = this.minWidth,
+		maxWidth: Int = this.maxWidth,
+		minHeight: Int = this.minHeight,
+		maxHeight: Int = this.maxHeight
+	): Constraints {
+		require(minHeight >= 0 && minWidth >= 0) {
+			"minHeight($minHeight) and minWidth($minWidth) must be >= 0"
+		}
+		require(maxWidth >= minWidth || maxWidth == Infinity) {
+			"maxWidth($maxWidth) must be >= minWidth($minWidth)"
+		}
+		require(maxHeight >= minHeight || maxHeight == Infinity) {
+			"maxHeight($maxHeight) must be >= minHeight($minHeight)"
+		}
+		return createConstraints(minWidth, maxWidth, minHeight, maxHeight)
+	}
+
+	override fun toString(): String {
+		val maxWidth = maxWidth
+		val maxWidthStr = if (maxWidth == Infinity) "Infinity" else maxWidth.toString()
+		val maxHeight = maxHeight
+		val maxHeightStr = if (maxHeight == Infinity) "Infinity" else maxHeight.toString()
+		return "Constraints(minWidth = $minWidth, maxWidth = $maxWidthStr, " +
+			"minHeight = $minHeight, maxHeight = $maxHeightStr)"
+	}
+
+	public companion object {
+		/**
+		 * A value that [maxWidth] or [maxHeight] will be set to when the constraint should
+		 * be considered infinite. [hasBoundedWidth] or [hasBoundedHeight] will be
+		 * `false` when [maxWidth] or [maxHeight] is [Infinity], respectively.
+		 */
+		public const val Infinity: Int = Int.MAX_VALUE
+
+		/**
+		 * The bit distribution when the focus of the bits should be on the width, but only
+		 * a minimal difference in focus.
+		 *
+		 * 16 bits assigned to width, 15 bits assigned to height.
+		 */
+		private const val MinFocusWidth = 0x00L
+
+		/**
+		 * The bit distribution when the focus of the bits should be on the width, and a
+		 * maximal number of bits assigned to the width.
+		 *
+		 * 18 bits assigned to width, 13 bits assigned to height.
+		 */
+		private const val MaxFocusWidth = 0x01L
+
+		/**
+		 * The bit distribution when the focus of the bits should be on the height, but only
+		 * a minimal difference in focus.
+		 *
+		 * 15 bits assigned to width, 16 bits assigned to height.
+		 */
+		private const val MinFocusHeight = 0x02L
+
+		/**
+		 * The bit distribution when the focus of the bits should be on the height, and a
+		 * a maximal number of bits assigned to the height.
+		 *
+		 * 13 bits assigned to width, 18 bits assigned to height.
+		 */
+		private const val MaxFocusHeight = 0x03L
+
+		/**
+		 * The mask to retrieve the focus ([MinFocusWidth], [MaxFocusWidth],
+		 * [MinFocusHeight], [MaxFocusHeight]).
+		 */
+		private const val FocusMask = 0x03L
+
+		/**
+		 * The number of bits used for the focused dimension when there is minimal focus.
+		 */
+		private const val MinFocusBits = 16
+
+		/**
+		 * The mask to use for the focused dimension when there is minimal focus.
+		 */
+		private const val MinFocusMask = 0xFFFF // 64K (16 bits)
+
+		/**
+		 * The number of bits used for the non-focused dimension when there is minimal focus.
+		 */
+		private const val MinNonFocusBits = 15
+
+		/**
+		 * The mask to use for the non-focused dimension when there is minimal focus.
+		 */
+		private const val MinNonFocusMask = 0x7FFF // 32K (15 bits)
+
+		/**
+		 * The number of bits to use for the focused dimension when there is maximal focus.
+		 */
+		private const val MaxFocusBits = 18
+
+		/**
+		 * The mask to use for the focused dimension when there is maximal focus.
+		 */
+		private const val MaxFocusMask = 0x3FFFF // 256K (18 bits)
+
+		/**
+		 * The number of bits to use for the non-focused dimension when there is maximal focus.
+		 */
+		private const val MaxNonFocusBits = 13
+
+		/**
+		 * The mask to use for the non-focused dimension when there is maximal focus.
+		 */
+		private const val MaxNonFocusMask = 0x1FFF // 8K (13 bits)
+
+		/**
+		 * Minimum Height shift offsets into Long value, indexed by FocusMask
+		 * Max offsets are these + 31
+		 * Width offsets are always either 2 (min) or 33 (max)
+		 */
+		private val MinHeightOffsets = intArrayOf(
+			18, // MinFocusWidth: 2 + 16
+			20, // MaxFocusWidth: 2 + 18
+			17, // MinFocusHeight: 2 + 15
+			15 // MaxFocusHeight: 2 + 13
+		)
+
+		/**
+		 * The mask to use for both minimum and maximum width.
+		 */
+		private val WidthMask = intArrayOf(
+			MinFocusMask, // MinFocusWidth (16 bits)
+			MaxFocusMask, // MaxFocusWidth (18 bits)
+			MinNonFocusMask, // MinFocusHeight (15 bits)
+			MaxNonFocusMask // MaxFocusHeight (13 bits)
+		)
+
+		/**
+		 * The mask to use for both minimum and maximum height.
+		 */
+		private val HeightMask = intArrayOf(
+			MinNonFocusMask, // MinFocusWidth (15 bits)
+			MaxNonFocusMask, // MaxFocusWidth (13 bits)
+			MinFocusMask, // MinFocusHeight (16 bits)
+			MaxFocusMask // MaxFocusHeight (18 bits)
+		)
+
+		/**
+		 * Creates constraints for fixed size in both dimensions.
+		 */
+		@Stable
+		public fun fixed(
+			width: Int,
+			height: Int
+		): Constraints {
+			require(width >= 0 && height >= 0) {
+				"width($width) and height($height) must be >= 0"
+			}
+			return createConstraints(width, width, height, height)
+		}
+
+		/**
+		 * Creates constraints for fixed width and unspecified height.
+		 */
+		@Stable
+		public fun fixedWidth(
+			width: Int
+		): Constraints {
+			require(width >= 0) {
+				"width($width) must be >= 0"
+			}
+			return createConstraints(
+				minWidth = width,
+				maxWidth = width,
+				minHeight = 0,
+				maxHeight = Infinity
+			)
+		}
+
+		/**
+		 * Creates constraints for fixed height and unspecified width.
+		 */
+		@Stable
+		public fun fixedHeight(
+			height: Int
+		): Constraints {
+			require(height >= 0) {
+				"height($height) must be >= 0"
+			}
+			return createConstraints(
+				minWidth = 0,
+				maxWidth = Infinity,
+				minHeight = height,
+				maxHeight = height
+			)
+		}
+
+		/**
+		 * Creates a [Constraints], only checking that the values fit in the packed Long.
+		 */
+		internal fun createConstraints(
+			minWidth: Int,
+			maxWidth: Int,
+			minHeight: Int,
+			maxHeight: Int
+		): Constraints {
+			val heightVal = if (maxHeight == Infinity) minHeight else maxHeight
+			val heightBits = bitsNeedForSize(heightVal)
+
+			val widthVal = if (maxWidth == Infinity) minWidth else maxWidth
+			val widthBits = bitsNeedForSize(widthVal)
+
+			if (widthBits + heightBits > 31) {
+				throw IllegalArgumentException(
+					"Can't represent a width of $widthVal and height " +
+						"of $heightVal in Constraints"
+				)
+			}
+
+			val focus = when (widthBits) {
+				MinNonFocusBits -> MinFocusHeight
+				MinFocusBits -> MinFocusWidth
+				MaxNonFocusBits -> MaxFocusHeight
+				MaxFocusBits -> MaxFocusWidth
+				else -> throw IllegalStateException("Should only have the provided constants.")
+			}
+
+			val maxWidthValue = if (maxWidth == Infinity) 0 else maxWidth + 1
+			val maxHeightValue = if (maxHeight == Infinity) 0 else maxHeight + 1
+
+			val minHeightOffset = MinHeightOffsets[focus.toInt()]
+			val maxHeightOffset = minHeightOffset + 31
+
+			val value = focus or
+				(minWidth.toLong() shl 2) or
+				(maxWidthValue.toLong() shl 33) or
+				(minHeight.toLong() shl minHeightOffset) or
+				(maxHeightValue.toLong() shl maxHeightOffset)
+			return Constraints(value)
+		}
+
+		private fun bitsNeedForSize(size: Int): Int {
+			return when {
+				size < MaxNonFocusMask -> MaxNonFocusBits
+				size < MinNonFocusMask -> MinNonFocusBits
+				size < MinFocusMask -> MinFocusBits
+				size < MaxFocusMask -> MaxFocusBits
+				else -> throw IllegalArgumentException(
+					"Can't represent a size of $size in " +
+						"Constraints"
+				)
+			}
+		}
+	}
+}
+
+/**
+ * Create a [Constraints]. [minWidth] and [minHeight] must be positive and
+ * [maxWidth] and [maxHeight] must be greater than or equal to [minWidth] and [minHeight],
+ * respectively, or [Infinity][Constraints.Infinity].
+ */
+@Stable
+public fun Constraints(
+	minWidth: Int = 0,
+	maxWidth: Int = Constraints.Infinity,
+	minHeight: Int = 0,
+	maxHeight: Int = Constraints.Infinity
+): Constraints {
+	require(maxWidth >= minWidth) {
+		"maxWidth($maxWidth) must be >= than minWidth($minWidth)"
+	}
+	require(maxHeight >= minHeight) {
+		"maxHeight($maxHeight) must be >= than minHeight($minHeight)"
+	}
+	require(minWidth >= 0 && minHeight >= 0) {
+		"minWidth($minWidth) and minHeight($minHeight) must be >= 0"
+	}
+	return Constraints.createConstraints(minWidth, maxWidth, minHeight, maxHeight)
+}
+
+/**
+ * Takes [otherConstraints] and returns the result of coercing them in the current constraints.
+ * Note this means that any size satisfying the resulting constraints will satisfy the current
+ * constraints, but they might not satisfy the [otherConstraints] when the two set of constraints
+ * are disjoint.
+ * Examples (showing only width, height works the same):
+ * (minWidth=2, maxWidth=10).constrain(minWidth=7, maxWidth=12) -> (minWidth = 7, maxWidth = 10)
+ * (minWidth=2, maxWidth=10).constrain(minWidth=11, maxWidth=12) -> (minWidth=10, maxWidth=10)
+ * (minWidth=2, maxWidth=10).constrain(minWidth=5, maxWidth=7) -> (minWidth=5, maxWidth=7)
+ */
+public fun Constraints.constrain(otherConstraints: Constraints): Constraints = Constraints(
+	minWidth = otherConstraints.minWidth.coerceIn(minWidth, maxWidth),
+	maxWidth = otherConstraints.maxWidth.coerceIn(minWidth, maxWidth),
+	minHeight = otherConstraints.minHeight.coerceIn(minHeight, maxHeight),
+	maxHeight = otherConstraints.maxHeight.coerceIn(minHeight, maxHeight)
+)
+
+/**
+ * Takes a size and returns the closest size to it that satisfies the constraints.
+ */
+@Stable
+public fun Constraints.constrain(size: IntSize): IntSize = IntSize(
+	width = size.width.coerceIn(minWidth, maxWidth),
+	height = size.height.coerceIn(minHeight, maxHeight)
+)
+
+/**
+ * Takes a width and returns the closest size to it that satisfies the constraints.
+ */
+@Stable
+public fun Constraints.constrainWidth(width: Int): Int = width.coerceIn(minWidth, maxWidth)
+
+/**
+ * Takes a height and returns the closest size to it that satisfies the constraints.
+ */
+@Stable
+public fun Constraints.constrainHeight(height: Int): Int = height.coerceIn(minHeight, maxHeight)
+
+/**
+ * Takes a size and returns whether it satisfies the current constraints.
+ */
+@Stable
+public fun Constraints.isSatisfiedBy(size: IntSize): Boolean {
+	return size.width in minWidth..maxWidth && size.height in minHeight..maxHeight
+}
+
+/**
+ * Returns the Constraints obtained by offsetting the current instance with the given values.
+ */
+@Stable
+public fun Constraints.offset(horizontal: Int = 0, vertical: Int = 0): Constraints = Constraints(
+	(minWidth + horizontal).coerceAtLeast(0),
+	addMaxWithMinimum(maxWidth, horizontal),
+	(minHeight + vertical).coerceAtLeast(0),
+	addMaxWithMinimum(maxHeight, vertical)
+)
+
+private fun addMaxWithMinimum(max: Int, value: Int): Int {
+	return if (max == Constraints.Infinity) {
+		max
+	} else {
+		(max + value).coerceAtLeast(0)
+	}
+}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/DebugRenderingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/DebugRenderingTest.kt
@@ -38,7 +38,7 @@ class DebugRenderingTest {
 				|Failed
 				|
 				|NODES:
-				|Row\(\) x=0 y=0 w=11 h=1
+				|Row\(alignment=Vertical\(bias=-1\)\) x=0 y=0 w=11 h=1
 				|  Text\("Hello "\) x=0 y=0 w=6 h=1 DrawBehind
 				|  Layout\(\) x=6 y=0 w=5 h=1 DrawBehind
 				|

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/LayoutTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/LayoutTest.kt
@@ -19,7 +19,7 @@ class LayoutTest {
 					Text("Hey!")
 				},
 				debugInfo = { "Custom()" },
-			) {
+			) { _, _ ->
 				layout(0, 0) {
 				}
 			}
@@ -38,7 +38,7 @@ class LayoutTest {
 				Text("CCC")
 				Text("BB")
 				Text("A")
-			}) {
+			}) { _, _ ->
 				layout(3, 1) {
 				}
 			}
@@ -55,9 +55,9 @@ class LayoutTest {
 				Text("CCC")
 				Text("BB")
 				Text("A")
-			}) { measurables ->
+			}) {  measurables, constraints ->
 				for (measurable in measurables) {
-					measurable.measure()
+					measurable.measure(constraints)
 				}
 				layout(3, 1) {
 				}
@@ -75,8 +75,8 @@ class LayoutTest {
 				Text("CCC")
 				Text("BB")
 				Text("A")
-			}) { measurables ->
-				val (c, b, a) = measurables.map(Measurable::measure)
+			}) { measurables, constraints ->
+				val (c, b, a) = measurables.map{ it.measure(constraints) }
 				layout(8, 3) {
 					a.place(0, 2)
 					b.place(2, 1)


### PR DESCRIPTION
Added `Constraints` parameter for all required methods.
Extended `MeasurePolicy` with methods of intrinsics.
`Constraints` are fully supported in `Box` and `Modifier.padding`.
Add `Spacer` and size modifiers which use `Constraints`.