### PR TITLE
Support synchronized update for rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 New:
-- Nothing yet!
+- Support synchronized terminal update for rendering.
 
 Changed:
 - Nothing yet!

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ansi.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ansi.kt
@@ -8,6 +8,9 @@ import kotlin.math.roundToInt
 private const val ESC = "\u001B"
 internal const val CSI = "$ESC["
 
+internal const val ansiBeginSynchronizedUpdate = "$CSI?2026h"
+internal const val ansiEndSynchronizedUpdate = "$CSI?2026l"
+
 internal const val ansiReset = "${CSI}0"
 internal const val clearLine = "${CSI}K"
 internal const val cursorUp = "${CSI}F"

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -77,7 +77,7 @@ public suspend fun runMosaic(body: suspend MosaicScope.() -> Unit): Unit = corou
 	var displaySignal: CompletableDeferred<Unit>? = null
 	val applier = MosaicNodeApplier(rootNode) {
 		val render = rendering.render(rootNode)
-		platformDisplay(render)
+		platformDisplay("$ansiBeginSynchronizedUpdate$render$ansiEndSynchronizedUpdate")
 
 		displaySignal?.complete(Unit)
 		hasFrameWaiters = false


### PR DESCRIPTION
I am not 100% sure of the solution, but it seems that it is possible to use this, since those who do not support the terminal feature simply will not react in any way. I'm not sure yet, because I couldn't come up with a sample case that would show the real difference, everything was always fine in both cases.

Closes https://github.com/JakeWharton/mosaic/issues/108