### PR TITLE
Use CLRF line endings to support rendering in raw mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changed:
 - Disable klib signature clash checks for JS compilations. These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).
 
 Fixed:
-- Use CRLF line endings to fix rendering when a terminal is in raw mode
+- Use CRLF line endings to fix rendering when a terminal is in raw mode.
 
 
 ## [0.11.0] - 2023-02-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changed:
 - Disable klib signature clash checks for JS compilations. These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).
 
 Fixed:
--
+- Use CRLF line endings to fix rendering when a terminal is in raw mode
 
 
 ## [0.11.0] - 2023-02-27

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/canvas.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/canvas.kt
@@ -84,7 +84,7 @@ internal class TextSurface(
 	fun render(): String = buildString {
 		for (rowIndex in 0 until height) {
 			if (rowIndex > 0) {
-				append('\n')
+				append("\r\n")
 			}
 			appendRowTo(this, rowIndex)
 		}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/rendering.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/rendering.kt
@@ -89,7 +89,7 @@ internal class AnsiRendering : Rendering {
 						// We have previously drawn on this line. Clear the rest to be safe.
 						append(clearLine)
 					}
-					append('\n')
+					append("\r\n")
 				}
 			}
 
@@ -107,7 +107,7 @@ internal class AnsiRendering : Rendering {
 			// If the new output contains fewer lines than the last output, clear those old lines.
 			for (i in 0 until staleLines) {
 				if (i > 0) {
-					append('\n')
+					append("\r\n")
 				}
 				append(clearLine)
 			}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
@@ -25,7 +25,7 @@ class AnsiRenderingTest {
 			|Hello$s
 			|World!
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF()
 		)
 	}
 
@@ -42,7 +42,7 @@ class AnsiRenderingTest {
 			|Hello$s
 			|World!
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 
 		val second = mosaicNodes {
@@ -61,7 +61,7 @@ class AnsiRenderingTest {
 			|Wor
 			|ld!
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -82,7 +82,7 @@ class AnsiRenderingTest {
 			|Wor
 			|ld!
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 
 		val second = mosaicNodes {
@@ -98,7 +98,7 @@ class AnsiRenderingTest {
 			|World!$clearLine
 			|$clearLine
 			|$clearLine$cursorUp
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -115,7 +115,7 @@ class AnsiRenderingTest {
 			|World!
 			|Hello
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -132,7 +132,7 @@ class AnsiRenderingTest {
 			|One
 			|Two
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 
 		val second = mosaicNodes {
@@ -147,7 +147,7 @@ class AnsiRenderingTest {
 			|${cursorUp}Three$clearLine
 			|Four
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -184,7 +184,7 @@ class AnsiRenderingTest {
 			|Five
 			|Sup
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -207,7 +207,7 @@ class AnsiRenderingTest {
 			|TopTopTop
 			|LeftLeft$s
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 }

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
@@ -25,7 +25,7 @@ class AnsiRenderingTest {
 			|Hello$s
 			|World!
 			|
-			""".trimMargin().replaceLineEndingsWithCRLF()
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/LayoutTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/LayoutTest.kt
@@ -46,7 +46,7 @@ class LayoutTest {
 		val expected = """
 			|  $s
 			|
-		""".trimMargin()
+		""".trimMargin().replaceLineEndingsWithCRLF()
 		assertThat(actual).isEqualTo(expected)
 	}
 
@@ -67,7 +67,7 @@ class LayoutTest {
 		val expected = """
 			|ABC
 			|
-		""".trimMargin()
+		""".trimMargin().replaceLineEndingsWithCRLF()
 		assertThat(actual).isEqualTo(expected)
 	}
 
@@ -91,7 +91,7 @@ class LayoutTest {
 			|  BB   $s
 			|A      $s
 			|
-		""".trimMargin()
+		""".trimMargin().replaceLineEndingsWithCRLF()
 		assertThat(actual).isEqualTo(expected)
 	}
 
@@ -130,7 +130,7 @@ class LayoutTest {
 			|...XXX
 			|.....X
 			|
-		""".trimMargin()
+		""".trimMargin().replaceLineEndingsWithCRLF()
 		assertThat(actual).isEqualTo(expected)
 	}
 }

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/MosaicTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/MosaicTest.kt
@@ -21,7 +21,7 @@ class MosaicTest {
 			|Two $s
 			|Three
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 }

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/OffsetTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/OffsetTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.TestChar
 import com.jakewharton.mosaic.TestFiller
+import com.jakewharton.mosaic.replaceLineEndingsWithCRLF
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.renderMosaic
 import com.jakewharton.mosaic.s
@@ -28,7 +29,7 @@ class OffsetTest {
 			|     $s
 			|     $s
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -67,7 +68,7 @@ class OffsetTest {
 			|$TestChar    $s
 			|     $s
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -106,7 +107,7 @@ class OffsetTest {
 			|   $TestChar $s
 			|     $s
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -150,7 +151,7 @@ class OffsetTest {
 			|     $s
 			|     $s
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -189,7 +190,7 @@ class OffsetTest {
 			|$TestChar    $s
 			|     $s
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -228,7 +229,7 @@ class OffsetTest {
 			|   $TestChar $s
 			|     $s
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/OffsetTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/OffsetTest.kt
@@ -4,9 +4,9 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.TestChar
 import com.jakewharton.mosaic.TestFiller
-import com.jakewharton.mosaic.replaceLineEndingsWithCRLF
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.renderMosaic
+import com.jakewharton.mosaic.replaceLineEndingsWithCRLF
 import com.jakewharton.mosaic.s
 import com.jakewharton.mosaic.ui.Box
 import com.jakewharton.mosaic.ui.unit.IntOffset

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/PaddingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/PaddingTest.kt
@@ -6,9 +6,9 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.Container
 import com.jakewharton.mosaic.TestChar
 import com.jakewharton.mosaic.TestFiller
-import com.jakewharton.mosaic.replaceLineEndingsWithCRLF
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.renderMosaic
+import com.jakewharton.mosaic.replaceLineEndingsWithCRLF
 import com.jakewharton.mosaic.s
 import com.jakewharton.mosaic.testIntrinsics
 import com.jakewharton.mosaic.ui.Layout

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/PaddingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/PaddingTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.Container
 import com.jakewharton.mosaic.TestChar
 import com.jakewharton.mosaic.TestFiller
+import com.jakewharton.mosaic.replaceLineEndingsWithCRLF
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.renderMosaic
 import com.jakewharton.mosaic.s
@@ -40,7 +41,7 @@ class PaddingTest {
 			"""
 			|$TestChar
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -52,7 +53,7 @@ class PaddingTest {
 			"""
 			|  $TestChar
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -75,7 +76,7 @@ class PaddingTest {
 			"""
 			|$TestChar
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -89,7 +90,7 @@ class PaddingTest {
 			|$s
 			|$TestChar
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -112,7 +113,7 @@ class PaddingTest {
 			"""
 			|$TestChar
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -124,7 +125,7 @@ class PaddingTest {
 			"""
 			|$TestChar $s
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -147,7 +148,7 @@ class PaddingTest {
 			"""
 			|$TestChar
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -161,7 +162,7 @@ class PaddingTest {
 			|$s
 			|$s
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -184,7 +185,7 @@ class PaddingTest {
 			"""
 			|$TestChar
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 
@@ -198,7 +199,7 @@ class PaddingTest {
 			| $s
 			| $s
 			|
-			""".trimMargin(),
+			""".trimMargin().replaceLineEndingsWithCRLF(),
 		)
 	}
 

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/stuff.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/stuff.kt
@@ -23,6 +23,10 @@ const val s = " "
 
 const val TestChar = 'X'
 
+fun String.replaceLineEndingsWithCRLF(): String {
+	return this.replace("\n", "\r\n")
+}
+
 fun <T> snapshotStateListOf(vararg values: T): SnapshotStateList<T> {
 	return SnapshotStateList<T>().apply { addAll(values) }
 }


### PR DESCRIPTION
Fixes https://github.com/JakeWharton/mosaic/issues/336

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
