### PR TITLE
Disable klib signature clash checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+New:
+-
+
+Changed:
+- Disable klib signature clash checks for JS compilations. These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).
+
+Fixed:
+-
+
 
 ## [0.11.0] - 2023-02-27
 


### PR DESCRIPTION
These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).

Closes #321 