### PR TITLE
Update robot sample with offset modifier

### DIFF
--- a/samples/robot/input.sh
+++ b/samples/robot/input.sh
@@ -30,17 +30,9 @@ sleep .1
 echo -e "\e[B"
 sleep .1
 echo -e "\e[B"
-sleep .1
-echo -e "\e[B"
 
 # Right to edge
 sleep .4
-echo -e "\e[C"
-sleep .1
-echo -e "\e[C"
-sleep .1
-echo -e "\e[C"
-sleep .1
 echo -e "\e[C"
 sleep .1
 echo -e "\e[C"

--- a/samples/robot/src/main/kotlin/example/robot.kt
+++ b/samples/robot/src/main/kotlin/example/robot.kt
@@ -3,17 +3,25 @@ package example
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import com.jakewharton.mosaic.layout.padding
+import com.jakewharton.mosaic.layout.height
+import com.jakewharton.mosaic.layout.offset
+import com.jakewharton.mosaic.layout.size
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.runMosaicBlocking
+import com.jakewharton.mosaic.ui.Box
 import com.jakewharton.mosaic.ui.Column
+import com.jakewharton.mosaic.ui.Spacer
 import com.jakewharton.mosaic.ui.Text
+import com.jakewharton.mosaic.ui.unit.IntOffset
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
 import org.jline.terminal.TerminalBuilder
 
 private const val width = 20
 private const val height = 10
+
+private const val robotWidth = 3
+private const val robotHeight = 1
 
 fun main() = runMosaicBlocking {
 	// TODO https://github.com/JakeWharton/mosaic/issues/3
@@ -23,10 +31,12 @@ fun main() = runMosaicBlocking {
 	setContent {
 		Column {
 			Text("Use arrow keys to move the face. Press “q” to exit.")
-			Text("Position: $x, $y   World: $width, $height")
-			Text("")
+			Text("Position: $x, $y   Robot: $robotWidth, $robotHeight   World: $width, $height")
+			Spacer(Modifier.height(1))
 			// TODO https://github.com/JakeWharton/mosaic/issues/11
-			Text("^_^", modifier = Modifier.padding(x, y, width - x, height - y))
+			Box(modifier = Modifier.size(width, height).offset { IntOffset(x, y) }) {
+				Text("^_^")
+			}
 		}
 	}
 
@@ -44,8 +54,8 @@ fun main() = runMosaicBlocking {
 						91, 79 -> {
 							when (reader.read()) {
 								65 -> y = (y - 1).coerceAtLeast(0)
-								66 -> y = (y + 1).coerceAtMost(height)
-								67 -> x = (x + 1).coerceAtMost(width)
+								66 -> y = (y + 1).coerceAtMost(height - robotHeight)
+								67 -> x = (x + 1).coerceAtMost(width - robotWidth)
 								68 -> x = (x - 1).coerceAtLeast(0)
 							}
 						}


### PR DESCRIPTION
Previously, the actual width and height were greater than the specified ones, now exactly the same. That's also why a few clicks are removed from input.sh .

It was:
<img width="416" alt="Screenshot 2023-11-19 at 00 56 35" src="https://github.com/JakeWharton/mosaic/assets/37583380/307a8e34-5271-40a6-a1f0-c50f6b80e6b1">

Become:
<img width="415" alt="Screenshot 2023-11-19 at 00 57 23" src="https://github.com/JakeWharton/mosaic/assets/37583380/e2ed4d87-3431-455e-ba6e-8db73fcbf291">