### PR TITLE
Remove autoboxing and object creation from multiple locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ New:
 Changed:
 - Disable klib signature clash checks for JS compilations. These occasionally occur as a result of Compose compiler behavior, and are safe to disable (the first-party JetBrains Compose Gradle plugin also disables them).
 - Remove `Terminal$Size` and use `IntSize` instead in `Terminal#size` for optimization purposes.
-- Remove Color.Bright* constants. Use Color to create the desired color.
+- Remove `Color.Bright*` constants. Use `Color` function to create the desired color.
+- Replace nullable `Color` and `TextStyle` with `Color.Unspecified` and `TextStyle.Unspecified` respectively. Also make `TextStyle` an inline class.
 
 Fixed:
 - Use CRLF line endings to fix rendering when a terminal is in raw mode.

--- a/mosaic-runtime/api/mosaic-runtime.api
+++ b/mosaic-runtime/api/mosaic-runtime.api
@@ -49,10 +49,10 @@ public final class com/jakewharton/mosaic/layout/DrawModifierKt {
 public abstract interface class com/jakewharton/mosaic/layout/DrawScope {
 	public abstract fun drawRect-e5kUBSE (IIIII)V
 	public static synthetic fun drawRect-e5kUBSE$default (Lcom/jakewharton/mosaic/layout/DrawScope;IIIIIILjava/lang/Object;)V
-	public abstract fun drawText-HJtvjdw (IILcom/jakewharton/mosaic/text/AnnotatedString;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/TextStyle;)V
-	public abstract fun drawText-HJtvjdw (IILjava/lang/String;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/TextStyle;)V
-	public static synthetic fun drawText-HJtvjdw$default (Lcom/jakewharton/mosaic/layout/DrawScope;IILcom/jakewharton/mosaic/text/AnnotatedString;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/TextStyle;ILjava/lang/Object;)V
-	public static synthetic fun drawText-HJtvjdw$default (Lcom/jakewharton/mosaic/layout/DrawScope;IILjava/lang/String;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/TextStyle;ILjava/lang/Object;)V
+	public abstract fun drawText-8Xo7vWM (IILcom/jakewharton/mosaic/text/AnnotatedString;III)V
+	public abstract fun drawText-8Xo7vWM (IILjava/lang/String;III)V
+	public static synthetic fun drawText-8Xo7vWM$default (Lcom/jakewharton/mosaic/layout/DrawScope;IILcom/jakewharton/mosaic/text/AnnotatedString;IIIILjava/lang/Object;)V
+	public static synthetic fun drawText-8Xo7vWM$default (Lcom/jakewharton/mosaic/layout/DrawScope;IILjava/lang/String;IIIILjava/lang/Object;)V
 	public abstract fun getHeight ()I
 	public abstract fun getWidth ()I
 }
@@ -268,14 +268,14 @@ public final class com/jakewharton/mosaic/text/AnnotatedStringKt {
 
 public final class com/jakewharton/mosaic/text/SpanStyle {
 	public static final field $stable I
-	public synthetic fun <init> (Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/TextStyle;Lcom/jakewharton/mosaic/ui/Color;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/TextStyle;Lcom/jakewharton/mosaic/ui/Color;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy-0C4kZ_4 (Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/TextStyle;Lcom/jakewharton/mosaic/ui/Color;)Lcom/jakewharton/mosaic/text/SpanStyle;
-	public static synthetic fun copy-0C4kZ_4$default (Lcom/jakewharton/mosaic/text/SpanStyle;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/TextStyle;Lcom/jakewharton/mosaic/ui/Color;ILjava/lang/Object;)Lcom/jakewharton/mosaic/text/SpanStyle;
+	public synthetic fun <init> (IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy-64_Jk1s (III)Lcom/jakewharton/mosaic/text/SpanStyle;
+	public static synthetic fun copy-64_Jk1s$default (Lcom/jakewharton/mosaic/text/SpanStyle;IIIILjava/lang/Object;)Lcom/jakewharton/mosaic/text/SpanStyle;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBackground-xbxrsts ()Lcom/jakewharton/mosaic/ui/Color;
-	public final fun getColor-xbxrsts ()Lcom/jakewharton/mosaic/ui/Color;
-	public final fun getTextStyle ()Lcom/jakewharton/mosaic/ui/TextStyle;
+	public final fun getBackground-OrXnJU4 ()I
+	public final fun getColor-OrXnJU4 ()I
+	public final fun getTextStyle-4EWmQI8 ()I
 	public fun hashCode ()I
 	public final fun merge (Lcom/jakewharton/mosaic/text/SpanStyle;)Lcom/jakewharton/mosaic/text/SpanStyle;
 	public static synthetic fun merge$default (Lcom/jakewharton/mosaic/text/SpanStyle;Lcom/jakewharton/mosaic/text/SpanStyle;ILjava/lang/Object;)Lcom/jakewharton/mosaic/text/SpanStyle;
@@ -422,13 +422,18 @@ public final class com/jakewharton/mosaic/ui/Color$Companion {
 	public final fun getGreen-OrXnJU4 ()I
 	public final fun getMagenta-OrXnJU4 ()I
 	public final fun getRed-OrXnJU4 ()I
+	public final fun getUnspecified-OrXnJU4 ()I
 	public final fun getWhite-OrXnJU4 ()I
 	public final fun getYellow-OrXnJU4 ()I
 }
 
 public final class com/jakewharton/mosaic/ui/ColorKt {
+	public static final field UnspecifiedColor I
 	public static final fun Color (FFF)I
 	public static final fun Color (III)I
+	public static final fun isSpecifiedColor-ZsyVsVM (I)Z
+	public static final fun isUnspecifiedColor-ZsyVsVM (I)Z
+	public static final fun takeOrElse-ZKdZ-WM (ILkotlin/jvm/functions/Function0;)I
 }
 
 public final class com/jakewharton/mosaic/ui/Column {
@@ -463,7 +468,7 @@ public final class com/jakewharton/mosaic/ui/ComposableSingletons$SpacerKt {
 }
 
 public final class com/jakewharton/mosaic/ui/FillerKt {
-	public static final fun Filler-g8kd68k (CLcom/jakewharton/mosaic/modifier/Modifier;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Filler-GddN7rU (CLcom/jakewharton/mosaic/modifier/Modifier;IIILandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/jakewharton/mosaic/ui/Layout {
@@ -495,25 +500,44 @@ public final class com/jakewharton/mosaic/ui/Static {
 }
 
 public final class com/jakewharton/mosaic/ui/Text {
-	public static final fun Text-g8kd68k (Lcom/jakewharton/mosaic/text/AnnotatedString;Lcom/jakewharton/mosaic/modifier/Modifier;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/TextStyle;Landroidx/compose/runtime/Composer;II)V
-	public static final fun Text-g8kd68k (Ljava/lang/String;Lcom/jakewharton/mosaic/modifier/Modifier;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/Color;Lcom/jakewharton/mosaic/ui/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Text-GddN7rU (Lcom/jakewharton/mosaic/text/AnnotatedString;Lcom/jakewharton/mosaic/modifier/Modifier;IIILandroidx/compose/runtime/Composer;II)V
+	public static final fun Text-GddN7rU (Ljava/lang/String;Lcom/jakewharton/mosaic/modifier/Modifier;IIILandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/jakewharton/mosaic/ui/TextStyle {
-	public static final field $stable I
 	public static final field Companion Lcom/jakewharton/mosaic/ui/TextStyle$Companion;
-	public final fun contains (Lcom/jakewharton/mosaic/ui/TextStyle;)Z
-	public final fun plus (Lcom/jakewharton/mosaic/ui/TextStyle;)Lcom/jakewharton/mosaic/ui/TextStyle;
+	public static final synthetic fun box-impl (I)Lcom/jakewharton/mosaic/ui/TextStyle;
+	public static final fun contains-kLqBjOQ (II)Z
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public static final fun plus-h7PR1DU (II)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
 }
 
 public final class com/jakewharton/mosaic/ui/TextStyle$Companion {
-	public final fun getBold ()Lcom/jakewharton/mosaic/ui/TextStyle;
-	public final fun getDim ()Lcom/jakewharton/mosaic/ui/TextStyle;
-	public final fun getInvert ()Lcom/jakewharton/mosaic/ui/TextStyle;
-	public final fun getItalic ()Lcom/jakewharton/mosaic/ui/TextStyle;
-	public final fun getNone ()Lcom/jakewharton/mosaic/ui/TextStyle;
-	public final fun getStrikethrough ()Lcom/jakewharton/mosaic/ui/TextStyle;
-	public final fun getUnderline ()Lcom/jakewharton/mosaic/ui/TextStyle;
+	public final fun getBold-4EWmQI8 ()I
+	public final fun getDim-4EWmQI8 ()I
+	public final fun getEmpty-4EWmQI8 ()I
+	public final fun getInvert-4EWmQI8 ()I
+	public final fun getItalic-4EWmQI8 ()I
+	public final fun getStrikethrough-4EWmQI8 ()I
+	public final fun getUnderline-4EWmQI8 ()I
+	public final fun getUnspecified-4EWmQI8 ()I
+}
+
+public final class com/jakewharton/mosaic/ui/TextStyleKt {
+	public static final field EmptyTextStyle I
+	public static final field UnspecifiedTextStyle I
+	public static final fun isEmptyTextStyle-kLqBjOQ (I)Z
+	public static final fun isNotEmptyTextStyle-kLqBjOQ (I)Z
+	public static final fun isSpecifiedTextStyle-kLqBjOQ (I)Z
+	public static final fun isUnspecifiedTextStyle-kLqBjOQ (I)Z
+	public static final fun takeOrElse-XIQd4Uw (ILkotlin/jvm/functions/Function0;)I
 }
 
 public final class com/jakewharton/mosaic/ui/unit/Constraints {

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawScope.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawScope.kt
@@ -22,6 +22,9 @@ import com.jakewharton.mosaic.text.SpanStyle
 import com.jakewharton.mosaic.text.getLocalRawSpanStyles
 import com.jakewharton.mosaic.ui.Color
 import com.jakewharton.mosaic.ui.TextStyle
+import com.jakewharton.mosaic.ui.isSpecifiedColor
+import com.jakewharton.mosaic.ui.isSpecifiedTextStyle
+import de.cketti.codepoints.codePointAt
 
 public interface DrawScope {
 	public val width: Int
@@ -39,18 +42,18 @@ public interface DrawScope {
 		row: Int,
 		column: Int,
 		string: String,
-		foreground: Color? = null,
-		background: Color? = null,
-		style: TextStyle? = null,
+		foreground: Color = Color.Unspecified,
+		background: Color = Color.Unspecified,
+		textStyle: TextStyle = TextStyle.Unspecified,
 	)
 
 	public fun drawText(
 		row: Int,
 		column: Int,
 		string: AnnotatedString,
-		foreground: Color? = null,
-		background: Color? = null,
-		style: TextStyle? = null,
+		foreground: Color = Color.Unspecified,
+		background: Color = Color.Unspecified,
+		textStyle: TextStyle = TextStyle.Unspecified,
 	)
 }
 
@@ -77,22 +80,22 @@ internal open class TextCanvasDrawScope(
 		row: Int,
 		column: Int,
 		string: String,
-		foreground: Color?,
-		background: Color?,
-		style: TextStyle?,
+		foreground: Color,
+		background: Color,
+		textStyle: TextStyle,
 	) {
-		drawText(row, column, string, foreground, background, style, null)
+		drawText(row, column, string, foreground, background, textStyle, null)
 	}
 
 	override fun drawText(
 		row: Int,
 		column: Int,
 		string: AnnotatedString,
-		foreground: Color?,
-		background: Color?,
-		style: TextStyle?,
+		foreground: Color,
+		background: Color,
+		textStyle: TextStyle,
 	) {
-		drawText(row, column, string.text, foreground, background, style) { start, end ->
+		drawText(row, column, string.text, foreground, background, textStyle) { start, end ->
 			string.getLocalRawSpanStyles(start, end)
 		}
 	}
@@ -101,9 +104,9 @@ internal open class TextCanvasDrawScope(
 		row: Int,
 		column: Int,
 		text: String,
-		foreground: Color?,
-		background: Color?,
-		style: TextStyle?,
+		foreground: Color,
+		background: Color,
+		textStyle: TextStyle,
 		spanStylesProvider: ((start: Int, end: Int) -> List<SpanStyle>)?,
 	) {
 		var pixelIndex = 0
@@ -117,23 +120,23 @@ internal open class TextCanvasDrawScope(
 				pixelIndex + 1
 			}
 
-			character.value = text.substring(pixelIndex, pixelEnd)
+			character.codePoint = text.codePointAt(pixelIndex)
 			val spanStyles = spanStylesProvider?.invoke(pixelIndex, pixelEnd)
 			pixelIndex = pixelEnd
 
-			fun maybeUpdateCharacter(background: Color?, foreground: Color?, style: TextStyle?) {
-				if (background != null) {
+			fun maybeUpdateCharacter(background: Color, foreground: Color, style: TextStyle) {
+				if (background.isSpecifiedColor) {
 					character.background = background
 				}
-				if (foreground != null) {
+				if (foreground.isSpecifiedColor) {
 					character.foreground = foreground
 				}
-				if (style != null) {
-					character.style = style
+				if (style.isSpecifiedTextStyle) {
+					character.textStyle = style
 				}
 			}
 
-			maybeUpdateCharacter(background, foreground, style)
+			maybeUpdateCharacter(background, foreground, textStyle)
 			spanStyles?.forEach {
 				maybeUpdateCharacter(it.background, it.color, it.textStyle)
 			}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/SpanStyle.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/SpanStyle.kt
@@ -4,12 +4,13 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import com.jakewharton.mosaic.ui.Color
 import com.jakewharton.mosaic.ui.TextStyle
+import com.jakewharton.mosaic.ui.takeOrElse
 
 @Immutable
-public class SpanStyle constructor(
-	public val color: Color? = null,
-	public val textStyle: TextStyle? = null,
-	public val background: Color? = null,
+public class SpanStyle(
+	public val color: Color = Color.Unspecified,
+	public val textStyle: TextStyle = TextStyle.Unspecified,
+	public val background: Color = Color.Unspecified,
 ) {
 
 	/**
@@ -25,9 +26,9 @@ public class SpanStyle constructor(
 	public fun merge(other: SpanStyle? = null): SpanStyle {
 		if (other == null) return this
 		return SpanStyle(
-			color = other.color ?: this.color,
-			textStyle = other.textStyle ?: this.textStyle,
-			background = other.background ?: this.background,
+			color = other.color.takeOrElse { this.color },
+			textStyle = other.textStyle.takeOrElse { this.textStyle },
+			background = other.background.takeOrElse { this.background },
 		)
 	}
 
@@ -38,9 +39,9 @@ public class SpanStyle constructor(
 	public operator fun plus(other: SpanStyle): SpanStyle = this.merge(other)
 
 	public fun copy(
-		color: Color? = this.color,
-		textStyle: TextStyle? = this.textStyle,
-		background: Color? = this.background,
+		color: Color = this.color,
+		textStyle: TextStyle = this.textStyle,
+		background: Color = this.background,
 	): SpanStyle {
 		return SpanStyle(
 			color = color,
@@ -63,9 +64,9 @@ public class SpanStyle constructor(
 	}
 
 	override fun hashCode(): Int {
-		var result = color?.hashCode() ?: 0
-		result = 31 * result + (textStyle?.hashCode() ?: 0)
-		result = 31 * result + (background?.hashCode() ?: 0)
+		var result = color.hashCode()
+		result = 31 * result + textStyle.hashCode()
+		result = 31 * result + background.hashCode()
 		return result
 	}
 

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Color.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Color.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
 package com.jakewharton.mosaic.ui
 
 import androidx.compose.runtime.Immutable
@@ -7,7 +9,8 @@ import kotlin.jvm.JvmInline
 @Immutable
 @JvmInline
 public value class Color internal constructor(
-	private val value: Int,
+	@PublishedApi
+	internal val value: Int,
 ) {
 	override fun toString(): String = "Color($redInt, $greenInt, $blueInt)"
 
@@ -85,6 +88,9 @@ public value class Color internal constructor(
 
 	public companion object {
 		@Stable
+		public val Unspecified: Color = Color(UnspecifiedColor)
+
+		@Stable
 		public val Black: Color = Color(0x000000)
 
 		@Stable
@@ -109,6 +115,9 @@ public value class Color internal constructor(
 		public val White: Color = Color(0xFFFFFF)
 	}
 }
+
+@PublishedApi
+internal const val UnspecifiedColor: Int = Int.MIN_VALUE
 
 /**
  * Creates a new [Color] instance from an RGB color components.
@@ -154,3 +163,21 @@ public fun Color(red: Int, green: Int, blue: Int): Color {
 
 	return Color(rgb)
 }
+
+/**
+ * `false` when this is [Color.Unspecified].
+ */
+@Stable
+public inline val Color.isSpecifiedColor: Boolean get() = value != UnspecifiedColor
+
+/**
+ * `true` when this is [Color.Unspecified].
+ */
+@Stable
+public inline val Color.isUnspecifiedColor: Boolean get() = value == UnspecifiedColor
+
+/**
+ * If this color [isSpecifiedColor] then this is returned, otherwise [block] is executed and its result
+ * is returned.
+ */
+public inline fun Color.takeOrElse(block: () -> Color): Color = if (isSpecifiedColor) this else block()

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Filler.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Filler.kt
@@ -24,9 +24,9 @@ import com.jakewharton.mosaic.ui.unit.Constraints
 public fun Filler(
 	char: Char,
 	modifier: Modifier = Modifier,
-	foreground: Color? = null,
-	background: Color? = null,
-	style: TextStyle? = null,
+	foreground: Color = Color.Unspecified,
+	background: Color = Color.Unspecified,
+	textStyle: TextStyle = TextStyle.Unspecified,
 ) {
 	Layout(
 		content = EmptyFillerContent,
@@ -35,7 +35,7 @@ public fun Filler(
 		modifier = modifier.drawBehind {
 			val line = char.toString().repeat(width)
 			repeat(height) { row ->
-				drawText(row, 0, line, foreground, background, style)
+				drawText(row, 0, line, foreground, background, textStyle)
 			}
 		},
 	)

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Text.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Text.kt
@@ -16,9 +16,9 @@ import kotlin.jvm.JvmName
 public fun Text(
 	value: String,
 	modifier: Modifier = Modifier,
-	color: Color? = null,
-	background: Color? = null,
-	style: TextStyle? = null,
+	color: Color = Color.Unspecified,
+	background: Color = Color.Unspecified,
+	textStyle: TextStyle = TextStyle.Unspecified,
 ) {
 	val layout = remember { StringTextLayout() }
 	layout.value = value
@@ -33,7 +33,7 @@ public fun Text(
 		},
 		modifier = modifier.drawBehind {
 			layout.lines.forEachIndexed { row, line ->
-				drawText(row, 0, line, color, background, style)
+				drawText(row, 0, line, color, background, textStyle)
 			}
 		},
 	)
@@ -44,9 +44,9 @@ public fun Text(
 public fun Text(
 	value: AnnotatedString,
 	modifier: Modifier = Modifier,
-	color: Color? = null,
-	background: Color? = null,
-	style: TextStyle? = null,
+	color: Color = Color.Unspecified,
+	background: Color = Color.Unspecified,
+	textStyle: TextStyle = TextStyle.Unspecified,
 ) {
 	val layout = remember { AnnotatedStringTextLayout() }
 	layout.value = value
@@ -61,7 +61,7 @@ public fun Text(
 		},
 		modifier = modifier.drawBehind {
 			layout.lines.forEachIndexed { row, line ->
-				drawText(row, 0, line, color, background, style)
+				drawText(row, 0, line, color, background, textStyle)
 			}
 		},
 	)

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/TextStyle.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/TextStyle.kt
@@ -1,35 +1,141 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
 package com.jakewharton.mosaic.ui
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
+import kotlin.jvm.JvmInline
 
 @Immutable
-public class TextStyle private constructor(
-	private val bits: Int,
+@JvmInline
+public value class TextStyle internal constructor(
+	@PublishedApi
+	internal val bits: Int,
 ) {
 	public operator fun plus(other: TextStyle): TextStyle = TextStyle(bits or other.bits)
-	public operator fun contains(style: TextStyle): Boolean = (style.bits and bits) != 0
+	public operator fun contains(other: TextStyle): Boolean = (bits and other.bits) == other.bits
 
 	public companion object {
+		/**
+		 * It is needed to indicate that there is no style (not the same as an [Empty] one),
+		 * since it does not replace the style that was previously specified.
+		 *
+		 * In the example below, we will get `789456` in the console, where everything will be in bold,
+		 * as indicated in the first [Text]. The second [Text] changes `123` to `789`,
+		 * but does not change the previously specified style in any way.
+		 *
+		 * ```kotlin
+		 * Box {
+		 * 	Text("123456", textStyle = TextStyle.Invert)
+		 * 	Text("789", textStyle = TextStyle.Unspecified)
+		 * }
+		 * ```
+		 *
+		 * or (because [TextStyle.Unspecified] is specified by default)
+		 *
+		 * ```kotlin
+		 * Box {
+		 * 	Text("123456", textStyle = TextStyle.Invert)
+		 * 	Text("789")
+		 * }
+		 * ```
+		 *
+		 * Output to the console:
+		 * **789456**
+		 *
+		 * When adding other styles to this, when using the [plus] operator,
+		 * the added styles will be applied.
+		 *
+		 * If you need to reset the style, then explicitly use [TextStyle.Empty].
+		 *
+		 * @see TextStyle.Empty
+		 */
 		@Stable
-		public val None: TextStyle = TextStyle(0)
+		public val Unspecified: TextStyle = TextStyle(UnspecifiedTextStyle)
+
+		/**
+		 * It is needed to indicate that this style is empty and the rest of the styles
+		 * need to be reset.
+		 *
+		 * In the example below, we will get `789456` in the console,
+		 * where `789` will be without any style, and `456` will be in bold,
+		 * as indicated in the first [Text]. The second [Text] with the content change to `789`
+		 * will also reset the previously specified style.
+		 *
+		 * ```kotlin
+		 * Box {
+		 * 	Text("123456", textStyle = TextStyle.Bold)
+		 * 	Text("789", textStyle = TextStyle.Empty)
+		 * }
+		 * ```
+		 *
+		 * Output to the console:
+		 * 789**456**
+		 *
+		 * When adding other styles to this, when using the [plus] operator,
+		 * the added styles will be applied.
+		 *
+		 * If you do not need to change the style specified earlier in any way,
+		 * you can use [TextStyle.Unspecified].
+		 *
+		 * @see TextStyle.Unspecified
+		 */
+		@Stable
+		public val Empty: TextStyle = TextStyle(EmptyTextStyle)
 
 		@Stable
-		public val Underline: TextStyle = TextStyle(1)
+		public val Underline: TextStyle = TextStyle(2)
 
 		@Stable
-		public val Strikethrough: TextStyle = TextStyle(2)
+		public val Strikethrough: TextStyle = TextStyle(4)
 
 		@Stable
-		public val Bold: TextStyle = TextStyle(4)
+		public val Bold: TextStyle = TextStyle(8)
 
 		@Stable
-		public val Dim: TextStyle = TextStyle(8)
+		public val Dim: TextStyle = TextStyle(16)
 
 		@Stable
-		public val Italic: TextStyle = TextStyle(16)
+		public val Italic: TextStyle = TextStyle(32)
 
 		@Stable
-		public val Invert: TextStyle = TextStyle(32)
+		public val Invert: TextStyle = TextStyle(64)
 	}
 }
+
+@PublishedApi
+internal const val UnspecifiedTextStyle: Int = 0
+
+@PublishedApi
+internal const val EmptyTextStyle: Int = 1
+
+/**
+ * `false` when this is [TextStyle.Unspecified].
+ */
+@Stable
+public inline val TextStyle.isSpecifiedTextStyle: Boolean get() = bits != UnspecifiedTextStyle
+
+/**
+ * `true` when this is [TextStyle.Unspecified].
+ */
+@Stable
+public inline val TextStyle.isUnspecifiedTextStyle: Boolean get() = bits == UnspecifiedTextStyle
+
+/**
+ * `false` when this is [TextStyle.Empty].
+ */
+@Stable
+public inline val TextStyle.isNotEmptyTextStyle: Boolean get() = bits != EmptyTextStyle
+
+/**
+ * `true` when this is [TextStyle.Empty].
+ */
+@Stable
+public inline val TextStyle.isEmptyTextStyle: Boolean get() = bits == EmptyTextStyle
+
+/**
+ * If this text style [isSpecifiedTextStyle] then this is returned, otherwise [block] is executed and its result
+ * is returned.
+ */
+public inline fun TextStyle.takeOrElse(block: () -> TextStyle): TextStyle =
+	if (isSpecifiedTextStyle) this else block()

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/unit/IntSize.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/unit/IntSize.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
 package com.jakewharton.mosaic.ui.unit
 
 import androidx.compose.runtime.Immutable

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/stuff.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/stuff.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
 package com.jakewharton.mosaic
 
 import androidx.compose.runtime.Composable

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/text/SpanStyleTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/text/SpanStyleTest.kt
@@ -2,7 +2,6 @@ package com.jakewharton.mosaic.text
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import assertk.assertions.isNull
 import com.jakewharton.mosaic.ui.Color
 import com.jakewharton.mosaic.ui.TextStyle
 import kotlin.test.Test
@@ -12,9 +11,9 @@ class SpanStyleTest {
 	@Test fun constructorWithDefaultValues() {
 		val style = SpanStyle()
 
-		assertThat(style.color).isNull()
-		assertThat(style.textStyle).isNull()
-		assertThat(style.background).isNull()
+		assertThat(style.color).isEqualTo(Color.Unspecified)
+		assertThat(style.textStyle).isEqualTo(TextStyle.Unspecified)
+		assertThat(style.background).isEqualTo(Color.Unspecified)
 	}
 
 	@Test fun constructorWithCustomizedColor() {
@@ -52,7 +51,7 @@ class SpanStyleTest {
 	@Test fun mergeWithOthersColorIsNullShouldUseThisColor() {
 		val style = SpanStyle(color = Color.Red)
 
-		val newSpanStyle = style.merge(SpanStyle(color = null))
+		val newSpanStyle = style.merge(SpanStyle(color = Color.Unspecified))
 
 		assertThat(newSpanStyle.color).isEqualTo(style.color)
 	}
@@ -69,7 +68,7 @@ class SpanStyleTest {
 	@Test fun mergeWithOthersTextStyleIsNullShouldUseThisTextStyle() {
 		val style = SpanStyle(textStyle = TextStyle.Underline)
 
-		val newSpanStyle = style.merge(SpanStyle(textStyle = null))
+		val newSpanStyle = style.merge(SpanStyle(textStyle = TextStyle.Unspecified))
 
 		assertThat(newSpanStyle.textStyle).isEqualTo(style.textStyle)
 	}
@@ -86,7 +85,7 @@ class SpanStyleTest {
 	@Test fun mergeWithOthersBackgroundIsNullShouldUseThisBackground() {
 		val style = SpanStyle(background = Color.Red)
 
-		val newSpanStyle = style.merge(SpanStyle(background = null))
+		val newSpanStyle = style.merge(SpanStyle(background = Color.Unspecified))
 
 		assertThat(newSpanStyle.background).isEqualTo(style.background)
 	}

--- a/samples/demo/src/main/kotlin/example/demo.kt
+++ b/samples/demo/src/main/kotlin/example/demo.kt
@@ -17,6 +17,7 @@ import com.jakewharton.mosaic.ui.Filler
 import com.jakewharton.mosaic.ui.Row
 import com.jakewharton.mosaic.ui.Spacer
 import com.jakewharton.mosaic.ui.Text
+import com.jakewharton.mosaic.ui.TextStyle
 import kotlinx.coroutines.suspendCancellableCoroutine
 
 private val BrightGreen = Color(100, 255, 100)
@@ -28,21 +29,25 @@ fun main() = runMosaicBlocking {
 			val terminal = LocalTerminal.current
 			Text(
 				buildAnnotatedString {
+					append("\uD83D\uDDA5\uFE0F")
+					append("  ")
 					append("Terminal(")
 					withStyle(SpanStyle(color = BrightGreen)) {
 						append("width=")
 					}
-					withStyle(SpanStyle(color = BrightBlue)) {
+					withStyle(SpanStyle(color = BrightBlue, textStyle = TextStyle.Bold + TextStyle.Underline)) {
 						append(terminal.size.width.toString())
 					}
 					append(", ")
 					withStyle(SpanStyle(color = BrightGreen)) {
 						append("height=")
 					}
-					withStyle(SpanStyle(color = BrightBlue)) {
+					withStyle(SpanStyle(color = BrightBlue, textStyle = TextStyle.Bold + TextStyle.Underline)) {
 						append(terminal.size.height.toString())
 					}
 					append(")")
+					append(" ")
+					append("\uD83D\uDDA5\uFE0F")
 				},
 			)
 			Spacer(modifier = Modifier.height(1))

--- a/samples/rrtop/src/main/kotlin/example/common/Border.kt
+++ b/samples/rrtop/src/main/kotlin/example/common/Border.kt
@@ -17,7 +17,7 @@ fun Modifier.border(
 	verticalEnd: Char = '│',
 	horizontalTop: Char = '─',
 	horizontalBottom: Char = '─',
-	color: Color? = null,
+	color: Color = Color.Unspecified,
 ): Modifier = this.then(
 	BorderModifier(
 		topStart.toString(),
@@ -41,7 +41,7 @@ private class BorderModifier(
 	private val verticalEnd: String,
 	private val horizontalTop: String,
 	private val horizontalBottom: String,
-	private val color: Color?,
+	private val color: Color,
 ) : DrawModifier {
 
 	override fun ContentDrawScope.draw() {
@@ -91,7 +91,7 @@ private class BorderModifier(
 		result = 31 * result + bottomEnd.hashCode()
 		result = 31 * result + horizontalBottom.hashCode()
 		result = 31 * result + bottomStart.hashCode()
-		result = 31 * result + (color?.hashCode() ?: 0)
+		result = 31 * result + color.hashCode()
 		return result
 	}
 


### PR DESCRIPTION
- Add `Color.Unspecified` for replace nullable `Color`
- Add some extension functions for `Color` to check on `Color.Unspecified`
- Use `TextStyle.Null` instead null for `TextStyle`
- Add some extension functions for `TextStyle` to check on `TextStyle.Null` and `TextStyle.None`
- Make `TextStyle` an inline class
- Using `Int` as codepoint (`TextPixel#codePoint`) instead of `String` in `TextPixel` (`TextPixel#value`)
- Rename `style: TextStyle` to `textStyle: TextStyle` for clearer and less confusing naming, as there are several other styles
- Add emoji to demo sample and use of 2 styles for part of the text
    <img width="400" alt="image" src="https://github.com/JakeWharton/mosaic/assets/37583380/f7345167-e176-4f89-b84f-52c46cfd4272">
