### PR TITLE
Update compose-rules to 0.3.9 and remove suppressions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ allprojects {
 					'ktlint_function_naming_ignore_when_annotated_with': 'Composable',
 					'ktlint_compose_modifier-missing-check': 'disabled',
 					'ktlint_compose_compositionlocal-allowlist': 'disabled',
+					'compose_treat_as_lambda': 'MeasurePolicy'
 				])
 				.customRuleSets([
 					libs.ktlint.composeRules.get().toString(),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ poko-gradlePlugin = "dev.drewhamilton.poko:poko-gradle-plugin:0.15.2"
 
 spotless-gradlePlugin = "com.diffplug.spotless:spotless-plugin-gradle:6.24.0"
 ktlint-core = "com.pinterest.ktlint:ktlint-cli:1.1.1"
-ktlint-composeRules = "io.nlopez.compose.rules:ktlint:0.3.7"
+ktlint-composeRules = "io.nlopez.compose.rules:ktlint:0.3.9"
 
 jansi = "org.fusesource.jansi:jansi:2.4.1"
 mordant = "com.github.ajalt.mordant:mordant:2.2.0"

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Layout.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Layout.kt
@@ -37,7 +37,6 @@ internal sealed class NoContentMeasureScope {
 
 @Composable
 @MosaicComposable
-@Suppress("ktlint:compose:param-order-check") // Order is correct, check just can't tell.
 internal fun Layout(
 	modifier: Modifier = Modifier,
 	debugInfo: () -> String = { "Layout()" },
@@ -45,8 +44,8 @@ internal fun Layout(
 ) {
 	Node(
 		measurePolicy = NoContentMeasurePolicyMeasurePolicy(measurePolicy),
-		modifier = modifier,
 		debugPolicy = { debugInfo() + " x=$x y=$y w=$width h=$height${modifier.toDebugString()}" },
+		modifier = modifier,
 		factory = NodeFactory,
 	)
 }
@@ -64,7 +63,6 @@ private class NoContentMeasurePolicyMeasurePolicy(
 }
 
 @Composable
-@Suppress("ktlint:compose:param-order-check") // Order is what we want.
 public fun Layout(
 	content: @Composable () -> Unit,
 	modifier: Modifier = Modifier,
@@ -72,9 +70,7 @@ public fun Layout(
 	measurePolicy: MeasurePolicy,
 ) {
 	Node(
-		content = content,
 		measurePolicy = measurePolicy,
-		modifier = modifier,
 		debugPolicy = {
 			buildString {
 				append(debugInfo())
@@ -84,6 +80,8 @@ public fun Layout(
 				}
 			}
 		},
+		modifier = modifier,
+		content = content,
 		factory = NodeFactory,
 	)
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Node.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Node.kt
@@ -14,14 +14,13 @@ import com.jakewharton.mosaic.ui.unit.Constraints
 
 @Composable
 @MosaicComposable
-@Suppress("ktlint") // TODO why doesn't "ktlint:compose:param-order-check" work here?
 internal inline fun Node(
+	measurePolicy: MeasurePolicy,
+	debugPolicy: DebugPolicy,
+	modifier: Modifier = Modifier,
 	content:
 	@Composable @MosaicComposable
 	() -> Unit = {},
-	modifier: Modifier,
-	measurePolicy: MeasurePolicy,
-	debugPolicy: DebugPolicy,
 	noinline factory: () -> MosaicNode,
 ) {
 	ComposeNode<MosaicNode, Applier<Any>>(

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Static.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Static.kt
@@ -24,13 +24,6 @@ public fun <T> Static(
 	var lastRendered by remember { mutableStateOf(0) }
 
 	Node(
-		content = {
-			for (i in lastDrawn until items.size) {
-				val item = items[i]
-				content(item)
-			}
-			lastRendered = items.size
-		},
 		measurePolicy = { measurables, constraints ->
 			val placeables = measurables.map { measurable ->
 				measurable.measure(constraints)
@@ -44,9 +37,16 @@ public fun <T> Static(
 				}
 			}
 		},
-		modifier = Modifier,
 		debugPolicy = {
 			children.joinToString(prefix = "Static()") { "\n" + it.toString().prependIndent("  ") }
+		},
+		modifier = Modifier,
+		content = {
+			for (i in lastDrawn until items.size) {
+				val item = items[i]
+				content(item)
+			}
+			lastRendered = items.size
 		},
 		factory = staticNodeFactory {
 			lastDrawn = lastRendered


### PR DESCRIPTION
Updates compose-rules to the latest version, adds the new configuration available to treat `MeasurePolicy` as a lambda (as it is one) and removes all the suppressions. 

Merging this should close #277.