### PR TITLE
Add offset modifier

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Offset.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Offset.kt
@@ -1,0 +1,65 @@
+package com.jakewharton.mosaic.layout
+
+import androidx.compose.runtime.Stable
+import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.unit.Constraints
+import com.jakewharton.mosaic.ui.unit.IntOffset
+
+/**
+ * Offset the content by ([x], [y]). The offsets can be positive as well as non-positive.
+ * Applying an offset only changes the position of the content, without interfering with
+ * its size measurement.
+ *
+ * A positive [x] offset will always move the content to the right.
+ */
+@Stable
+public fun Modifier.offset(x: Int = 0, y: Int = 0): Modifier = this then
+	OffsetModifier(x = x, y = y)
+
+/**
+ * Offset the content by [offset]. The offsets can be positive as well as non-positive.
+ * Applying an offset only changes the position of the content, without interfering with
+ * its size measurement.
+ *
+ * This modifier is designed to be used for offsets that change, possibly due to user interactions.
+ * It avoids recomposition when the offset is changing, and also adds a graphics layer that
+ * prevents unnecessary redrawing of the context when the offset is changing.
+ *
+ * A positive horizontal offset will always move the content to the right.
+ */
+public fun Modifier.offset(offset: () -> IntOffset): Modifier = this then
+	ChangeableOffsetModifier(offset = offset)
+
+private class OffsetModifier(
+	private val x: Int,
+	private val y: Int,
+) : LayoutModifier {
+	override fun MeasureScope.measure(
+		measurable: Measurable,
+		constraints: Constraints
+	): MeasureResult {
+		val placeable = measurable.measure(constraints)
+		return layout(placeable.width, placeable.height) {
+			placeable.place(x, y)
+		}
+	}
+
+	override fun toString(): String = "Offset(x=$x, y=$y)"
+}
+
+private class ChangeableOffsetModifier(
+	private val offset: () -> IntOffset,
+) : LayoutModifier {
+	override fun MeasureScope.measure(
+		measurable: Measurable,
+		constraints: Constraints
+	): MeasureResult {
+		val placeable = measurable.measure(constraints)
+		return layout(placeable.width, placeable.height) {
+			val offsetValue = offset()
+			placeable.place(offsetValue.x, offsetValue.y)
+		}
+	}
+
+	override fun toString(): String = "ChangeableOffset(offset=$offset)"
+}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Offset.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Offset.kt
@@ -36,7 +36,7 @@ private class OffsetModifier(
 ) : LayoutModifier {
 	override fun MeasureScope.measure(
 		measurable: Measurable,
-		constraints: Constraints
+		constraints: Constraints,
 	): MeasureResult {
 		val placeable = measurable.measure(constraints)
 		return layout(placeable.width, placeable.height) {
@@ -52,7 +52,7 @@ private class ChangeableOffsetModifier(
 ) : LayoutModifier {
 	override fun MeasureScope.measure(
 		measurable: Measurable,
-		constraints: Constraints
+		constraints: Constraints,
 	): MeasureResult {
 		val placeable = measurable.measure(constraints)
 		return layout(placeable.width, placeable.height) {


### PR DESCRIPTION
robot sample using the offset modifier. I haven't updated it here, as I'm not sure that the honest size of the world and the maximum position of the robot will look nice in animation.

Example with offset
<details>
<summary>The first picture</summary>

<img width="416" alt="image" src="https://github.com/JakeWharton/mosaic/assets/37583380/33233bb7-2d04-4a09-9cd4-f1a395f94f8d">
</details>
<details>
<summary>The second picture</summary>

<img width="411" alt="image" src="https://github.com/JakeWharton/mosaic/assets/37583380/19c2d8ad-432a-4db7-9d52-fcd1af5e6b5f">
</details>

<details>
<summary>Full code</summary>

```kotlin
package example

import androidx.compose.runtime.getValue
import androidx.compose.runtime.mutableStateOf
import androidx.compose.runtime.setValue
import com.jakewharton.mosaic.layout.background
import com.jakewharton.mosaic.layout.height
import com.jakewharton.mosaic.layout.offset
import com.jakewharton.mosaic.layout.size
import com.jakewharton.mosaic.modifier.Modifier
import com.jakewharton.mosaic.runMosaicBlocking
import com.jakewharton.mosaic.ui.Box
import com.jakewharton.mosaic.ui.Color
import com.jakewharton.mosaic.ui.Column
import com.jakewharton.mosaic.ui.Spacer
import com.jakewharton.mosaic.ui.Text
import com.jakewharton.mosaic.ui.unit.IntOffset
import kotlinx.coroutines.Dispatchers.IO
import kotlinx.coroutines.withContext
import org.jline.terminal.TerminalBuilder

private const val width = 20
private const val height = 10

private const val robotWidth = 3
private const val robotHeight = 1

fun main() = runMosaicBlocking {
  // TODO https://github.com/JakeWharton/mosaic/issues/3
  var x by mutableStateOf(0)
  var y by mutableStateOf(0)

  setContent {
    Column {
      Text("Use arrow keys to move the face. Press “q” to exit.")
      Text("Position: $x, $y   Robot: $robotWidth, $robotHeight   World: $width, $height")
      Spacer(modifier = Modifier.height(1))
      // TODO https://github.com/JakeWharton/mosaic/issues/11
      Box(
        modifier = Modifier
          .size(width, height)
          .background(Color.Green)
          .offset { IntOffset(x, y) }) {
        Text("^_^")
      }
    }
  }

  withContext(IO) {
    val terminal = TerminalBuilder.terminal()
    terminal.enterRawMode()
    val reader = terminal.reader()

    while (true) {
      // TODO https://github.com/JakeWharton/mosaic/issues/10
      when (reader.read()) {
        'q'.code -> break
        27 -> {
          when (reader.read()) {
            91, 79 -> {
              when (reader.read()) {
                65 -> y = (y - 1).coerceAtLeast(0)
                66 -> y = (y + 1).coerceAtMost(height - robotHeight)
                67 -> x = (x + 1).coerceAtMost(width - robotWidth)
                68 -> x = (x - 1).coerceAtLeast(0)
              }
            }
          }
        }
      }
    }
  }
}

```
</details>

Example with no offset width limit
<details>
<img width="440" alt="image" src="https://github.com/JakeWharton/mosaic/assets/37583380/81e78ae3-dd5b-4487-9f79-5043563c2e60">
</details>

If you do not limit the width to zero and specify -1, an exception will be thrown if you press "q" to finish reading the input. I saw item 5 in https://github.com/JakeWharton/mosaic/issues/153 where we are talking about something similar, I will make it a separate pull request.
<details>
<img width="867" alt="image" src="https://github.com/JakeWharton/mosaic/assets/37583380/fde3f292-7ffb-49f6-ba9f-b68fc24da666">
</details>


