### PR TITLE
Fix Gradle warnings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,3 +33,5 @@ org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
 com.jakewharton.mosaic.internal=true
+
+kotlin.native.ignoreDisabledTargets=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ compose-runtime = "org.jetbrains.compose.runtime:runtime:1.5.10"
 
 maven-publish-gradlePlugin = "com.vanniktech:gradle-maven-publish-plugin:0.25.3"
 dokka-gradlePlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.9.10"
-buildconfig-gradlePlugin = "com.github.gmazzo:gradle-buildconfig-plugin:3.1.0"
+buildconfig-gradlePlugin = "com.github.gmazzo.buildconfig:plugin:4.1.2"
 poko-gradlePlugin = "dev.drewhamilton.poko:poko-gradle-plugin:0.15.0"
 
 spotless-gradlePlugin = "com.diffplug.spotless:spotless-plugin-gradle:6.22.0"

--- a/samples/counter/build.gradle
+++ b/samples/counter/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'com.jakewharton.mosaic'
 apply plugin: 'application'
 
 application {
-	mainClassName = 'example.Main'
+	mainClass = 'example.Main'
 }
 
 kotlin {

--- a/samples/demo/build.gradle
+++ b/samples/demo/build.gradle
@@ -2,4 +2,6 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.jakewharton.mosaic'
 apply plugin: 'application'
 
-mainClassName = 'example.DemoKt'
+application {
+	mainClass = 'example.DemoKt'
+}

--- a/samples/jest/build.gradle
+++ b/samples/jest/build.gradle
@@ -2,4 +2,6 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.jakewharton.mosaic'
 apply plugin: 'application'
 
-mainClassName = 'example.JestKt'
+application {
+	mainClass = 'example.JestKt'
+}

--- a/samples/robot/build.gradle
+++ b/samples/robot/build.gradle
@@ -2,7 +2,9 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.jakewharton.mosaic'
 apply plugin: 'application'
 
-mainClassName = 'example.RobotKt'
+application {
+	mainClass = 'example.RobotKt'
+}
 
 dependencies {
 	implementation 'org.jline:jline:3.24.1'


### PR DESCRIPTION
See commit message details for what warning each commit fixes.

This should result in a clean (no-output) `gradlew build` now, except maybe:
```
> Task :kotlinNpmInstall
warning Ignored scripts due to flag.
```
Tracking issue: https://youtrack.jetbrains.com/issue/KT-52578, I'm not sure what side-effect the workaround may have.
