### PR TITLE
Unit tests for modifiers and some fixes

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/AspectRatio.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/AspectRatio.kt
@@ -37,6 +37,11 @@ private class AspectRatioModifier(
 	private val aspectRatio: Float,
 	private val matchHeightConstraintsFirst: Boolean,
 ) : LayoutModifier {
+
+	init {
+		require(aspectRatio > 0) { "aspectRatio $aspectRatio must be > 0" }
+	}
+
 	override fun MeasureScope.measure(
 		measurable: Measurable,
 		constraints: Constraints,

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Node.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Node.kt
@@ -161,11 +161,11 @@ internal class MosaicNode(
 	}
 
 	override fun minIntrinsicHeight(width: Int): Int {
-		return topLayer.minIntrinsicHeight(height)
+		return topLayer.minIntrinsicHeight(width)
 	}
 
 	override fun maxIntrinsicHeight(width: Int): Int {
-		return topLayer.maxIntrinsicHeight(height)
+		return topLayer.maxIntrinsicHeight(width)
 	}
 
 	override fun toString() = debugPolicy.run { renderDebug() }
@@ -185,6 +185,22 @@ private class BottomLayer(
 			}
 		}
 	}
+
+	override fun minIntrinsicWidth(height: Int): Int {
+		return node.measurePolicy.run { minIntrinsicWidth(node.children, height) }
+	}
+
+	override fun maxIntrinsicWidth(height: Int): Int {
+		return node.measurePolicy.run { maxIntrinsicWidth(node.children, height) }
+	}
+
+	override fun minIntrinsicHeight(width: Int): Int {
+		return node.measurePolicy.run { minIntrinsicHeight(node.children, width) }
+	}
+
+	override fun maxIntrinsicHeight(width: Int): Int {
+		return node.measurePolicy.run { maxIntrinsicHeight(node.children, width) }
+	}
 }
 
 private class LayoutLayer(
@@ -193,6 +209,22 @@ private class LayoutLayer(
 ) : AbstractMosaicNodeLayer(lowerLayer, false) {
 	override fun doMeasure(constraints: Constraints): MeasureResult {
 		return element.run { measure(lowerLayer, constraints) }
+	}
+
+	override fun minIntrinsicWidth(height: Int): Int {
+		return element.minIntrinsicWidth(lowerLayer, height)
+	}
+
+	override fun maxIntrinsicWidth(height: Int): Int {
+		return element.maxIntrinsicWidth(lowerLayer, height)
+	}
+
+	override fun minIntrinsicHeight(width: Int): Int {
+		return element.minIntrinsicHeight(lowerLayer, width)
+	}
+
+	override fun maxIntrinsicHeight(width: Int): Int {
+		return element.maxIntrinsicHeight(lowerLayer, width)
 	}
 }
 

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Offset.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Offset.kt
@@ -40,7 +40,7 @@ private class OffsetModifier(
 	): MeasureResult {
 		val placeable = measurable.measure(constraints)
 		return layout(placeable.width, placeable.height) {
-			placeable.place(x, y)
+			placeable.place(this@OffsetModifier.x, this@OffsetModifier.y)
 		}
 	}
 

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Size.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Size.kt
@@ -9,6 +9,7 @@ import com.jakewharton.mosaic.ui.unit.IntSize
 import com.jakewharton.mosaic.ui.unit.constrain
 import com.jakewharton.mosaic.ui.unit.constrainHeight
 import com.jakewharton.mosaic.ui.unit.constrainWidth
+import dev.drewhamilton.poko.Poko
 import kotlin.math.roundToInt
 
 /**
@@ -468,6 +469,7 @@ public fun Modifier.defaultMinSize(
 	minHeight: Int = Unspecified,
 ): Modifier = this.then(UnspecifiedConstraintsModifier(minWidth = minWidth, minHeight = minHeight))
 
+@Poko
 private class SizeModifier(
 	private val minWidth: Int = Unspecified,
 	private val minHeight: Int = Unspecified,
@@ -599,28 +601,6 @@ private class SizeModifier(
 		}
 	}
 
-	override fun equals(other: Any?): Boolean {
-		if (this === other) return true
-		if (other !is SizeModifier) return false
-
-		if (minWidth != other.minWidth) return false
-		if (minHeight != other.minHeight) return false
-		if (maxWidth != other.maxWidth) return false
-		if (maxHeight != other.maxHeight) return false
-		if (enforceIncoming != other.enforceIncoming) return false
-
-		return true
-	}
-
-	override fun hashCode(): Int {
-		var result = minWidth.hashCode()
-		result = 31 * result + minHeight.hashCode()
-		result = 31 * result + maxWidth.hashCode()
-		result = 31 * result + maxHeight.hashCode()
-		result = 31 * result + enforceIncoming.hashCode()
-		return result
-	}
-
 	override fun toString(): String {
 		val params = buildList {
 			if (minWidth != Unspecified) {
@@ -641,6 +621,7 @@ private class SizeModifier(
 	}
 }
 
+@Poko
 private class FillModifier(
 	private val direction: Direction,
 	private val fraction: Float,
@@ -678,22 +659,6 @@ private class FillModifier(
 		return layout(placeable.width, placeable.height) {
 			placeable.place(0, 0)
 		}
-	}
-
-	override fun equals(other: Any?): Boolean {
-		if (this === other) return true
-		if (other !is FillModifier) return false
-
-		if (direction != other.direction) return false
-		if (fraction != other.fraction) return false
-
-		return true
-	}
-
-	override fun hashCode(): Int {
-		var result = direction.hashCode()
-		result = 31 * result + fraction.hashCode()
-		return result
 	}
 
 	override fun toString(): String = "Fill(direction=$direction, fraction=$fraction)"
@@ -817,6 +782,7 @@ private class WrapContentModifier(
 	}
 }
 
+@Poko
 private class UnspecifiedConstraintsModifier(
 	private val minWidth: Int = Unspecified,
 	private val minHeight: Int = Unspecified,
@@ -872,13 +838,6 @@ private class UnspecifiedConstraintsModifier(
 	) = measurable.maxIntrinsicHeight(width).coerceAtLeast(
 		if (minHeight != Unspecified) minHeight else 0,
 	)
-
-	override fun equals(other: Any?): Boolean {
-		if (other !is UnspecifiedConstraintsModifier) return false
-		return minWidth == other.minWidth && minHeight == other.minHeight
-	}
-
-	override fun hashCode() = minWidth.hashCode() * 31 + minHeight.hashCode()
 
 	override fun toString(): String {
 		val params = buildList {

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Size.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Size.kt
@@ -599,6 +599,28 @@ private class SizeModifier(
 		}
 	}
 
+	override fun equals(other: Any?): Boolean {
+		if (this === other) return true
+		if (other !is SizeModifier) return false
+
+		if (minWidth != other.minWidth) return false
+		if (minHeight != other.minHeight) return false
+		if (maxWidth != other.maxWidth) return false
+		if (maxHeight != other.maxHeight) return false
+		if (enforceIncoming != other.enforceIncoming) return false
+
+		return true
+	}
+
+	override fun hashCode(): Int {
+		var result = minWidth.hashCode()
+		result = 31 * result + minHeight.hashCode()
+		result = 31 * result + maxWidth.hashCode()
+		result = 31 * result + maxHeight.hashCode()
+		result = 31 * result + enforceIncoming.hashCode()
+		return result
+	}
+
 	override fun toString(): String {
 		val params = buildList {
 			if (minWidth != Unspecified) {
@@ -658,6 +680,22 @@ private class FillModifier(
 		}
 	}
 
+	override fun equals(other: Any?): Boolean {
+		if (this === other) return true
+		if (other !is FillModifier) return false
+
+		if (direction != other.direction) return false
+		if (fraction != other.fraction) return false
+
+		return true
+	}
+
+	override fun hashCode(): Int {
+		var result = direction.hashCode()
+		result = 31 * result + fraction.hashCode()
+		return result
+	}
+
 	override fun toString(): String = "Fill(direction=$direction, fraction=$fraction)"
 
 	companion object {
@@ -685,6 +723,7 @@ private class WrapContentModifier(
 	private val direction: Direction,
 	private val unbounded: Boolean,
 	private val alignmentCallback: (IntSize) -> IntOffset,
+	private val align: Any,
 ) : LayoutModifier {
 
 	override fun MeasureScope.measure(
@@ -719,6 +758,27 @@ private class WrapContentModifier(
 		}
 	}
 
+	override fun equals(other: Any?): Boolean {
+		if (this === other) return true
+		if (other === null) return false
+		if (this::class != other::class) return false
+
+		other as WrapContentModifier
+
+		if (direction != other.direction) return false
+		if (unbounded != other.unbounded) return false
+		if (align != other.align) return false
+
+		return true
+	}
+
+	override fun hashCode(): Int {
+		var result = direction.hashCode()
+		result = 31 * result + unbounded.hashCode()
+		result = 31 * result + align.hashCode()
+		return result
+	}
+
 	override fun toString(): String = "WrapContent(direction=$direction, unbounded=$unbounded)"
 
 	companion object {
@@ -730,6 +790,7 @@ private class WrapContentModifier(
 			direction = Direction.Horizontal,
 			unbounded = unbounded,
 			alignmentCallback = { size -> IntOffset(align.align(0, size.width), 0) },
+			align = align,
 		)
 
 		@Stable
@@ -740,6 +801,7 @@ private class WrapContentModifier(
 			direction = Direction.Vertical,
 			unbounded = unbounded,
 			alignmentCallback = { size -> IntOffset(0, align.align(0, size.height)) },
+			align = align,
 		)
 
 		@Stable
@@ -750,6 +812,7 @@ private class WrapContentModifier(
 			direction = Direction.Both,
 			unbounded = unbounded,
 			alignmentCallback = { size -> align.align(IntSize.Zero, size) },
+			align = align,
 		)
 	}
 }
@@ -809,6 +872,13 @@ private class UnspecifiedConstraintsModifier(
 	) = measurable.maxIntrinsicHeight(width).coerceAtLeast(
 		if (minHeight != Unspecified) minHeight else 0,
 	)
+
+	override fun equals(other: Any?): Boolean {
+		if (other !is UnspecifiedConstraintsModifier) return false
+		return minWidth == other.minWidth && minHeight == other.minHeight
+	}
+
+	override fun hashCode() = minWidth.hashCode() * 31 + minHeight.hashCode()
 
 	override fun toString(): String {
 		val params = buildList {

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Alignment.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Alignment.kt
@@ -135,7 +135,9 @@ public class BiasAlignment(
 	}
 
 	override fun toString(): String {
-		return "Alignment(horizontalBias=${horizontalBias.toInt()}, verticalBias=${verticalBias.toInt()})"
+		val horizontalBiasStr = horizontalBias.toString().removeSuffix(".0")
+		val verticalBiasStr = verticalBias.toString().removeSuffix(".0")
+		return "Alignment(horizontalBias=$horizontalBiasStr, verticalBias=$verticalBiasStr)"
 	}
 
 	/**
@@ -157,7 +159,8 @@ public class BiasAlignment(
 		}
 
 		override fun toString(): String {
-			return "Horizontal(bias=${bias.toInt()})"
+			val biasStr = bias.toString().removeSuffix(".0")
+			return "Horizontal(bias=$biasStr)"
 		}
 	}
 
@@ -180,7 +183,8 @@ public class BiasAlignment(
 		}
 
 		override fun toString(): String {
-			return "Vertical(bias=${bias.toInt()})"
+			val biasStr = bias.toString().removeSuffix(".0")
+			return "Vertical(bias=$biasStr)"
 		}
 	}
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Box.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Box.kt
@@ -149,6 +149,28 @@ private fun Placeable.PlacementScope.placeInBox(
 }
 
 /**
+ * A box with no content that can participate in layout, drawing
+ * due to the [modifier] applied to it.
+ *
+ * @param modifier The modifier to be applied to the layout.
+ */
+@Composable
+public fun Box(modifier: Modifier) {
+	Layout(
+		content = EmptyBoxContent,
+		modifiers = modifier,
+		debugInfo = { "Box()" },
+		measurePolicy = EmptyBoxMeasurePolicy,
+	)
+}
+
+private val EmptyBoxContent: @Composable () -> Unit = {}
+
+private val EmptyBoxMeasurePolicy = MeasurePolicy { _, constraints ->
+	layout(constraints.minWidth, constraints.minHeight) {}
+}
+
+/**
  * A BoxScope provides a scope for the children of [Box].
  */
 @LayoutScopeMarker

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Filler.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Filler.kt
@@ -1,0 +1,57 @@
+package com.jakewharton.mosaic.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonRestartableComposable
+import com.jakewharton.mosaic.layout.Measurable
+import com.jakewharton.mosaic.layout.MeasurePolicy
+import com.jakewharton.mosaic.layout.MeasureResult
+import com.jakewharton.mosaic.layout.MeasureScope
+import com.jakewharton.mosaic.layout.drawBehind
+import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.unit.Constraints
+
+/**
+ * Component that represents an layout of identical characters, whose size can be
+ * defined using [Modifier.width], [Modifier.height] and [Modifier.size] modifiers.
+ *
+ * This layout is similar to [Spacer].
+ *
+ * @param char character to fill in
+ * @param modifier modifiers to set to this spacer
+ */
+@Composable
+@NonRestartableComposable
+public fun Filler(
+	char: Char,
+	modifier: Modifier = Modifier,
+	foreground: Color? = null,
+	background: Color? = null,
+	style: TextStyle? = null,
+) {
+	Layout(
+		content = EmptyFillerContent,
+		measurePolicy = FillerMeasurePolicy,
+		debugInfo = { "Filler('$char')" },
+		modifiers = modifier.drawBehind {
+			val line = char.toString().repeat(width)
+			repeat(height) { row ->
+				drawText(row, 0, line, foreground, background, style)
+			}
+		},
+	)
+}
+
+private val EmptyFillerContent: @Composable () -> Unit = {}
+
+private object FillerMeasurePolicy : MeasurePolicy {
+	override fun MeasureScope.measure(
+		measurables: List<Measurable>,
+		constraints: Constraints,
+	): MeasureResult {
+		return with(constraints) {
+			val width = if (hasFixedWidth) maxWidth else 0
+			val height = if (hasFixedHeight) maxHeight else 0
+			layout(width, height) {}
+		}
+	}
+}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/AspectRatioTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/AspectRatioTest.kt
@@ -1,0 +1,114 @@
+package com.jakewharton.mosaic.layout
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jakewharton.mosaic.Container
+import com.jakewharton.mosaic.TestFiller
+import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.mosaicNodesWithMeasureAndPlace
+import com.jakewharton.mosaic.renderMosaic
+import com.jakewharton.mosaic.size
+import com.jakewharton.mosaic.testIntrinsics
+import com.jakewharton.mosaic.ui.Layout
+import com.jakewharton.mosaic.ui.unit.Constraints
+import com.jakewharton.mosaic.ui.unit.IntSize
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class AspectRatioTest {
+	@Test fun aspectRatioNegative() {
+		assertFails {
+			renderMosaic {
+				TestFiller(modifier = Modifier.aspectRatio(-2.0f))
+			}
+		}
+	}
+
+	@Test fun aspectRatioZero() {
+		assertFails {
+			renderMosaic {
+				TestFiller(modifier = Modifier.aspectRatio(0.0f))
+			}
+		}
+	}
+
+	@Test fun aspectRatioDefault() {
+		assertThat(getSize(1f, Constraints(maxWidth = 30))).isEqualTo(IntSize(30, 30))
+		assertThat(getSize(2f, Constraints(maxWidth = 30))).isEqualTo(IntSize(30, 15))
+		assertThat(getSize(1f, Constraints(maxWidth = 30, maxHeight = 10))).isEqualTo(IntSize(10, 10))
+		assertThat(getSize(2f, Constraints(maxWidth = 30, maxHeight = 10))).isEqualTo(IntSize(20, 10))
+		assertThat(getSize(2f, Constraints(minWidth = 10, minHeight = 5))).isEqualTo(IntSize(10, 5))
+		assertThat(getSize(2f, Constraints(minWidth = 5, minHeight = 10))).isEqualTo(IntSize(20, 10))
+		assertThat(getSize(2f, Constraints.fixed(20, 20))).isEqualTo(IntSize(20, 10))
+		assertThat(getSize(2f, Constraints(minWidth = 50, minHeight = 20))).isEqualTo(IntSize(50, 25))
+	}
+
+	@Test fun aspectRatioMatchHeightConstraintsFirstTrue() {
+		assertThat(getSize(1f, Constraints(maxHeight = 30), true)).isEqualTo(IntSize(30, 30))
+		assertThat(getSize(0.5f, Constraints(maxHeight = 30), true)).isEqualTo(IntSize(15, 30))
+		assertThat(getSize(1f, Constraints(maxWidth = 10, maxHeight = 30), true))
+			.isEqualTo(IntSize(10, 10))
+		assertThat(getSize(0.5f, Constraints(maxWidth = 10, maxHeight = 30), true))
+			.isEqualTo(IntSize(10, 20))
+		assertThat(getSize(0.5f, Constraints(minWidth = 5, minHeight = 10), true))
+			.isEqualTo(IntSize(5, 10))
+		assertThat(getSize(0.5f, Constraints(minWidth = 10, minHeight = 5), true))
+			.isEqualTo(IntSize(10, 20))
+		assertThat(getSize(0.5f, Constraints.fixed(20, 20), true))
+			.isEqualTo(IntSize(10, 20))
+		assertThat(getSize(0.5f, Constraints(minWidth = 20, minHeight = 50), true))
+			.isEqualTo(IntSize(25, 50))
+	}
+
+	@Test fun aspectRatioIntrinsicDimensions() {
+		testIntrinsics(
+			{
+				Container(modifier = Modifier.aspectRatio(2f), width = 30, height = 40)
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			assertThat(minIntrinsicWidth(20)).isEqualTo(40)
+			assertThat(maxIntrinsicWidth(20)).isEqualTo(40)
+			assertThat(minIntrinsicHeight(40)).isEqualTo(20)
+			assertThat(maxIntrinsicHeight(40)).isEqualTo(20)
+
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(30)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(30)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(40)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(40)
+		}
+	}
+
+	@Test fun aspectRatioDebug() {
+		val actual = Modifier.aspectRatio(1.5f).toString()
+		assertThat(actual).isEqualTo("AspectRatio(1.5, matchHeightConstraintsFirst=false)")
+	}
+
+	@Test fun aspectRatioMatchHeightConstraintsFirstTrueDebug() {
+		val actual = Modifier.aspectRatio(1.5f, true).toString()
+		assertThat(actual).isEqualTo("AspectRatio(1.5, matchHeightConstraintsFirst=true)")
+	}
+
+	private fun getSize(
+		aspectRatio: Float,
+		childContraints: Constraints,
+		matchHeightConstraintsFirst: Boolean = false,
+	): IntSize {
+		val rootNode = mosaicNodesWithMeasureAndPlace {
+			Layout(
+				content = {
+					TestFiller(Modifier.aspectRatio(aspectRatio, matchHeightConstraintsFirst))
+				},
+				modifiers = Modifier.widthIn(max = 100).heightIn(max = 100),
+				measurePolicy = { measurables, incomingConstraints ->
+					require(measurables.isNotEmpty())
+					val placeable = measurables.first().measure(childContraints)
+					layout(incomingConstraints.maxWidth, incomingConstraints.maxHeight) {
+						placeable.place(0, 0)
+					}
+				},
+			)
+		}
+
+		return rootNode.children[0].children[0].size
+	}
+}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/AspectRatioTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/AspectRatioTest.kt
@@ -6,7 +6,6 @@ import com.jakewharton.mosaic.Container
 import com.jakewharton.mosaic.TestFiller
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.mosaicNodesWithMeasureAndPlace
-import com.jakewharton.mosaic.renderMosaic
 import com.jakewharton.mosaic.size
 import com.jakewharton.mosaic.testIntrinsics
 import com.jakewharton.mosaic.ui.Layout
@@ -18,17 +17,13 @@ import kotlin.test.assertFails
 class AspectRatioTest {
 	@Test fun aspectRatioNegative() {
 		assertFails {
-			renderMosaic {
-				TestFiller(modifier = Modifier.aspectRatio(-2.0f))
-			}
+			Modifier.aspectRatio(-2.0f)
 		}
 	}
 
 	@Test fun aspectRatioZero() {
 		assertFails {
-			renderMosaic {
-				TestFiller(modifier = Modifier.aspectRatio(0.0f))
-			}
+			Modifier.aspectRatio(0.0f)
 		}
 	}
 

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/OffsetTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/OffsetTest.kt
@@ -1,0 +1,260 @@
+package com.jakewharton.mosaic.layout
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jakewharton.mosaic.TestChar
+import com.jakewharton.mosaic.TestFiller
+import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.renderMosaic
+import com.jakewharton.mosaic.s
+import com.jakewharton.mosaic.ui.Box
+import com.jakewharton.mosaic.ui.unit.IntOffset
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class OffsetTest {
+	@Test fun offsetHorizontalFixed() {
+		val actual = renderMosaic {
+			Box(modifier = Modifier.size(6).offset(3, 0)) {
+				TestFiller(modifier = Modifier.size(1))
+			}
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|   $TestChar $s
+			|     $s
+			|     $s
+			|     $s
+			|     $s
+			|     $s
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun offsetHorizontalFixedBeyondBorders() {
+		assertFails {
+			renderMosaic {
+				Box(modifier = Modifier.size(6).offset(30, 0)) {
+					TestFiller(modifier = Modifier.size(1))
+				}
+			}
+		}
+	}
+
+	@Test fun offsetHorizontalFixedNegativeBeyondBorders() {
+		assertFails {
+			renderMosaic {
+				Box(modifier = Modifier.size(6).offset(-3, 0)) {
+					TestFiller(modifier = Modifier.size(1))
+				}
+			}
+		}
+	}
+
+	@Test fun offsetVerticalFixed() {
+		val actual = renderMosaic {
+			Box(modifier = Modifier.size(6).offset(0, 4)) {
+				TestFiller(modifier = Modifier.size(1))
+			}
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|     $s
+			|     $s
+			|     $s
+			|     $s
+			|$TestChar    $s
+			|     $s
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun offsetVerticalFixedBeyondBorders() {
+		assertFails {
+			renderMosaic {
+				Box(modifier = Modifier.size(6).offset(0, 40)) {
+					TestFiller(modifier = Modifier.size(1))
+				}
+			}
+		}
+	}
+
+	@Test fun offsetVerticalFixedNegativeBeyondBorders() {
+		assertFails {
+			renderMosaic {
+				Box(modifier = Modifier.size(6).offset(0, -4)) {
+					TestFiller(modifier = Modifier.size(1))
+				}
+			}
+		}
+	}
+
+	@Test fun offsetFixed() {
+		val actual = renderMosaic {
+			Box(modifier = Modifier.size(6).offset(3, 4)) {
+				TestFiller(modifier = Modifier.size(1))
+			}
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|     $s
+			|     $s
+			|     $s
+			|     $s
+			|   $TestChar $s
+			|     $s
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun offsetFixedBeyondBorders() {
+		assertFails {
+			renderMosaic {
+				Box(modifier = Modifier.size(6).offset(30, 40)) {
+					TestFiller(modifier = Modifier.size(1))
+				}
+			}
+		}
+	}
+
+	@Test fun offsetFixedNegativeBeyondBorders() {
+		assertFails {
+			renderMosaic {
+				Box(modifier = Modifier.size(6).offset(-3, -4)) {
+					TestFiller(modifier = Modifier.size(1))
+				}
+			}
+		}
+	}
+
+	@Test fun offsetFixedDebug() {
+		val actual = Modifier.offset(3, 4).toString()
+		assertThat(actual).isEqualTo("Offset(x=3, y=4)")
+	}
+
+	@Test fun offsetHorizontalModifiable() {
+		val actual = renderMosaic {
+			Box(modifier = Modifier.size(6).offset { IntOffset(3, 0) }) {
+				TestFiller(modifier = Modifier.size(1))
+			}
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|   $TestChar $s
+			|     $s
+			|     $s
+			|     $s
+			|     $s
+			|     $s
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun offsetHorizontalModifiableBeyondBorders() {
+		assertFails {
+			renderMosaic {
+				Box(modifier = Modifier.size(6).offset { IntOffset(30, 0) }) {
+					TestFiller(modifier = Modifier.size(1))
+				}
+			}
+		}
+	}
+
+	@Test fun offsetHorizontalModifiableNegativeBeyondBorders() {
+		assertFails {
+			renderMosaic {
+				Box(modifier = Modifier.size(6).offset { IntOffset(-3, 0) }) {
+					TestFiller(modifier = Modifier.size(1))
+				}
+			}
+		}
+	}
+
+	@Test fun offsetVerticalModifiable() {
+		val actual = renderMosaic {
+			Box(modifier = Modifier.size(6).offset { IntOffset(0, 4) }) {
+				TestFiller(modifier = Modifier.size(1))
+			}
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|     $s
+			|     $s
+			|     $s
+			|     $s
+			|$TestChar    $s
+			|     $s
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun offsetVerticalModifiableBeyondBorders() {
+		assertFails {
+			renderMosaic {
+				Box(modifier = Modifier.size(6).offset { IntOffset(0, 40) }) {
+					TestFiller(modifier = Modifier.size(1))
+				}
+			}
+		}
+	}
+
+	@Test fun offsetVerticalModifiableNegativeBeyondBorders() {
+		assertFails {
+			renderMosaic {
+				Box(modifier = Modifier.size(6).offset { IntOffset(0, -4) }) {
+					TestFiller(modifier = Modifier.size(1))
+				}
+			}
+		}
+	}
+
+	@Test fun offsetModifiable() {
+		val actual = renderMosaic {
+			Box(modifier = Modifier.size(6).offset { IntOffset(3, 4) }) {
+				TestFiller(modifier = Modifier.size(1))
+			}
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|     $s
+			|     $s
+			|     $s
+			|     $s
+			|   $TestChar $s
+			|     $s
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun offsetModifiableBeyondBorders() {
+		assertFails {
+			renderMosaic {
+				Box(modifier = Modifier.size(6).offset { IntOffset(30, 40) }) {
+					TestFiller(modifier = Modifier.size(1))
+				}
+			}
+		}
+	}
+
+	@Test fun offsetModifiableNegativeBeyondBorders() {
+		assertFails {
+			renderMosaic {
+				Box(modifier = Modifier.size(6).offset { IntOffset(-3, -4) }) {
+					TestFiller(modifier = Modifier.size(1))
+				}
+			}
+		}
+	}
+
+	@Test fun offsetModifiableDebug() {
+		val offsetLambda = { IntOffset(-3, -4) }
+		val actual = Modifier.offset(offsetLambda).toString()
+		assertThat(actual).isEqualTo("ChangeableOffset(offset=$offsetLambda)")
+	}
+}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/PaddingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/PaddingTest.kt
@@ -28,9 +28,7 @@ class PaddingTest {
 
 	@Test fun paddingLeftNegative() {
 		assertFails {
-			renderMosaic {
-				SingleFiller(Modifier.padding(left = -2))
-			}
+			Modifier.padding(left = -2)
 		}
 	}
 
@@ -65,9 +63,7 @@ class PaddingTest {
 
 	@Test fun paddingTopNegative() {
 		assertFails {
-			renderMosaic {
-				SingleFiller(Modifier.padding(top = -2))
-			}
+			Modifier.padding(top = -2)
 		}
 	}
 
@@ -104,9 +100,7 @@ class PaddingTest {
 
 	@Test fun paddingRightNegative() {
 		assertFails {
-			renderMosaic {
-				SingleFiller(Modifier.padding(right = -2))
-			}
+			Modifier.padding(right = -2)
 		}
 	}
 
@@ -141,9 +135,7 @@ class PaddingTest {
 
 	@Test fun paddingBottomNegative() {
 		assertFails {
-			renderMosaic {
-				SingleFiller(Modifier.padding(bottom = -2))
-			}
+			Modifier.padding(bottom = -2)
 		}
 	}
 
@@ -180,9 +172,7 @@ class PaddingTest {
 
 	@Test fun paddingLeftBottomNegative() {
 		assertFails {
-			renderMosaic {
-				SingleFiller(Modifier.padding(left = -1, bottom = -2))
-			}
+			Modifier.padding(left = -1, bottom = -2)
 		}
 	}
 
@@ -235,7 +225,6 @@ class PaddingTest {
 	@Test fun intrinsicMeasurements() {
 		val padding = 100
 
-		var error: Throwable? = null
 		testIntrinsics(
 			@Composable {
 				TestBox(modifier = Modifier.padding(padding)) {
@@ -261,29 +250,23 @@ class PaddingTest {
 			// Add back the padding on both sides to get the total expected height
 			val expectedTotalWidth = expectedAspectRatioWidth + totalAxisSpacing
 
-			try {
-				// Min width
-				assertThat(totalAxisSpacing).isEqualTo(minIntrinsicWidth(0))
-				assertThat(expectedTotalWidth).isEqualTo(minIntrinsicWidth(testDimension))
-				assertThat(totalAxisSpacing).isEqualTo(minIntrinsicWidth(Constraints.Infinity))
-				// Min height
-				assertThat(totalAxisSpacing).isEqualTo(minIntrinsicHeight(0))
-				assertThat(expectedTotalHeight).isEqualTo(minIntrinsicHeight(testDimension))
-				assertThat(totalAxisSpacing).isEqualTo(minIntrinsicHeight(Constraints.Infinity))
-				// Max width
-				assertThat(totalAxisSpacing).isEqualTo(maxIntrinsicWidth(0))
-				assertThat(expectedTotalWidth).isEqualTo(maxIntrinsicWidth(testDimension))
-				assertThat(totalAxisSpacing).isEqualTo(maxIntrinsicWidth(Constraints.Infinity))
-				// Max height
-				assertThat(totalAxisSpacing).isEqualTo(maxIntrinsicHeight(0))
-				assertThat(expectedTotalHeight).isEqualTo(maxIntrinsicHeight(testDimension))
-				assertThat(totalAxisSpacing).isEqualTo(maxIntrinsicHeight(Constraints.Infinity))
-			} catch (t: Throwable) {
-				error = t
-			}
+			// Min width
+			assertThat(totalAxisSpacing).isEqualTo(minIntrinsicWidth(0))
+			assertThat(expectedTotalWidth).isEqualTo(minIntrinsicWidth(testDimension))
+			assertThat(totalAxisSpacing).isEqualTo(minIntrinsicWidth(Constraints.Infinity))
+			// Min height
+			assertThat(totalAxisSpacing).isEqualTo(minIntrinsicHeight(0))
+			assertThat(expectedTotalHeight).isEqualTo(minIntrinsicHeight(testDimension))
+			assertThat(totalAxisSpacing).isEqualTo(minIntrinsicHeight(Constraints.Infinity))
+			// Max width
+			assertThat(totalAxisSpacing).isEqualTo(maxIntrinsicWidth(0))
+			assertThat(expectedTotalWidth).isEqualTo(maxIntrinsicWidth(testDimension))
+			assertThat(totalAxisSpacing).isEqualTo(maxIntrinsicWidth(Constraints.Infinity))
+			// Max height
+			assertThat(totalAxisSpacing).isEqualTo(maxIntrinsicHeight(0))
+			assertThat(expectedTotalHeight).isEqualTo(maxIntrinsicHeight(testDimension))
+			assertThat(totalAxisSpacing).isEqualTo(maxIntrinsicHeight(Constraints.Infinity))
 		}
-
-		error?.let { throw it }
 	}
 
 	/**

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/PaddingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/PaddingTest.kt
@@ -1,0 +1,313 @@
+package com.jakewharton.mosaic.layout
+
+import androidx.compose.runtime.Composable
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jakewharton.mosaic.Container
+import com.jakewharton.mosaic.TestChar
+import com.jakewharton.mosaic.TestFiller
+import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.renderMosaic
+import com.jakewharton.mosaic.s
+import com.jakewharton.mosaic.testIntrinsics
+import com.jakewharton.mosaic.ui.Layout
+import com.jakewharton.mosaic.ui.unit.Constraints
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+class PaddingTest {
+	@Test fun paddingAllEqualsToPaddingWithExplicitSides() {
+		assertThat(Modifier.padding(10))
+			.isEqualTo(Modifier.padding(10, 10, 10, 10))
+	}
+
+	@Test fun paddingSymmerticEqualsToPaddingWithExplicitSides() {
+		assertThat(Modifier.padding(10, 20))
+			.isEqualTo(Modifier.padding(10, 20, 10, 20))
+	}
+
+	@Test fun paddingLeftNegative() {
+		assertFails {
+			renderMosaic {
+				SingleFiller(Modifier.padding(left = -2))
+			}
+		}
+	}
+
+	@Test fun paddingLeftZero() {
+		val actual = renderMosaic {
+			SingleFiller(Modifier.padding(left = 0))
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|$TestChar
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun paddingLeft() {
+		val actual = renderMosaic {
+			SingleFiller(Modifier.padding(left = 2))
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|  $TestChar
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun paddingLeftDebug() {
+		val actual = Modifier.padding(left = 2).toString()
+		assertThat(actual).isEqualTo("Padding(l=2, t=0, r=0, b=0)")
+	}
+
+	@Test fun paddingTopNegative() {
+		assertFails {
+			renderMosaic {
+				SingleFiller(Modifier.padding(top = -2))
+			}
+		}
+	}
+
+	@Test fun paddingTopZero() {
+		val actual = renderMosaic {
+			SingleFiller(Modifier.padding(top = 0))
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|$TestChar
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun paddingTop() {
+		val actual = renderMosaic {
+			SingleFiller(Modifier.padding(top = 2))
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|$s
+			|$s
+			|$TestChar
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun paddingTopDebug() {
+		val actual = Modifier.padding(top = 2).toString()
+		assertThat(actual).isEqualTo("Padding(l=0, t=2, r=0, b=0)")
+	}
+
+	@Test fun paddingRightNegative() {
+		assertFails {
+			renderMosaic {
+				SingleFiller(Modifier.padding(right = -2))
+			}
+		}
+	}
+
+	@Test fun paddingRightZero() {
+		val actual = renderMosaic {
+			SingleFiller(Modifier.padding(right = 0))
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|$TestChar
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun paddingRight() {
+		val actual = renderMosaic {
+			SingleFiller(Modifier.padding(right = 2))
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|$TestChar $s
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun paddingRightDebug() {
+		val actual = Modifier.padding(right = 2).toString()
+		assertThat(actual).isEqualTo("Padding(l=0, t=0, r=2, b=0)")
+	}
+
+	@Test fun paddingBottomNegative() {
+		assertFails {
+			renderMosaic {
+				SingleFiller(Modifier.padding(bottom = -2))
+			}
+		}
+	}
+
+	@Test fun paddingBottomZero() {
+		val actual = renderMosaic {
+			SingleFiller(Modifier.padding(bottom = 0))
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|$TestChar
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun paddingBottom() {
+		val actual = renderMosaic {
+			SingleFiller(Modifier.padding(bottom = 2))
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|$TestChar
+			|$s
+			|$s
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun paddingBottomDebug() {
+		val actual = Modifier.padding(bottom = 2).toString()
+		assertThat(actual).isEqualTo("Padding(l=0, t=0, r=0, b=2)")
+	}
+
+	@Test fun paddingLeftBottomNegative() {
+		assertFails {
+			renderMosaic {
+				SingleFiller(Modifier.padding(left = -1, bottom = -2))
+			}
+		}
+	}
+
+	@Test fun paddingLeftBottomZero() {
+		val actual = renderMosaic {
+			SingleFiller(Modifier.padding(left = 0, bottom = 0))
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|$TestChar
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun paddingLeftBottom() {
+		val actual = renderMosaic {
+			SingleFiller(Modifier.padding(left = 1, bottom = 2))
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			| $TestChar
+			| $s
+			| $s
+			|
+			""".trimMargin(),
+		)
+	}
+
+	@Test fun paddingLeftBottomDebug() {
+		val actual = Modifier.padding(left = 1, bottom = 2).toString()
+		assertThat(actual).isEqualTo("Padding(l=1, t=0, r=0, b=2)")
+	}
+
+	@Test fun paddingAllDebug() {
+		val actual = Modifier.padding(2).toString()
+		assertThat(actual).isEqualTo("Padding(2)")
+	}
+
+	@Test fun paddingHorizontalDebug() {
+		val actual = Modifier.padding(horizontal = 2).toString()
+		assertThat(actual).isEqualTo("Padding(h=2, v=0)")
+	}
+
+	@Test fun paddingVerticalDebug() {
+		val actual = Modifier.padding(vertical = 2).toString()
+		assertThat(actual).isEqualTo("Padding(h=0, v=2)")
+	}
+
+	@Test fun intrinsicMeasurements() {
+		val padding = 100
+
+		var error: Throwable? = null
+		testIntrinsics(
+			@Composable {
+				TestBox(modifier = Modifier.padding(padding)) {
+					Container(Modifier.aspectRatio(2f)) { }
+				}
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Spacing is applied on both sides of an axis
+			val totalAxisSpacing = padding * 2
+
+			// When the width/height is measured as 3 x the padding
+			val testDimension = padding * 3
+			// The actual dimension for the AspectRatio will be: test dimension - total padding
+			val actualAspectRatioDimension = testDimension - totalAxisSpacing
+
+			// When we measure the width first, the height will be half
+			val expectedAspectRatioHeight = actualAspectRatioDimension / 2f
+			// When we measure the height first, the width will be double
+			val expectedAspectRatioWidth = actualAspectRatioDimension * 2
+
+			// Add back the padding on both sides to get the total expected height
+			val expectedTotalHeight = (expectedAspectRatioHeight + totalAxisSpacing).toInt()
+			// Add back the padding on both sides to get the total expected height
+			val expectedTotalWidth = expectedAspectRatioWidth + totalAxisSpacing
+
+			try {
+				// Min width
+				assertThat(totalAxisSpacing).isEqualTo(minIntrinsicWidth(0))
+				assertThat(expectedTotalWidth).isEqualTo(minIntrinsicWidth(testDimension))
+				assertThat(totalAxisSpacing).isEqualTo(minIntrinsicWidth(Constraints.Infinity))
+				// Min height
+				assertThat(totalAxisSpacing).isEqualTo(minIntrinsicHeight(0))
+				assertThat(expectedTotalHeight).isEqualTo(minIntrinsicHeight(testDimension))
+				assertThat(totalAxisSpacing).isEqualTo(minIntrinsicHeight(Constraints.Infinity))
+				// Max width
+				assertThat(totalAxisSpacing).isEqualTo(maxIntrinsicWidth(0))
+				assertThat(expectedTotalWidth).isEqualTo(maxIntrinsicWidth(testDimension))
+				assertThat(totalAxisSpacing).isEqualTo(maxIntrinsicWidth(Constraints.Infinity))
+				// Max height
+				assertThat(totalAxisSpacing).isEqualTo(maxIntrinsicHeight(0))
+				assertThat(expectedTotalHeight).isEqualTo(maxIntrinsicHeight(testDimension))
+				assertThat(totalAxisSpacing).isEqualTo(maxIntrinsicHeight(Constraints.Infinity))
+			} catch (t: Throwable) {
+				error = t
+			}
+		}
+
+		error?.let { throw it }
+	}
+
+	/**
+	 * A trivial layout that applies a [Modifier] and measures/lays out a single child
+	 * with the same constraints it received.
+	 */
+	@Composable
+	private fun TestBox(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+		Layout(content = content, modifiers = modifier) { measurables, constraints ->
+			require(measurables.size == 1) {
+				"TestBox received ${measurables.size} children; must have exactly 1"
+			}
+			val placeable = measurables.first().measure(constraints)
+			layout(
+				placeable.width.coerceAtMost(constraints.maxWidth),
+				placeable.height.coerceAtMost(constraints.maxHeight),
+			) {
+				placeable.place(0, 0)
+			}
+		}
+	}
+
+	@Composable
+	private fun SingleFiller(modifier: Modifier) {
+		TestFiller(modifier = modifier.size(1))
+	}
+}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/SizeTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/SizeTest.kt
@@ -1,0 +1,1114 @@
+package com.jakewharton.mosaic.layout
+
+import androidx.compose.runtime.Composable
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import com.jakewharton.mosaic.Container
+import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.mosaicNodesWithMeasureAndPlace
+import com.jakewharton.mosaic.position
+import com.jakewharton.mosaic.renderMosaic
+import com.jakewharton.mosaic.size
+import com.jakewharton.mosaic.testIntrinsics
+import com.jakewharton.mosaic.ui.Alignment
+import com.jakewharton.mosaic.ui.Box
+import com.jakewharton.mosaic.ui.Column
+import com.jakewharton.mosaic.ui.Layout
+import com.jakewharton.mosaic.ui.Row
+import com.jakewharton.mosaic.ui.unit.Constraints
+import com.jakewharton.mosaic.ui.unit.IntOffset
+import com.jakewharton.mosaic.ui.unit.IntSize
+import kotlin.test.Test
+
+class SizeTest {
+	@Test fun testPreferredSize_withWidthSizeModifiers() {
+		val size = 50
+
+		val rootNode = mosaicNodesWithMeasureAndPlace {
+			Box {
+				Column {
+					Container(Modifier.widthIn(min = size, max = size * 2).height(size))
+					Container(Modifier.widthIn(max = size * 2).height(size))
+					Container(Modifier.widthIn(min = size).height(size))
+					Container(Modifier.widthIn(max = size).widthIn(min = size * 2).height(size))
+					Container(Modifier.widthIn(min = size * 2).widthIn(max = size).height(size))
+					Container(Modifier.size(size))
+				}
+			}
+		}
+
+		val tempNode = rootNode.children[0].children[0]
+
+		val firstContainerNode = tempNode.children[0]
+		val secondContainerNode = tempNode.children[1]
+		val thirdContainerNode = tempNode.children[2]
+		val fourthContainerNode = tempNode.children[3]
+		val fifthContainerNode = tempNode.children[4]
+		val sixthContainerNode = tempNode.children[5]
+
+		assertThat(firstContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(firstContainerNode.position).isEqualTo(IntOffset.Zero)
+
+		assertThat(secondContainerNode.size).isEqualTo(IntSize(0, size))
+		assertThat(secondContainerNode.position).isEqualTo(IntOffset(0, size))
+
+		assertThat(thirdContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(thirdContainerNode.position).isEqualTo(IntOffset(0, size * 2))
+
+		assertThat(fourthContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(fourthContainerNode.position).isEqualTo(IntOffset(0, size * 3))
+
+		assertThat(fifthContainerNode.size).isEqualTo(IntSize((size * 2), size))
+		assertThat(fifthContainerNode.position).isEqualTo(IntOffset(0, size * 4))
+
+		assertThat(sixthContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(sixthContainerNode.position).isEqualTo(IntOffset(0, size * 5))
+	}
+
+	@Test fun testPreferredSize_withHeightSizeModifiers() {
+		val size = 10
+
+		val rootNode = mosaicNodesWithMeasureAndPlace {
+			Box {
+				Row {
+					Container(Modifier.heightIn(min = size, max = size * 2).width(size))
+					Container(Modifier.heightIn(max = size * 2).width(size))
+					Container(Modifier.heightIn(min = size).width(size))
+					Container(Modifier.heightIn(max = size).heightIn(min = size * 2).width(size))
+					Container(Modifier.heightIn(min = size * 2).heightIn(max = size).width(size))
+					Container(Modifier.height(size).then(Modifier.width(size)))
+				}
+			}
+		}
+
+		val tempNode = rootNode.children[0].children[0]
+
+		val firstContainerNode = tempNode.children[0]
+		val secondContainerNode = tempNode.children[1]
+		val thirdContainerNode = tempNode.children[2]
+		val fourthContainerNode = tempNode.children[3]
+		val fifthContainerNode = tempNode.children[4]
+		val sixthContainerNode = tempNode.children[5]
+
+		assertThat(firstContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(firstContainerNode.position).isEqualTo(IntOffset.Zero)
+
+		assertThat(secondContainerNode.size).isEqualTo(IntSize(size, 0))
+		assertThat(secondContainerNode.position).isEqualTo(IntOffset(size, 0))
+
+		assertThat(thirdContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(thirdContainerNode.position).isEqualTo(IntOffset(size * 2, 0))
+
+		assertThat(fourthContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(fourthContainerNode.position).isEqualTo(IntOffset(size * 3, 0))
+
+		assertThat(fifthContainerNode.size).isEqualTo(IntSize(size, (size * 2)))
+		assertThat(fifthContainerNode.position).isEqualTo(IntOffset(size * 4, 0))
+
+		assertThat(sixthContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(sixthContainerNode.position).isEqualTo(IntOffset(size * 5, 0))
+	}
+
+	@Test fun testPreferredSize_withSizeModifiers() {
+		val size = 50
+
+		val rootNode = mosaicNodesWithMeasureAndPlace {
+			Box {
+				Row {
+					val maxSize = size * 2
+					Container(
+						Modifier.sizeIn(maxWidth = maxSize, maxHeight = maxSize)
+							.sizeIn(minWidth = size, minHeight = size),
+					)
+					Container(
+						Modifier.sizeIn(maxWidth = size, maxHeight = size)
+							.sizeIn(minWidth = size * 2, minHeight = size),
+					)
+					val maxSize1 = size * 2
+					Container(
+						Modifier.sizeIn(minWidth = size, minHeight = size)
+							.sizeIn(maxWidth = maxSize1, maxHeight = maxSize1),
+					)
+					val minSize = size * 2
+					Container(
+						Modifier.sizeIn(minWidth = minSize, minHeight = minSize)
+							.sizeIn(maxWidth = size, maxHeight = size),
+					)
+					Container(Modifier.size(size))
+				}
+			}
+		}
+
+		val tempNode = rootNode.children[0].children[0]
+
+		val firstContainerNode = tempNode.children[0]
+		val secondContainerNode = tempNode.children[1]
+		val thirdContainerNode = tempNode.children[2]
+		val fourthContainerNode = tempNode.children[3]
+		val fifthContainerNode = tempNode.children[4]
+
+		assertThat(firstContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(firstContainerNode.position).isEqualTo(IntOffset.Zero)
+
+		assertThat(secondContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(secondContainerNode.position).isEqualTo(IntOffset(size, 0))
+
+		assertThat(thirdContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(thirdContainerNode.position).isEqualTo(IntOffset(size * 2, 0))
+
+		assertThat(fourthContainerNode.size).isEqualTo(IntSize(size * 2, size * 2))
+		assertThat(fourthContainerNode.position).isEqualTo(IntOffset(size * 3, 0))
+
+		assertThat(fifthContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(fifthContainerNode.position).isEqualTo(IntOffset(size * 5, 0))
+	}
+
+	@Test fun testPreferredSizeModifiers_respectMaxConstraint() {
+		val size = 100
+
+		val rootNode = mosaicNodesWithMeasureAndPlace {
+			Box {
+				Container(width = size, height = size) {
+					Container(Modifier.width(size * 2).height(size * 3)) {
+						Container(expanded = true)
+					}
+				}
+			}
+		}
+
+		val tempNode = rootNode.children[0].children[0]
+
+		val parentContainerNode = tempNode.children[0]
+		val childContainerNode = parentContainerNode.children[0]
+
+		assertThat(parentContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(childContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(childContainerNode.position).isEqualTo(IntOffset.Zero)
+	}
+
+	@Test fun testMaxModifiers_withInfiniteValue() {
+		val size = 20
+
+		val rootNode = mosaicNodesWithMeasureAndPlace {
+			Box {
+				Row {
+					Container(Modifier.widthIn(max = Constraints.Infinity)) {
+						Container(width = size, height = size)
+					}
+					Container(Modifier.heightIn(max = Constraints.Infinity)) {
+						Container(width = size, height = size)
+					}
+					Container(
+						Modifier.width(size)
+							.height(size)
+							.widthIn(max = Constraints.Infinity)
+							.heightIn(max = Constraints.Infinity),
+					)
+					Container(
+						Modifier.sizeIn(
+							maxWidth = Constraints.Infinity,
+							maxHeight = Constraints.Infinity,
+						),
+					) {
+						Container(width = size, height = size) {}
+					}
+				}
+			}
+		}
+
+		val tempNode = rootNode.children[0].children[0]
+
+		val firstContainerNode = tempNode.children[0].children[0]
+		val secondContainerNode = tempNode.children[1].children[0]
+		val thirdContainerNode = tempNode.children[2]
+		val fourthContainerNode = tempNode.children[3].children[0]
+
+		assertThat(firstContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(secondContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(thirdContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(fourthContainerNode.size).isEqualTo(IntSize(size, size))
+	}
+
+	@Test fun testMeasurementConstraints_preferredSatisfiable() {
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.width(20),
+			Constraints(20, 20, 15, 35),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.height(20),
+			Constraints(10, 30, 20, 20),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.size(20),
+			Constraints(20, 20, 20, 20),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.widthIn(20, 25),
+			Constraints(20, 25, 15, 35),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.heightIn(20, 25),
+			Constraints(10, 30, 20, 25),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.sizeIn(20, 20, 25, 25),
+			Constraints(20, 25, 20, 25),
+		)
+	}
+
+	@Test fun testMeasurementConstraints_preferredUnsatisfiable() {
+		assertConstraints(
+			Constraints(20, 40, 15, 35),
+			Modifier.width(15),
+			Constraints(20, 20, 15, 35),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.height(10),
+			Constraints(10, 30, 15, 15),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.size(40),
+			Constraints(30, 30, 35, 35),
+		)
+		assertConstraints(
+			Constraints(20, 30, 15, 35),
+			Modifier.widthIn(10, 15),
+			Constraints(20, 20, 15, 35),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.heightIn(5, 10),
+			Constraints(10, 30, 15, 15),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.sizeIn(40, 50, 45, 55),
+			Constraints(30, 30, 35, 35),
+		)
+	}
+
+	@Test fun testMeasurementConstraints_compulsorySatisfiable() {
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.requiredWidth(20),
+			Constraints(20, 20, 15, 35),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.requiredHeight(20),
+			Constraints(10, 30, 20, 20),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.requiredSize(20),
+			Constraints(20, 20, 20, 20),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.requiredWidthIn(20, 25),
+			Constraints(20, 25, 15, 35),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.requiredHeightIn(20, 25),
+			Constraints(10, 30, 20, 25),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.requiredSizeIn(20, 20, 25, 25),
+			Constraints(20, 25, 20, 25),
+		)
+	}
+
+	@Test fun testMeasurementConstraints_compulsoryUnsatisfiable() {
+		assertConstraints(
+			Constraints(20, 40, 15, 35),
+			Modifier.requiredWidth(15),
+			Constraints(15, 15, 15, 35),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.requiredHeight(10),
+			Constraints(10, 30, 10, 10),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.requiredSize(40),
+			Constraints(40, 40, 40, 40),
+		)
+		assertConstraints(
+			Constraints(20, 30, 15, 35),
+			Modifier.requiredWidthIn(10, 15),
+			Constraints(10, 15, 15, 35),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.requiredHeightIn(5, 10),
+			Constraints(10, 30, 5, 10),
+		)
+		assertConstraints(
+			Constraints(10, 30, 15, 35),
+			Modifier.requiredSizeIn(40, 50, 45, 55),
+			Constraints(40, 45, 50, 55),
+		)
+		// When one dimension is unspecified and the other contradicts the incoming constraint.
+		assertConstraints(
+			Constraints(10, 10, 10, 10),
+			Modifier.requiredSizeIn(20, 30, Int.MIN_VALUE, Int.MIN_VALUE),
+			Constraints(20, 20, 30, 30),
+		)
+		assertConstraints(
+			Constraints(40, 40, 40, 40),
+			Modifier.requiredSizeIn(Int.MIN_VALUE, Int.MIN_VALUE, 20, 30),
+			Constraints(20, 20, 30, 30),
+		)
+	}
+
+	private fun assertConstraints(
+		incomingConstraints: Constraints,
+		modifier: Modifier,
+		expectedConstraints: Constraints,
+	) {
+		// Capture constraints and assert on test thread
+		var actualConstraints: Constraints? = null
+		// Clear contents before each test so that we don't recompose the BoxWithConstraints call;
+		// doing so would recompose the old subcomposition with old constraints in the presence of
+		// new content before the measurement performs explicit composition the new constraints.
+		renderMosaic {
+			Layout({
+				Layout(
+					content = {},
+					modifiers = modifier,
+					measurePolicy = { _, constraints ->
+						actualConstraints = constraints
+						layout(0, 0) {}
+					},
+				)
+			}) { measurables, _ ->
+				measurables[0].measure(incomingConstraints)
+				layout(0, 0) {}
+			}
+		}
+		assertThat(actualConstraints).isEqualTo(expectedConstraints)
+	}
+
+	@Test fun testDefaultMinSize() {
+		renderMosaic {
+			// Constraints are applied.
+			Layout(
+				{},
+				Modifier.wrapContentSize()
+					.requiredSizeIn(maxWidth = 30, maxHeight = 40)
+					.defaultMinSize(minWidth = 10, minHeight = 20),
+			) { _, constraints ->
+				assertThat(constraints.minWidth).isEqualTo(10)
+				assertThat(constraints.minHeight).isEqualTo(20)
+				assertThat(constraints.maxWidth).isEqualTo(30)
+				assertThat(constraints.maxHeight).isEqualTo(40)
+				layout(0, 0) {}
+			}
+			// Constraints are not applied
+			Layout(
+				{},
+				Modifier.requiredSizeIn(
+					minWidth = 10,
+					minHeight = 20,
+					maxWidth = 100,
+					maxHeight = 110,
+				).defaultMinSize(
+					minWidth = 50,
+					minHeight = 50,
+				),
+			) { _, constraints ->
+				assertThat(constraints.minWidth).isEqualTo(10)
+				assertThat(constraints.minHeight).isEqualTo(20)
+				assertThat(constraints.maxWidth).isEqualTo(100)
+				assertThat(constraints.maxHeight).isEqualTo(110)
+				layout(0, 0) {}
+			}
+			// Defaults values are not changing
+			Layout(
+				{},
+				Modifier.requiredSizeIn(
+					minWidth = 10,
+					minHeight = 20,
+					maxWidth = 100,
+					maxHeight = 110,
+				).defaultMinSize(),
+			) { _, constraints ->
+				assertThat(constraints.minWidth).isEqualTo(10)
+				assertThat(constraints.minHeight).isEqualTo(20)
+				assertThat(constraints.maxWidth).isEqualTo(100)
+				assertThat(constraints.maxHeight).isEqualTo(110)
+				layout(0, 0) {}
+			}
+		}
+	}
+
+	@Test fun testDefaultMinSize_withCoercingMaxConstraints() {
+		renderMosaic {
+			Layout(
+				{},
+				Modifier.wrapContentSize()
+					.requiredSizeIn(maxWidth = 30, maxHeight = 40)
+					.defaultMinSize(minWidth = 70, minHeight = 80),
+			) { _, constraints ->
+				assertThat(constraints.minWidth).isEqualTo(30)
+				assertThat(constraints.minHeight).isEqualTo(40)
+				assertThat(constraints.maxWidth).isEqualTo(30)
+				assertThat(constraints.maxHeight).isEqualTo(40)
+				layout(0, 0) {}
+			}
+		}
+	}
+
+	@Test fun testMinWidthModifier_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics(
+			@Composable {
+				Container(Modifier.widthIn(min = 10)) {
+					Container(Modifier.aspectRatio(1f)) { }
+				}
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(10)
+			assertThat(minIntrinsicWidth(5)).isEqualTo(10)
+			assertThat(minIntrinsicWidth(50)).isEqualTo(50)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(10)
+			// Min height
+			assertThat(minIntrinsicHeight(0)).isEqualTo(0)
+			assertThat(minIntrinsicHeight(35)).isEqualTo(35)
+			assertThat(minIntrinsicHeight(50)).isEqualTo(50)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+			// Max width
+			assertThat(maxIntrinsicWidth(0)).isEqualTo(10)
+			assertThat(maxIntrinsicWidth(5)).isEqualTo(10)
+			assertThat(maxIntrinsicWidth(50)).isEqualTo(50)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(10)
+			// Max height
+			assertThat(maxIntrinsicHeight(0)).isEqualTo(0)
+			assertThat(maxIntrinsicHeight(35)).isEqualTo(35)
+			assertThat(maxIntrinsicHeight(50)).isEqualTo(50)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+		}
+	}
+
+	@Test fun testMaxWidthModifier_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics(
+			@Composable {
+				Container(Modifier.widthIn(max = 20)) {
+					Container(Modifier.aspectRatio(1f)) { }
+				}
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(minIntrinsicWidth(15)).isEqualTo(15)
+			assertThat(minIntrinsicWidth(50)).isEqualTo(20)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+			// Min height
+			assertThat(minIntrinsicHeight(0)).isEqualTo(0)
+			assertThat(minIntrinsicHeight(15)).isEqualTo(15)
+			assertThat(minIntrinsicHeight(50)).isEqualTo(50)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+			// Max width
+			assertThat(maxIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(maxIntrinsicWidth(15)).isEqualTo(15)
+			assertThat(maxIntrinsicWidth(50)).isEqualTo(20)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+			// Max height
+			assertThat(maxIntrinsicHeight(0)).isEqualTo(0)
+			assertThat(maxIntrinsicHeight(15)).isEqualTo(15)
+			assertThat(maxIntrinsicHeight(50)).isEqualTo(50)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+		}
+	}
+
+	@Test fun testMinHeightModifier_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics(
+			@Composable {
+				Container(Modifier.heightIn(min = 30)) {
+					Container(Modifier.aspectRatio(1f)) { }
+				}
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(minIntrinsicWidth(15)).isEqualTo(15)
+			assertThat(minIntrinsicWidth(50)).isEqualTo(50)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+			// Min height
+			assertThat(minIntrinsicHeight(0)).isEqualTo(30)
+			assertThat(minIntrinsicHeight(15)).isEqualTo(30)
+			assertThat(minIntrinsicHeight(50)).isEqualTo(50)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(30)
+			// Max width
+			assertThat(maxIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(maxIntrinsicWidth(15)).isEqualTo(15)
+			assertThat(maxIntrinsicWidth(50)).isEqualTo(50)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+			// Max height
+			assertThat(maxIntrinsicHeight(0)).isEqualTo(30)
+			assertThat(maxIntrinsicHeight(15)).isEqualTo(30)
+			assertThat(maxIntrinsicHeight(50)).isEqualTo(50)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(30)
+		}
+	}
+
+	@Test fun testMaxHeightModifier_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics(
+			@Composable {
+				Container(Modifier.heightIn(max = 40)) {
+					Container(Modifier.aspectRatio(1f)) { }
+				}
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(minIntrinsicWidth(15)).isEqualTo(15)
+			assertThat(minIntrinsicWidth(50)).isEqualTo(50)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+			// Min height
+			assertThat(minIntrinsicHeight(0)).isEqualTo(0)
+			assertThat(minIntrinsicHeight(15)).isEqualTo(15)
+			assertThat(minIntrinsicHeight(50)).isEqualTo(40)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+			// Max width
+			assertThat(maxIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(maxIntrinsicWidth(15)).isEqualTo(15)
+			assertThat(maxIntrinsicWidth(50)).isEqualTo(50)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+			// Max height
+			assertThat(maxIntrinsicHeight(0)).isEqualTo(0)
+			assertThat(maxIntrinsicHeight(15)).isEqualTo(15)
+			assertThat(maxIntrinsicHeight(50)).isEqualTo(40)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+		}
+	}
+
+	@Test fun testWidthModifier_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics(
+			@Composable {
+				Container(Modifier.width(10)) {
+					Container(Modifier.aspectRatio(1f)) { }
+				}
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(10)
+			assertThat(minIntrinsicWidth(10)).isEqualTo(10)
+			assertThat(minIntrinsicWidth(75)).isEqualTo(10)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(10)
+			// Min height
+			assertThat(minIntrinsicHeight(0)).isEqualTo(0)
+			assertThat(minIntrinsicHeight(35)).isEqualTo(35)
+			assertThat(minIntrinsicHeight(70)).isEqualTo(70)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+			// Max width
+			assertThat(maxIntrinsicWidth(0)).isEqualTo(10)
+			assertThat(maxIntrinsicWidth(15)).isEqualTo(10)
+			assertThat(maxIntrinsicWidth(75)).isEqualTo(10)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(10)
+			// Max height
+			assertThat(maxIntrinsicHeight(0)).isEqualTo(0)
+			assertThat(maxIntrinsicHeight(35)).isEqualTo(35)
+			assertThat(maxIntrinsicHeight(70)).isEqualTo(70)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+		}
+	}
+
+	@Test fun testHeightModifier_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics(
+			@Composable {
+				Container(Modifier.height(10)) {
+					Container(Modifier.aspectRatio(1f)) { }
+				}
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(minIntrinsicWidth(15)).isEqualTo(15)
+			assertThat(minIntrinsicWidth(75)).isEqualTo(75)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+			// Min height
+			assertThat(minIntrinsicHeight(0)).isEqualTo(10)
+			assertThat(minIntrinsicHeight(35)).isEqualTo(10)
+			assertThat(minIntrinsicHeight(70)).isEqualTo(10)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(10)
+			// Max width
+			assertThat(maxIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(maxIntrinsicWidth(15)).isEqualTo(15)
+			assertThat(maxIntrinsicWidth(75)).isEqualTo(75)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+			// Max height
+			assertThat(maxIntrinsicHeight(0)).isEqualTo(10)
+			assertThat(maxIntrinsicHeight(35)).isEqualTo(10)
+			assertThat(maxIntrinsicHeight(70)).isEqualTo(10)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(10)
+		}
+	}
+
+	@Test fun testWidthHeightModifiers_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics(
+			@Composable {
+				Container(
+					Modifier.sizeIn(
+						minWidth = 10,
+						maxWidth = 20,
+						minHeight = 30,
+						maxHeight = 40,
+					),
+				) {
+					Container(Modifier.aspectRatio(1f)) { }
+				}
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(10)
+			assertThat(minIntrinsicWidth(15)).isEqualTo(15)
+			assertThat(minIntrinsicWidth(50)).isEqualTo(20)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(10)
+			// Min height
+			assertThat(minIntrinsicHeight(0)).isEqualTo(30)
+			assertThat(minIntrinsicHeight(35)).isEqualTo(35)
+			assertThat(minIntrinsicHeight(50)).isEqualTo(40)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(30)
+			// Max width
+			assertThat(maxIntrinsicWidth(0)).isEqualTo(10)
+			assertThat(maxIntrinsicWidth(15)).isEqualTo(15)
+			assertThat(maxIntrinsicWidth(50)).isEqualTo(20)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(10)
+			// Max height
+			assertThat(maxIntrinsicHeight(0)).isEqualTo(30)
+			assertThat(maxIntrinsicHeight(35)).isEqualTo(35)
+			assertThat(maxIntrinsicHeight(50)).isEqualTo(40)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(30)
+		}
+	}
+
+	@Test fun testMinSizeModifier_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics(
+			@Composable {
+				Container(Modifier.sizeIn(minWidth = 20, minHeight = 30)) {
+					Container(Modifier.aspectRatio(1f)) { }
+				}
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(20)
+			assertThat(minIntrinsicWidth(10)).isEqualTo(20)
+			assertThat(minIntrinsicWidth(50)).isEqualTo(50)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(20)
+			// Min height
+			assertThat(minIntrinsicHeight(0)).isEqualTo(30)
+			assertThat(minIntrinsicHeight(10)).isEqualTo(30)
+			assertThat(minIntrinsicHeight(50)).isEqualTo(50)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(30)
+			// Max width
+			assertThat(maxIntrinsicWidth(0)).isEqualTo(20)
+			assertThat(maxIntrinsicWidth(10)).isEqualTo(20)
+			assertThat(maxIntrinsicWidth(50)).isEqualTo(50)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(20)
+			// Max height
+			assertThat(maxIntrinsicHeight(0)).isEqualTo(30)
+			assertThat(maxIntrinsicHeight(10)).isEqualTo(30)
+			assertThat(maxIntrinsicHeight(50)).isEqualTo(50)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(30)
+		}
+	}
+
+	@Test fun testMaxSizeModifier_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics(
+			@Composable {
+				Container(Modifier.sizeIn(maxWidth = 40, maxHeight = 50)) {
+					Container(Modifier.aspectRatio(1f)) { }
+				}
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(minIntrinsicWidth(15)).isEqualTo(15)
+			assertThat(minIntrinsicWidth(50)).isEqualTo(40)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+			// Min height
+			assertThat(minIntrinsicHeight(0)).isEqualTo(0)
+			assertThat(minIntrinsicHeight(15)).isEqualTo(15)
+			assertThat(minIntrinsicHeight(75)).isEqualTo(50)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+			// Max width
+			assertThat(maxIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(maxIntrinsicWidth(15)).isEqualTo(15)
+			assertThat(maxIntrinsicWidth(50)).isEqualTo(40)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+			// Max height
+			assertThat(maxIntrinsicHeight(0)).isEqualTo(0)
+			assertThat(maxIntrinsicHeight(15)).isEqualTo(15)
+			assertThat(maxIntrinsicHeight(75)).isEqualTo(50)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+		}
+	}
+
+	@Test fun testPreferredSizeModifier_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics(
+			@Composable {
+				Container(Modifier.size(40, 50)) {
+					Container(Modifier.aspectRatio(1f)) { }
+				}
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(40)
+			assertThat(minIntrinsicWidth(35)).isEqualTo(40)
+			assertThat(minIntrinsicWidth(75)).isEqualTo(40)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(40)
+			// Min height
+			assertThat(minIntrinsicHeight(0)).isEqualTo(50)
+			assertThat(minIntrinsicHeight(35)).isEqualTo(50)
+			assertThat(minIntrinsicHeight(70)).isEqualTo(50)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(50)
+			// Max width
+			assertThat(maxIntrinsicWidth(0)).isEqualTo(40)
+			assertThat(maxIntrinsicWidth(35)).isEqualTo(40)
+			assertThat(maxIntrinsicWidth(75)).isEqualTo(40)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(40)
+			// Max height
+			assertThat(maxIntrinsicHeight(0)).isEqualTo(50)
+			assertThat(maxIntrinsicHeight(35)).isEqualTo(50)
+			assertThat(maxIntrinsicHeight(70)).isEqualTo(50)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(50)
+		}
+	}
+
+	@Test fun testFillModifier_correctSize() {
+		val parentWidth = 100
+		val parentHeight = 80
+		val parentModifier = Modifier.requiredSize(parentWidth, parentHeight)
+		val childWidth = 40
+		val childHeight = 30
+		val childModifier = Modifier.size(childWidth, childHeight)
+
+		assertThat(calculateSizeFor(parentModifier, childModifier))
+			.isEqualTo(IntSize(childWidth, childHeight))
+		assertThat(calculateSizeFor(parentModifier, Modifier.fillMaxWidth().then(childModifier)))
+			.isEqualTo(IntSize(parentWidth, childHeight))
+		assertThat(calculateSizeFor(parentModifier, Modifier.fillMaxHeight().then(childModifier)))
+			.isEqualTo(IntSize(childWidth, parentHeight))
+		assertThat(calculateSizeFor(parentModifier, Modifier.fillMaxSize().then(childModifier)))
+			.isEqualTo(IntSize(parentWidth, parentHeight))
+	}
+
+	@Test fun testFractionalFillModifier_correctSize_whenSmallerChild() {
+		val parentWidth = 100
+		val parentHeight = 80
+		val parentModifier = Modifier.requiredSize(parentWidth, parentHeight)
+		val childWidth = 40
+		val childHeight = 30
+		val childModifier = Modifier.size(childWidth, childHeight)
+
+		assertThat(calculateSizeFor(parentModifier, childModifier))
+			.isEqualTo(IntSize(childWidth, childHeight))
+		assertThat(calculateSizeFor(parentModifier, Modifier.fillMaxWidth(0.5f).then(childModifier)))
+			.isEqualTo(IntSize(parentWidth / 2, childHeight))
+		assertThat(calculateSizeFor(parentModifier, Modifier.fillMaxHeight(0.5f).then(childModifier)))
+			.isEqualTo(IntSize(childWidth, parentHeight / 2))
+		assertThat(calculateSizeFor(parentModifier, Modifier.fillMaxSize(0.5f).then(childModifier)))
+			.isEqualTo(IntSize(parentWidth / 2, parentHeight / 2))
+	}
+
+	@Test fun testFractionalFillModifier_correctSize_whenLargerChild() {
+		val parentWidth = 100
+		val parentHeight = 80
+		val parentModifier = Modifier.requiredSize(parentWidth, parentHeight)
+		val childWidth = 70
+		val childHeight = 50
+		val childModifier = Modifier.size(childWidth, childHeight)
+
+		assertThat(calculateSizeFor(parentModifier, childModifier))
+			.isEqualTo(IntSize(childWidth, childHeight))
+		assertThat(calculateSizeFor(parentModifier, Modifier.fillMaxWidth(0.5f).then(childModifier)))
+			.isEqualTo(IntSize(parentWidth / 2, childHeight))
+		assertThat(calculateSizeFor(parentModifier, Modifier.fillMaxHeight(0.5f).then(childModifier)))
+			.isEqualTo(IntSize(childWidth, parentHeight / 2))
+		assertThat(calculateSizeFor(parentModifier, Modifier.fillMaxSize(0.5f).then(childModifier)))
+			.isEqualTo(IntSize(parentWidth / 2, parentHeight / 2))
+	}
+
+	@Test fun testFractionalFillModifier_coerced() {
+		val childMinWidth = 40
+		val childMinHeight = 30
+		val childMaxWidth = 60
+		val childMaxHeight = 50
+		val childModifier = Modifier.requiredSizeIn(
+			childMinWidth,
+			childMinHeight,
+			childMaxWidth,
+			childMaxHeight,
+		)
+
+		assertThat(calculateSizeFor(Modifier, childModifier.then(Modifier.fillMaxSize(0.1f))))
+			.isEqualTo(IntSize(childMinWidth, childMinHeight))
+		assertThat(calculateSizeFor(Modifier, childModifier.then(Modifier.fillMaxSize(1.0f))))
+			.isEqualTo(IntSize(childMaxWidth, childMaxHeight))
+	}
+
+	private fun calculateSizeFor(parentModifier: Modifier, modifier: Modifier): IntSize {
+		val rootNode = mosaicNodesWithMeasureAndPlace {
+			Box(parentModifier) {
+				Box(modifier)
+			}
+		}
+
+		val innerBoxNode = rootNode.children[0].children[0]
+		return IntSize(innerBoxNode.width, innerBoxNode.height)
+	}
+
+	@Test fun testDefaultMinSizeModifier_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics(
+			@Composable {
+				Container(Modifier.defaultMinSize(40, 50)) {
+					Container(Modifier.aspectRatio(1f)) {}
+				}
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, _, _ ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(40)
+			assertThat(minIntrinsicWidth(35)).isEqualTo(40)
+			assertThat(minIntrinsicWidth(55)).isEqualTo(55)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(40)
+			// Min height
+			assertThat(minIntrinsicHeight(0)).isEqualTo(50)
+			assertThat(minIntrinsicHeight(35)).isEqualTo(50)
+			assertThat(minIntrinsicHeight(55)).isEqualTo(55)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(50)
+			// Max width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(40)
+			assertThat(minIntrinsicWidth(35)).isEqualTo(40)
+			assertThat(minIntrinsicWidth(55)).isEqualTo(55)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(40)
+			// Max height
+			assertThat(minIntrinsicHeight(0)).isEqualTo(50)
+			assertThat(minIntrinsicHeight(35)).isEqualTo(50)
+			assertThat(minIntrinsicHeight(55)).isEqualTo(55)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(50)
+		}
+	}
+
+	@Test fun testFillModifier_noChangeIntrinsicMeasurements() {
+		verifyIntrinsicMeasurements(Modifier.fillMaxWidth())
+		verifyIntrinsicMeasurements(Modifier.fillMaxHeight())
+		verifyIntrinsicMeasurements(Modifier.fillMaxSize())
+	}
+
+	private fun verifyIntrinsicMeasurements(expandedModifier: Modifier) {
+		// intrinsic measurements do not change with the ExpandedModifier
+		testIntrinsics(
+			@Composable {
+				Container(
+					expandedModifier.then(Modifier.aspectRatio(2f)),
+					width = 30,
+					height = 40,
+				)
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Width
+			assertThat(minIntrinsicWidth(20)).isEqualTo(40)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(30)
+
+			assertThat(maxIntrinsicWidth(20)).isEqualTo(40)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(30)
+
+			// Height
+			assertThat(minIntrinsicHeight(40)).isEqualTo(20)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(40)
+
+			assertThat(maxIntrinsicHeight(40)).isEqualTo(20)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(40)
+		}
+	}
+
+	@Test fun test2DWrapContentSize() {
+		val size = 50
+
+		val rootNode = mosaicNodesWithMeasureAndPlace {
+			Container {
+				Container(
+					Modifier.fillMaxSize()
+						.wrapContentSize(Alignment.BottomEnd)
+						.size(size),
+				)
+			}
+		}
+
+		val innerContainerNode = rootNode.children[0]
+
+		assertThat(rootNode.position).isEqualTo(IntOffset.Zero)
+		assertThat(innerContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(innerContainerNode.position)
+			.isEqualTo(IntOffset(rootNode.width - size, rootNode.height - size))
+	}
+
+	@Test fun test1DWrapContentSize() {
+		val size = 50
+
+		val rootNode = mosaicNodesWithMeasureAndPlace {
+			Container {
+				Container(
+					Modifier.fillMaxSize()
+						.wrapContentWidth(Alignment.End)
+						.width(size),
+				)
+			}
+		}
+
+		val innerContainerNode = rootNode.children[0]
+
+		assertThat(rootNode.position).isEqualTo(IntOffset.Zero)
+		assertThat(innerContainerNode.size).isEqualTo(IntSize(size, rootNode.height))
+		assertThat(innerContainerNode.position).isEqualTo(IntOffset(rootNode.width - size, 0))
+	}
+
+	@Test fun testModifier_wrapsContent() {
+		val contentSize = 50
+
+		val rootNode = mosaicNodesWithMeasureAndPlace {
+			Container {
+				Container {
+					Container(Modifier.wrapContentSize(Alignment.TopStart).size(contentSize))
+				}
+			}
+		}
+
+		val middleContainerNode = rootNode.children[0].children[0]
+
+		assertThat(middleContainerNode.size).isEqualTo(IntSize(contentSize, contentSize))
+	}
+
+	@Test fun testWrapContentSize_wrapsContent_whenMeasuredWithInfiniteConstraints() {
+		val size = 50
+
+		val rootNode = mosaicNodesWithMeasureAndPlace {
+			Layout(
+				modifiers = Modifier.size(100),
+				content = {
+					Container {
+						Container(Modifier.wrapContentSize(Alignment.BottomEnd).size(size))
+					}
+				},
+				measurePolicy = { measurables, constraints ->
+					val placeable = measurables.first().measure(Constraints())
+					layout(constraints.maxWidth, constraints.maxHeight) {
+						placeable.place(0, 0)
+					}
+				},
+			)
+		}
+
+		val alignContainerNode = rootNode.children[0].children[0]
+		val childContainerNode = rootNode.children[0].children[0].children[0]
+
+		assertThat(alignContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(alignContainerNode.position).isEqualTo(IntOffset.Zero)
+		assertThat(childContainerNode.size).isEqualTo(IntSize(size, size))
+		assertThat(childContainerNode.position).isEqualTo(IntOffset.Zero)
+	}
+
+	@Test fun test2DAlignedModifier_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics(
+			@Composable {
+				Container(Modifier.wrapContentSize(Alignment.TopStart).aspectRatio(2f)) { }
+			},
+		) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(minIntrinsicWidth(25)).isEqualTo(50)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+
+			// Min height
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(minIntrinsicHeight(50)).isEqualTo(25)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+
+			// Max width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(maxIntrinsicWidth(25)).isEqualTo(50)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+
+			// Max height
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(maxIntrinsicHeight(50)).isEqualTo(25)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+		}
+	}
+
+	@Test fun test1DAlignedModifier_hasCorrectIntrinsicMeasurements() {
+		testIntrinsics({
+			Container(
+				Modifier.wrapContentHeight(Alignment.CenterVertically)
+					.aspectRatio(2f),
+			) { }
+		}) { minIntrinsicWidth, minIntrinsicHeight, maxIntrinsicWidth, maxIntrinsicHeight ->
+			// Min width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(minIntrinsicWidth(25)).isEqualTo(50)
+			assertThat(minIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+
+			// Min height
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(minIntrinsicHeight(50)).isEqualTo(25)
+			assertThat(minIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+
+			// Max width
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(maxIntrinsicWidth(25)).isEqualTo(50)
+			assertThat(maxIntrinsicWidth(Constraints.Infinity)).isEqualTo(0)
+
+			// Max height
+			assertThat(minIntrinsicWidth(0)).isEqualTo(0)
+			assertThat(maxIntrinsicHeight(50)).isEqualTo(25)
+			assertThat(maxIntrinsicHeight(Constraints.Infinity)).isEqualTo(0)
+		}
+	}
+
+	@Test fun testModifiers_equals() {
+		assertThat(Modifier.size(10, 20)).isEqualTo(Modifier.size(10, 20))
+		assertThat(Modifier.requiredSize(10, 20)).isEqualTo(Modifier.requiredSize(10, 20))
+		assertThat(Modifier.wrapContentSize(Alignment.BottomEnd))
+			.isEqualTo(Modifier.wrapContentSize(Alignment.BottomEnd))
+		assertThat(Modifier.fillMaxSize(0.8f)).isEqualTo(Modifier.fillMaxSize(0.8f))
+		assertThat(Modifier.defaultMinSize(10, 20)).isEqualTo(Modifier.defaultMinSize(10, 20))
+
+		assertThat(Modifier.size(10, 20)).isNotEqualTo(Modifier.size(20, 10))
+		assertThat(Modifier.requiredSize(10, 20)).isNotEqualTo(Modifier.requiredSize(20, 10))
+		assertThat(Modifier.wrapContentSize(Alignment.BottomEnd))
+			.isNotEqualTo(Modifier.wrapContentSize(Alignment.BottomCenter))
+		assertThat(Modifier.fillMaxSize(0.8f)).isNotEqualTo(Modifier.fillMaxSize())
+		assertThat(Modifier.defaultMinSize(10, 20)).isNotEqualTo(Modifier.defaultMinSize(20, 10))
+	}
+
+	@Test fun sizeModifiers_doNotCauseCrashesWhenCreatingConstraints() {
+		renderMosaic {
+			Box(Modifier.sizeIn(minWidth = -1))
+			Box(Modifier.sizeIn(minWidth = 10, maxWidth = 5))
+			Box(Modifier.sizeIn(minHeight = -1))
+			Box(Modifier.sizeIn(minHeight = 10, maxHeight = 5))
+			Box(
+				Modifier.sizeIn(
+					minWidth = Constraints.Infinity,
+					maxWidth = Constraints.Infinity,
+					minHeight = Constraints.Infinity,
+					maxHeight = Constraints.Infinity,
+				),
+			)
+			Box(Modifier.defaultMinSize(minWidth = -1, minHeight = -1))
+		}
+	}
+}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/stuff.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/stuff.kt
@@ -1,9 +1,148 @@
 package com.jakewharton.mosaic
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.snapshots.SnapshotStateList
+import com.jakewharton.mosaic.layout.IntrinsicMeasurable
+import com.jakewharton.mosaic.layout.Measurable
+import com.jakewharton.mosaic.layout.MeasurePolicy
+import com.jakewharton.mosaic.layout.MeasureResult
+import com.jakewharton.mosaic.layout.MeasureScope
+import com.jakewharton.mosaic.layout.MosaicNode
+import com.jakewharton.mosaic.layout.Placeable
+import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.ui.Alignment
+import com.jakewharton.mosaic.ui.Filler
+import com.jakewharton.mosaic.ui.Layout
+import com.jakewharton.mosaic.ui.unit.Constraints
+import com.jakewharton.mosaic.ui.unit.IntOffset
+import com.jakewharton.mosaic.ui.unit.IntSize
+import com.jakewharton.mosaic.ui.unit.constrain
+import kotlin.math.max
 
 const val s = " "
 
+const val TestChar = 'X'
+
 fun <T> snapshotStateListOf(vararg values: T): SnapshotStateList<T> {
 	return SnapshotStateList<T>().apply { addAll(values) }
+}
+
+internal val MosaicNode.size: IntSize
+	get() = IntSize(width, height)
+
+internal val MosaicNode.position: IntOffset
+	get() = IntOffset(x, y)
+
+internal fun mosaicNodesWithMeasureAndPlace(content: @Composable () -> Unit): MosaicNode {
+	return mosaicNodes(content).apply {
+		measureAndPlace()
+	}
+}
+
+@Composable
+inline fun TestFiller(modifier: Modifier = Modifier) {
+	Filler(TestChar, modifier = modifier)
+}
+
+@Composable
+fun Container(
+	modifier: Modifier = Modifier,
+	alignment: Alignment = Alignment.Center,
+	expanded: Boolean = false,
+	constraints: Constraints = Constraints(),
+	width: Int? = null,
+	height: Int? = null,
+	content: @Composable () -> Unit = {},
+) {
+	Layout(content, modifier, debugInfo = { "Container()" }) { measurables, incomingConstraints ->
+		val containerConstraints = incomingConstraints.constrain(
+			Constraints(constraints.value)
+				.copy(
+					width ?: constraints.minWidth,
+					width ?: constraints.maxWidth,
+					height ?: constraints.minHeight,
+					height ?: constraints.maxHeight,
+				),
+		)
+		val childConstraints = containerConstraints.copy(minWidth = 0, minHeight = 0)
+		var placeable: Placeable? = null
+		val containerWidth = if ((containerConstraints.hasFixedWidth || expanded) &&
+			containerConstraints.hasBoundedWidth
+		) {
+			containerConstraints.maxWidth
+		} else {
+			placeable = measurables.firstOrNull()?.measure(childConstraints)
+			max(placeable?.width ?: 0, containerConstraints.minWidth)
+		}
+		val containerHeight = if ((containerConstraints.hasFixedHeight || expanded) &&
+			containerConstraints.hasBoundedHeight
+		) {
+			containerConstraints.maxHeight
+		} else {
+			if (placeable == null) {
+				placeable = measurables.firstOrNull()?.measure(childConstraints)
+			}
+			max(placeable?.height ?: 0, containerConstraints.minHeight)
+		}
+		layout(containerWidth, containerHeight) {
+			val p = placeable ?: measurables.firstOrNull()?.measure(childConstraints)
+			p?.let {
+				val position = alignment.align(
+					IntSize(it.width, it.height),
+					IntSize(containerWidth, containerHeight),
+				)
+				it.place(position.x, position.y)
+			}
+		}
+	}
+}
+
+fun testIntrinsics(
+	vararg layouts: @Composable () -> Unit,
+	test: ((Int) -> Int, (Int) -> Int, (Int) -> Int, (Int) -> Int) -> Unit,
+) {
+	layouts.forEach { layout ->
+		renderMosaic {
+			val measurePolicy = object : MeasurePolicy {
+				override fun MeasureScope.measure(
+					measurables: List<Measurable>,
+					constraints: Constraints,
+				): MeasureResult {
+					val measurable = measurables.first()
+					test(
+						{ h -> measurable.minIntrinsicWidth(h) },
+						{ w -> measurable.minIntrinsicHeight(w) },
+						{ h -> measurable.maxIntrinsicWidth(h) },
+						{ w -> measurable.maxIntrinsicHeight(w) },
+					)
+
+					return layout(0, 0) {}
+				}
+
+				override fun minIntrinsicWidth(
+					measurables: List<IntrinsicMeasurable>,
+					height: Int,
+				) = 0
+
+				override fun minIntrinsicHeight(
+					measurables: List<IntrinsicMeasurable>,
+					width: Int,
+				) = 0
+
+				override fun maxIntrinsicWidth(
+					measurables: List<IntrinsicMeasurable>,
+					height: Int,
+				) = 0
+
+				override fun maxIntrinsicHeight(
+					measurables: List<IntrinsicMeasurable>,
+					width: Int,
+				) = 0
+			}
+			Layout(
+				content = layout,
+				measurePolicy = measurePolicy,
+			)
+		}
+	}
 }

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/ArrangementTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/ArrangementTest.kt
@@ -1,0 +1,277 @@
+package com.jakewharton.mosaic.ui
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class ArrangementTest {
+	@Test fun arrangementStart() {
+		testHorizontalArrangement(
+			actualArrangement = Arrangement.Start,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20),
+			actualOutPositions = intArrayOf(0),
+			expectedOutPositions = intArrayOf(0),
+		)
+		testHorizontalArrangement(
+			actualArrangement = Arrangement.Start,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30),
+			actualOutPositions = intArrayOf(0, 0),
+			expectedOutPositions = intArrayOf(0, 20),
+		)
+		testHorizontalArrangement(
+			actualArrangement = Arrangement.Start,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(0, 0, 0),
+			expectedOutPositions = intArrayOf(0, 20, 50),
+		)
+		testHorizontalArrangement(
+			actualArrangement = Arrangement.Start,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(50, 20, 0),
+			expectedOutPositions = intArrayOf(0, 20, 50),
+		)
+	}
+
+	@Test fun arrangementEnd() {
+		testHorizontalArrangement(
+			actualArrangement = Arrangement.End,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20),
+			actualOutPositions = intArrayOf(0),
+			expectedOutPositions = intArrayOf(120),
+		)
+		testHorizontalArrangement(
+			actualArrangement = Arrangement.End,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30),
+			actualOutPositions = intArrayOf(0, 0),
+			expectedOutPositions = intArrayOf(90, 110),
+		)
+		testHorizontalArrangement(
+			actualArrangement = Arrangement.End,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(0, 0, 0),
+			expectedOutPositions = intArrayOf(50, 70, 100),
+		)
+		testHorizontalArrangement(
+			actualArrangement = Arrangement.End,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(100, 70, 50),
+			expectedOutPositions = intArrayOf(50, 70, 100),
+		)
+	}
+
+	@Test fun arrangementTop() {
+		testVerticalArrangement(
+			actualArrangement = Arrangement.Top,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20),
+			actualOutPositions = intArrayOf(0),
+			expectedOutPositions = intArrayOf(0),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.Top,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30),
+			actualOutPositions = intArrayOf(0, 0),
+			expectedOutPositions = intArrayOf(0, 20),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.Top,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(0, 0, 0),
+			expectedOutPositions = intArrayOf(0, 20, 50),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.Top,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(50, 20, 0),
+			expectedOutPositions = intArrayOf(0, 20, 50),
+		)
+	}
+
+	@Test fun arrangementBottom() {
+		testVerticalArrangement(
+			actualArrangement = Arrangement.Bottom,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20),
+			actualOutPositions = intArrayOf(0),
+			expectedOutPositions = intArrayOf(120),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.Bottom,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30),
+			actualOutPositions = intArrayOf(0, 0),
+			expectedOutPositions = intArrayOf(90, 110),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.Bottom,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(0, 0, 0),
+			expectedOutPositions = intArrayOf(50, 70, 100),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.Bottom,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(100, 70, 50),
+			expectedOutPositions = intArrayOf(50, 70, 100),
+		)
+	}
+
+	@Test fun arrangementCenter() {
+		testVerticalArrangement(
+			actualArrangement = Arrangement.Center,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20),
+			actualOutPositions = intArrayOf(0),
+			expectedOutPositions = intArrayOf(60),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.Center,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30),
+			actualOutPositions = intArrayOf(0, 0),
+			expectedOutPositions = intArrayOf(45, 65),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.Center,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(0, 0, 0),
+			expectedOutPositions = intArrayOf(25, 45, 75),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.Center,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(75, 45, 25),
+			expectedOutPositions = intArrayOf(25, 45, 75),
+		)
+	}
+
+	@Test fun arrangementSpaceEvenly() {
+		testVerticalArrangement(
+			actualArrangement = Arrangement.SpaceEvenly,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20),
+			actualOutPositions = intArrayOf(0),
+			expectedOutPositions = intArrayOf(60),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.SpaceEvenly,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30),
+			actualOutPositions = intArrayOf(0, 0),
+			expectedOutPositions = intArrayOf(30, 80),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.SpaceEvenly,
+			actualTotalSize = 150,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(0, 0, 0),
+			expectedOutPositions = intArrayOf(15, 50, 95),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.SpaceEvenly,
+			actualTotalSize = 150,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(95, 50, 15),
+			expectedOutPositions = intArrayOf(15, 50, 95),
+		)
+	}
+
+	@Test fun arrangementSpaceBetween() {
+		testVerticalArrangement(
+			actualArrangement = Arrangement.SpaceBetween,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20),
+			actualOutPositions = intArrayOf(0),
+			expectedOutPositions = intArrayOf(0),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.SpaceBetween,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30),
+			actualOutPositions = intArrayOf(0, 0),
+			expectedOutPositions = intArrayOf(0, 110),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.SpaceBetween,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(0, 0, 0),
+			expectedOutPositions = intArrayOf(0, 45, 100),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.SpaceBetween,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(100, 45, 0),
+			expectedOutPositions = intArrayOf(0, 45, 100),
+		)
+	}
+
+	@Test fun arrangementSpaceAroung() {
+		testVerticalArrangement(
+			actualArrangement = Arrangement.SpaceAround,
+			actualTotalSize = 140,
+			actualSizes = intArrayOf(20),
+			actualOutPositions = intArrayOf(0),
+			expectedOutPositions = intArrayOf(60),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.SpaceAround,
+			actualTotalSize = 150,
+			actualSizes = intArrayOf(20, 30),
+			actualOutPositions = intArrayOf(0, 0),
+			expectedOutPositions = intArrayOf(25, 95),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.SpaceAround,
+			actualTotalSize = 150,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(0, 0, 0),
+			expectedOutPositions = intArrayOf(10, 50, 100),
+		)
+		testVerticalArrangement(
+			actualArrangement = Arrangement.SpaceAround,
+			actualTotalSize = 150,
+			actualSizes = intArrayOf(20, 30, 40),
+			actualOutPositions = intArrayOf(100, 50, 10),
+			expectedOutPositions = intArrayOf(10, 50, 100),
+		)
+	}
+
+	private fun testVerticalArrangement(
+		actualArrangement: Arrangement.Vertical,
+		actualTotalSize: Int,
+		actualSizes: IntArray,
+		actualOutPositions: IntArray,
+		expectedOutPositions: IntArray,
+	) {
+		actualArrangement.arrange(actualTotalSize, actualSizes, actualOutPositions)
+		assertThat(actualOutPositions).isEqualTo(expectedOutPositions)
+	}
+
+	private fun testHorizontalArrangement(
+		actualArrangement: Arrangement.Horizontal,
+		actualTotalSize: Int,
+		actualSizes: IntArray,
+		actualOutPositions: IntArray,
+		expectedOutPositions: IntArray,
+	) {
+		actualArrangement.arrange(actualTotalSize, actualSizes, actualOutPositions)
+		assertThat(actualOutPositions).isEqualTo(expectedOutPositions)
+	}
+}


### PR DESCRIPTION
Added unit tests for `AspectRatio`, `Offset`, `Padding`, `Size` modifiers. 
Added unit tests for `Arrangement`.
Added some auxiliary tools for unit tests.
Added `equals` and `hashCode` implementations for `SizeModifier`, `FillModifier`, `WrapContentModifier`, `UnspecifiedConstraintsModifier`. Added a new `Composable` - `Filler`. Draws the same symbol over its entire size. Similar to `Spacer`, where such a symbol is a space without additional styles. 
Added a `Composable` `Box` without content.
Fixed formatting in the `toString` implementation for `Alignment`, taking into account possible non-integers. 
Fixed a problem in `OffsetModifier` with incorrect transmission of `x` and `y` due to shadowing fields.
Fixed some bugs and typos in `Node.kt` related to the `minIntrinsicWidth`, `maxIntrinsicWidth`, `minIntrinsicHeight`, `maxIntrinsicHeight` methods.