### PR TITLE
Modify `DrawScope#drawRect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New:
 - Nothing yet!
 
 Changed:
-- Nothing yet!
+- Сhange `DrawScope#drawRect` API with the ability to draw with text characters and specify `DrawStyle` (`Fill` or `Stroke`).
 
 Fixed:
 - Nothing yet!

--- a/mosaic-runtime/api/mosaic-runtime.api
+++ b/mosaic-runtime/api/mosaic-runtime.api
@@ -47,14 +47,27 @@ public final class com/jakewharton/mosaic/layout/DrawModifierKt {
 }
 
 public abstract interface class com/jakewharton/mosaic/layout/DrawScope {
-	public abstract fun drawRect-e5kUBSE (IIIII)V
-	public static synthetic fun drawRect-e5kUBSE$default (Lcom/jakewharton/mosaic/layout/DrawScope;IIIIIILjava/lang/Object;)V
+	public abstract fun drawRect-K-Y9Gx4 (CIIIJJLcom/jakewharton/mosaic/layout/DrawStyle;)V
+	public abstract fun drawRect-K-Y9Gx4 (IIIIJJLcom/jakewharton/mosaic/layout/DrawStyle;)V
+	public static synthetic fun drawRect-K-Y9Gx4$default (Lcom/jakewharton/mosaic/layout/DrawScope;CIIIJJLcom/jakewharton/mosaic/layout/DrawStyle;ILjava/lang/Object;)V
+	public static synthetic fun drawRect-K-Y9Gx4$default (Lcom/jakewharton/mosaic/layout/DrawScope;IIIIJJLcom/jakewharton/mosaic/layout/DrawStyle;ILjava/lang/Object;)V
 	public abstract fun drawText-8Xo7vWM (IILcom/jakewharton/mosaic/text/AnnotatedString;III)V
 	public abstract fun drawText-8Xo7vWM (IILjava/lang/String;III)V
 	public static synthetic fun drawText-8Xo7vWM$default (Lcom/jakewharton/mosaic/layout/DrawScope;IILcom/jakewharton/mosaic/text/AnnotatedString;IIIILjava/lang/Object;)V
 	public static synthetic fun drawText-8Xo7vWM$default (Lcom/jakewharton/mosaic/layout/DrawScope;IILjava/lang/String;IIIILjava/lang/Object;)V
 	public abstract fun getHeight ()I
 	public abstract fun getWidth ()I
+}
+
+public abstract interface class com/jakewharton/mosaic/layout/DrawStyle {
+}
+
+public final class com/jakewharton/mosaic/layout/Fill : com/jakewharton/mosaic/layout/DrawStyle {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/jakewharton/mosaic/layout/Fill;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/jakewharton/mosaic/layout/IntrinsicMeasurable {
@@ -170,6 +183,16 @@ public final class com/jakewharton/mosaic/layout/SizeKt {
 	public static synthetic fun wrapContentSize$default (Lcom/jakewharton/mosaic/modifier/Modifier;Lcom/jakewharton/mosaic/ui/Alignment;ZILjava/lang/Object;)Lcom/jakewharton/mosaic/modifier/Modifier;
 	public static final fun wrapContentWidth (Lcom/jakewharton/mosaic/modifier/Modifier;Lcom/jakewharton/mosaic/ui/Alignment$Horizontal;Z)Lcom/jakewharton/mosaic/modifier/Modifier;
 	public static synthetic fun wrapContentWidth$default (Lcom/jakewharton/mosaic/modifier/Modifier;Lcom/jakewharton/mosaic/ui/Alignment$Horizontal;ZILjava/lang/Object;)Lcom/jakewharton/mosaic/modifier/Modifier;
+}
+
+public final class com/jakewharton/mosaic/layout/Stroke : com/jakewharton/mosaic/layout/DrawStyle {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (I)V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/jakewharton/mosaic/modifier/CombinedModifier : com/jakewharton/mosaic/modifier/Modifier {
@@ -469,6 +492,7 @@ public final class com/jakewharton/mosaic/ui/ComposableSingletons$SpacerKt {
 
 public final class com/jakewharton/mosaic/ui/FillerKt {
 	public static final fun Filler-GddN7rU (CLcom/jakewharton/mosaic/modifier/Modifier;IIILandroidx/compose/runtime/Composer;II)V
+	public static final fun Filler-GddN7rU (ILcom/jakewharton/mosaic/modifier/Modifier;IIILandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/jakewharton/mosaic/ui/Layout {

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Background.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Background.kt
@@ -17,7 +17,7 @@ private class BackgroundModifier(
 	private val color: Color,
 ) : DrawModifier {
 	override fun ContentDrawScope.draw() {
-		drawRect(color)
+		drawRect(background = color)
 		drawContent()
 	}
 

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawScope.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawScope.kt
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
+@file:Suppress("NOTHING_TO_INLINE")
+
 package com.jakewharton.mosaic.layout
 
 import com.jakewharton.mosaic.TextCanvas
+import com.jakewharton.mosaic.TextPixel
+import com.jakewharton.mosaic.UnspecifiedCodePoint
+import com.jakewharton.mosaic.isSpecifiedCodePoint
+import com.jakewharton.mosaic.isUnspecifiedCodePoint
 import com.jakewharton.mosaic.text.AnnotatedString
 import com.jakewharton.mosaic.text.SpanStyle
 import com.jakewharton.mosaic.text.getLocalRawSpanStyles
@@ -24,18 +30,63 @@ import com.jakewharton.mosaic.ui.Color
 import com.jakewharton.mosaic.ui.TextStyle
 import com.jakewharton.mosaic.ui.isSpecifiedColor
 import com.jakewharton.mosaic.ui.isSpecifiedTextStyle
+import com.jakewharton.mosaic.ui.isUnspecifiedColor
+import com.jakewharton.mosaic.ui.isUnspecifiedTextStyle
+import com.jakewharton.mosaic.ui.unit.IntOffset
+import com.jakewharton.mosaic.ui.unit.IntSize
 import de.cketti.codepoints.codePointAt
+import kotlin.math.max
 
 public interface DrawScope {
 	public val width: Int
 	public val height: Int
 
+	private val size: IntSize get() = IntSize(width, height)
+
+	/**
+	 * Draws a rectangle with the given offset and size. If no offset from the top left is provided,
+	 * it is drawn starting from the origin of the current translation. If no size is provided,
+	 * the size of the current environment is used.
+	 *
+	 * @param char Char to be applied to the rectangle
+	 * @param foreground Foreground color to be applied to the rectangle
+	 * @param background Background color to be applied to the rectangle
+	 * @param textStyle Text style color to be applied to the rectangle
+	 * @param topLeft Offset from the local origin of 0, 0 relative to the current translation
+	 * @param size Dimensions of the rectangle to draw
+	 * @param drawStyle Whether or not the rectangle is stroked or filled in
+	 */
 	public fun drawRect(
-		color: Color,
-		row: Int = 0,
-		column: Int = 0,
-		width: Int = this.width,
-		height: Int = this.height,
+		char: Char,
+		foreground: Color = Color.Unspecified,
+		background: Color = Color.Unspecified,
+		textStyle: TextStyle = TextStyle.Unspecified,
+		topLeft: IntOffset = IntOffset.Zero,
+		size: IntSize = this.size.offsetSize(topLeft),
+		drawStyle: DrawStyle = Fill,
+	)
+
+	/**
+	 * Draws a rectangle with the given offset and size. If no offset from the top left is provided,
+	 * it is drawn starting from the origin of the current translation. If no size is provided,
+	 * the size of the current environment is used.
+	 *
+	 * @param codePoint Code point to be applied to the rectangle
+	 * @param foreground Foreground color to be applied to the rectangle
+	 * @param background Background color to be applied to the rectangle
+	 * @param textStyle Text style color to be applied to the rectangle
+	 * @param topLeft Offset from the local origin of 0, 0 relative to the current translation
+	 * @param size Dimensions of the rectangle to draw
+	 * @param drawStyle Whether or not the rectangle is stroked or filled in
+	 */
+	public fun drawRect(
+		codePoint: Int = UnspecifiedCodePoint,
+		foreground: Color = Color.Unspecified,
+		background: Color = Color.Unspecified,
+		textStyle: TextStyle = TextStyle.Unspecified,
+		topLeft: IntOffset = IntOffset.Zero,
+		size: IntSize = this.size.offsetSize(topLeft),
+		drawStyle: DrawStyle = Fill,
 	)
 
 	public fun drawText(
@@ -55,6 +106,12 @@ public interface DrawScope {
 		background: Color = Color.Unspecified,
 		textStyle: TextStyle = TextStyle.Unspecified,
 	)
+
+	/**
+	 * Helper method to offset the provided size with the offset in box width and height
+	 */
+	private fun IntSize.offsetSize(offset: IntOffset): IntSize =
+		IntSize(this.width - offset.x, this.height - offset.y)
 }
 
 internal open class TextCanvasDrawScope(
@@ -63,15 +120,102 @@ internal open class TextCanvasDrawScope(
 	override val height: Int,
 ) : DrawScope {
 	override fun drawRect(
-		color: Color,
-		row: Int,
-		column: Int,
-		width: Int,
-		height: Int,
+		char: Char,
+		foreground: Color,
+		background: Color,
+		textStyle: TextStyle,
+		topLeft: IntOffset,
+		size: IntSize,
+		drawStyle: DrawStyle,
 	) {
-		for (y in row until row + height) {
-			for (x in column until column + width) {
-				canvas[y, x].background = color
+		drawRect(char.code, foreground, background, textStyle, topLeft, size, drawStyle)
+	}
+
+	override fun drawRect(
+		codePoint: Int,
+		foreground: Color,
+		background: Color,
+		textStyle: TextStyle,
+		topLeft: IntOffset,
+		size: IntSize,
+		drawStyle: DrawStyle,
+	) {
+		if (codePoint.isUnspecifiedCodePoint &&
+			foreground.isUnspecifiedColor &&
+			background.isUnspecifiedColor &&
+			textStyle.isUnspecifiedTextStyle ||
+			size.width <= 0 ||
+			size.height <= 0 ||
+			topLeft.x >= width ||
+			topLeft.y >= height ||
+			topLeft.x + size.width < 0 ||
+			topLeft.y + size.height < 0
+		) {
+			// exit: rectangle with the specified parameters cannot be seen
+			return
+		}
+
+		when (drawStyle) {
+			Fill -> drawSolidRect(codePoint, foreground, background, textStyle, topLeft, size)
+			is Stroke -> {
+				val strokeWidth = max(1, drawStyle.width)
+				if (strokeWidth * 2 >= size.width || strokeWidth * 2 >= size.height) {
+					// fast path: stroke width is large, it turns out a full fill
+					drawSolidRect(codePoint, foreground, background, textStyle, topLeft, size)
+					return
+				}
+
+				// left line
+				drawSolidRect(
+					codePoint,
+					foreground,
+					background,
+					textStyle,
+					topLeft,
+					IntSize(strokeWidth, size.height),
+				)
+				// top line
+				drawSolidRect(
+					codePoint,
+					foreground,
+					background,
+					textStyle,
+					IntOffset(topLeft.x + strokeWidth, topLeft.y),
+					IntSize(size.width - strokeWidth * 2, strokeWidth),
+				)
+				// right line
+				drawSolidRect(
+					codePoint,
+					foreground,
+					background,
+					textStyle,
+					IntOffset(topLeft.x + size.width - strokeWidth, topLeft.y),
+					IntSize(strokeWidth, size.height),
+				)
+				// bottom line
+				drawSolidRect(
+					codePoint,
+					foreground,
+					background,
+					textStyle,
+					IntOffset(topLeft.x + strokeWidth, topLeft.y + size.height - strokeWidth),
+					IntSize(size.width - strokeWidth * 2, strokeWidth),
+				)
+			}
+		}
+	}
+
+	private inline fun drawSolidRect(
+		codePoint: Int,
+		foreground: Color,
+		background: Color,
+		textStyle: TextStyle,
+		topLeft: IntOffset,
+		size: IntSize,
+	) {
+		for (y in topLeft.y until topLeft.y + size.height) {
+			for (x in topLeft.x until topLeft.x + size.width) {
+				drawTextPixel(x, y, codePoint, foreground, background, textStyle)
 			}
 		}
 	}
@@ -120,26 +264,43 @@ internal open class TextCanvasDrawScope(
 				pixelIndex + 1
 			}
 
-			character.codePoint = text.codePointAt(pixelIndex)
-			val spanStyles = spanStylesProvider?.invoke(pixelIndex, pixelEnd)
+			character.updateTextPixel(text.codePointAt(pixelIndex), foreground, background, textStyle)
+			spanStylesProvider?.invoke(pixelIndex, pixelEnd)?.forEach {
+				character.updateTextPixel(UnspecifiedCodePoint, it.color, it.background, it.textStyle)
+			}
+
 			pixelIndex = pixelEnd
+		}
+	}
 
-			fun maybeUpdateCharacter(background: Color, foreground: Color, style: TextStyle) {
-				if (background.isSpecifiedColor) {
-					character.background = background
-				}
-				if (foreground.isSpecifiedColor) {
-					character.foreground = foreground
-				}
-				if (style.isSpecifiedTextStyle) {
-					character.textStyle = style
-				}
-			}
+	private inline fun drawTextPixel(
+		x: Int,
+		y: Int,
+		codePoint: Int = UnspecifiedCodePoint,
+		foreground: Color = Color.Unspecified,
+		background: Color = Color.Unspecified,
+		textStyle: TextStyle = TextStyle.Unspecified,
+	) {
+		canvas[y, x].updateTextPixel(codePoint, foreground, background, textStyle)
+	}
 
-			maybeUpdateCharacter(background, foreground, textStyle)
-			spanStyles?.forEach {
-				maybeUpdateCharacter(it.background, it.color, it.textStyle)
-			}
+	private inline fun TextPixel.updateTextPixel(
+		codePoint: Int,
+		foreground: Color,
+		background: Color,
+		textStyle: TextStyle,
+	) {
+		if (codePoint.isSpecifiedCodePoint) {
+			this.codePoint = codePoint
+		}
+		if (foreground.isSpecifiedColor) {
+			this.foreground = foreground
+		}
+		if (background.isSpecifiedColor) {
+			this.background = background
+		}
+		if (textStyle.isSpecifiedTextStyle) {
+			this.textStyle = textStyle
 		}
 	}
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawStyle.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawStyle.kt
@@ -1,0 +1,28 @@
+package com.jakewharton.mosaic.layout
+
+import dev.drewhamilton.poko.Poko
+
+/**
+ * Represents how the shapes should be drawn within a [DrawScope]
+ */
+public sealed interface DrawStyle
+
+/**
+ * Default [DrawStyle] indicating shapes should be drawn completely filled in with the
+ * provided color or pattern
+ */
+public data object Fill : DrawStyle
+
+/**
+ * [DrawStyle] that provides information for drawing content with a stroke
+ *
+ * @param width Configure the width of the stroke in cells
+ */
+@Poko
+public class Stroke(
+	internal val width: Int = 1,
+) : DrawStyle {
+	override fun toString(): String {
+		return "Stroke(width=$width)"
+	}
+}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text.kt
@@ -1,0 +1,22 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package com.jakewharton.mosaic
+
+import androidx.compose.runtime.Stable
+
+/**
+ * Unicode code point cannot contain a negative value.
+ */
+internal const val UnspecifiedCodePoint: Int = -1
+
+/**
+ * `true` when this is [UnspecifiedCodePoint].
+ */
+@Stable
+internal inline val Int.isUnspecifiedCodePoint: Boolean get() = this == UnspecifiedCodePoint
+
+/**
+ * `false` when this is [UnspecifiedCodePoint].
+ */
+@Stable
+internal inline val Int.isSpecifiedCodePoint: Boolean get() = this != UnspecifiedCodePoint

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Filler.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Filler.kt
@@ -9,6 +9,7 @@ import com.jakewharton.mosaic.layout.MeasureScope
 import com.jakewharton.mosaic.layout.drawBehind
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.ui.unit.Constraints
+import de.cketti.codepoints.CodePoints
 
 /**
  * Component that represents an layout of identical characters, whose size can be
@@ -28,15 +29,33 @@ public fun Filler(
 	background: Color = Color.Unspecified,
 	textStyle: TextStyle = TextStyle.Unspecified,
 ) {
+	Filler(char.code, modifier, foreground, background, textStyle)
+}
+
+/**
+ * Component that represents an layout of identical characters, whose size can be
+ * defined using [Modifier.width], [Modifier.height] and [Modifier.size] modifiers.
+ *
+ * This layout is similar to [Spacer].
+ *
+ * @param codePoint code point to fill in
+ * @param modifier modifiers to set to this spacer
+ */
+@Composable
+@NonRestartableComposable
+public fun Filler(
+	codePoint: Int,
+	modifier: Modifier = Modifier,
+	foreground: Color = Color.Unspecified,
+	background: Color = Color.Unspecified,
+	textStyle: TextStyle = TextStyle.Unspecified,
+) {
 	Layout(
 		content = EmptyFillerContent,
 		measurePolicy = FillerMeasurePolicy,
-		debugInfo = { "Filler('$char')" },
+		debugInfo = { "Filler('${CodePoints.toChars(codePoint).concatToString()}')" },
 		modifier = modifier.drawBehind {
-			val line = char.toString().repeat(width)
-			repeat(height) { row ->
-				drawText(row, 0, line, foreground, background, textStyle)
-			}
+			drawRect(codePoint, foreground, background, textStyle)
 		},
 	)
 }

--- a/samples/robot/src/main/kotlin/example/robot.kt
+++ b/samples/robot/src/main/kotlin/example/robot.kt
@@ -3,8 +3,11 @@ package example
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
+import com.jakewharton.mosaic.layout.Stroke
+import com.jakewharton.mosaic.layout.drawBehind
 import com.jakewharton.mosaic.layout.height
 import com.jakewharton.mosaic.layout.offset
+import com.jakewharton.mosaic.layout.padding
 import com.jakewharton.mosaic.layout.size
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.runMosaicBlocking
@@ -17,8 +20,11 @@ import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
 import org.jline.terminal.TerminalBuilder
 
-private const val width = 20
-private const val height = 10
+private const val worldWidth = 20
+private const val worldHeight = 10
+
+private const val worldBorderChar = '*'
+private const val worldBorderWidth = 1
 
 private const val robotWidth = 3
 private const val robotHeight = 1
@@ -31,10 +37,16 @@ fun main() = runMosaicBlocking {
 	setContent {
 		Column {
 			Text("Use arrow keys to move the face. Press “q” to exit.")
-			Text("Position: $x, $y   Robot: $robotWidth, $robotHeight   World: $width, $height")
+			Text("Position: $x, $y   Robot: $robotWidth, $robotHeight   World: $worldWidth, $worldHeight")
 			Spacer(Modifier.height(1))
 			// TODO https://github.com/JakeWharton/mosaic/issues/11
-			Box(modifier = Modifier.size(width, height).offset { IntOffset(x, y) }) {
+			Box(
+				modifier = Modifier
+					.drawBehind { drawRect(worldBorderChar, drawStyle = Stroke(worldBorderWidth)) }
+					.padding(worldBorderWidth)
+					.size(worldWidth, worldHeight)
+					.offset { IntOffset(x, y) },
+			) {
 				Text("^_^")
 			}
 		}
@@ -55,8 +67,8 @@ fun main() = runMosaicBlocking {
 						91, 79 -> {
 							when (reader.read()) {
 								65 -> y = (y - 1).coerceAtLeast(0)
-								66 -> y = (y + 1).coerceAtMost(height - robotHeight)
-								67 -> x = (x + 1).coerceAtMost(width - robotWidth)
+								66 -> y = (y + 1).coerceAtMost(worldHeight - robotHeight)
+								67 -> x = (x + 1).coerceAtMost(worldWidth - robotWidth)
 								68 -> x = (x - 1).coerceAtLeast(0)
 							}
 						}

--- a/samples/rrtop/src/main/kotlin/example/screens/MainScreen.kt
+++ b/samples/rrtop/src/main/kotlin/example/screens/MainScreen.kt
@@ -20,6 +20,8 @@ import com.jakewharton.mosaic.ui.Column
 import com.jakewharton.mosaic.ui.Row
 import com.jakewharton.mosaic.ui.Spacer
 import com.jakewharton.mosaic.ui.Text
+import com.jakewharton.mosaic.ui.unit.IntOffset
+import com.jakewharton.mosaic.ui.unit.IntSize
 import example.LocalRrtopColorsPalette
 import example.MainScreenUiState
 import example.common.BorderedTitledBox
@@ -493,11 +495,9 @@ private fun SolidPlot(
 							)
 						} else {
 							drawRect(
-								color = plotInfo.color,
-								row = height - valueHeight,
-								column = startColumn + i,
-								width = 1,
-								height = valueHeight,
+								background = plotInfo.color,
+								topLeft = IntOffset(startColumn + i, height - valueHeight),
+								size = IntSize(1, valueHeight),
 							)
 						}
 					}


### PR DESCRIPTION
- Change the `drawRect` method in `DrawScope` like the method from the Compose UI
- Add support for `DrawStyle`: `Fill` and `Stroke` in `DrawScope#drawRect`
- Add support for drawing a rectangle from text characters
- Add `Filler` with code point
- Change the robot sample to show `drawRect` with `Stroke`:
  <img width="300" alt="Screenshot 2024-05-29 at 22 22 48" src="https://github.com/JakeWharton/mosaic/assets/37583380/fe3c98ad-8af2-4628-8f4d-4a817b0f4af2">
