### PR TITLE
Some code fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ Instead, we have to use Compose's `State` objects to hold state.
 
 ```diff
 -var count = 0
-+var count by mutableStateOf(0)
++var count by mutableIntStateOf(0)
 ```
 
 Now, when the `count` value is updated, Compose will know that it needs to re-render the string.
 
 ```kotlin
 fun main() = runMosaic {
-  var count by mutableStateOf(0)
+  var count by mutableIntStateOf(0)
 
   setContent {
     Text("The count is: $count")
@@ -162,7 +162,7 @@ This is the goal. It is currently blocked by [issuetracker.google.com/178904648]
 When that change lands, and Mosaic is updated, the counter sample will look like this:
 ```kotlin
 fun main() = runMosaic {
-  var count by remember { mutableStateOf(0) }
+  var count by remember { mutableIntStateOf(0) }
 
   Text("The count is: $count")
 

--- a/mosaic-runtime/api/mosaic-runtime.api
+++ b/mosaic-runtime/api/mosaic-runtime.api
@@ -62,9 +62,19 @@ public abstract interface class com/jakewharton/mosaic/layout/DrawScope {
 public abstract interface class com/jakewharton/mosaic/layout/DrawStyle {
 }
 
-public final class com/jakewharton/mosaic/layout/Fill : com/jakewharton/mosaic/layout/DrawStyle {
+public final class com/jakewharton/mosaic/layout/DrawStyle$Fill : com/jakewharton/mosaic/layout/DrawStyle {
 	public static final field $stable I
-	public static final field INSTANCE Lcom/jakewharton/mosaic/layout/Fill;
+	public static final field INSTANCE Lcom/jakewharton/mosaic/layout/DrawStyle$Fill;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/jakewharton/mosaic/layout/DrawStyle$Stroke : com/jakewharton/mosaic/layout/DrawStyle {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (I)V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -183,16 +193,6 @@ public final class com/jakewharton/mosaic/layout/SizeKt {
 	public static synthetic fun wrapContentSize$default (Lcom/jakewharton/mosaic/modifier/Modifier;Lcom/jakewharton/mosaic/ui/Alignment;ZILjava/lang/Object;)Lcom/jakewharton/mosaic/modifier/Modifier;
 	public static final fun wrapContentWidth (Lcom/jakewharton/mosaic/modifier/Modifier;Lcom/jakewharton/mosaic/ui/Alignment$Horizontal;Z)Lcom/jakewharton/mosaic/modifier/Modifier;
 	public static synthetic fun wrapContentWidth$default (Lcom/jakewharton/mosaic/modifier/Modifier;Lcom/jakewharton/mosaic/ui/Alignment$Horizontal;ZILjava/lang/Object;)Lcom/jakewharton/mosaic/modifier/Modifier;
-}
-
-public final class com/jakewharton/mosaic/layout/Stroke : com/jakewharton/mosaic/layout/DrawStyle {
-	public static final field $stable I
-	public fun <init> ()V
-	public fun <init> (I)V
-	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/jakewharton/mosaic/modifier/CombinedModifier : com/jakewharton/mosaic/modifier/Modifier {

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawScope.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawScope.kt
@@ -63,7 +63,7 @@ public interface DrawScope {
 		textStyle: TextStyle = TextStyle.Unspecified,
 		topLeft: IntOffset = IntOffset.Zero,
 		size: IntSize = this.size.offsetSize(topLeft),
-		drawStyle: DrawStyle = Fill,
+		drawStyle: DrawStyle = DrawStyle.Fill,
 	)
 
 	/**
@@ -86,7 +86,7 @@ public interface DrawScope {
 		textStyle: TextStyle = TextStyle.Unspecified,
 		topLeft: IntOffset = IntOffset.Zero,
 		size: IntSize = this.size.offsetSize(topLeft),
-		drawStyle: DrawStyle = Fill,
+		drawStyle: DrawStyle = DrawStyle.Fill,
 	)
 
 	public fun drawText(
@@ -156,8 +156,8 @@ internal open class TextCanvasDrawScope(
 		}
 
 		when (drawStyle) {
-			Fill -> drawSolidRect(codePoint, foreground, background, textStyle, topLeft, size)
-			is Stroke -> {
+			DrawStyle.Fill -> drawSolidRect(codePoint, foreground, background, textStyle, topLeft, size)
+			is DrawStyle.Stroke -> {
 				val strokeWidth = max(1, drawStyle.width)
 				if (strokeWidth * 2 >= size.width || strokeWidth * 2 >= size.height) {
 					// fast path: stroke width is large, it turns out a full fill

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawStyle.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawStyle.kt
@@ -5,24 +5,19 @@ import dev.drewhamilton.poko.Poko
 /**
  * Represents how the shapes should be drawn within a [DrawScope]
  */
-public sealed interface DrawStyle
+public sealed interface DrawStyle {
 
-/**
- * Default [DrawStyle] indicating shapes should be drawn completely filled in with the
- * provided color or pattern
- */
-public data object Fill : DrawStyle
+	/**
+	 * Default [DrawStyle] indicating shapes should be drawn completely filled in with the
+	 * provided color or pattern
+	 */
+	public data object Fill : DrawStyle
 
-/**
- * [DrawStyle] that provides information for drawing content with a stroke
- *
- * @param width Configure the width of the stroke in cells
- */
-@Poko
-public class Stroke(
-	internal val width: Int = 1,
-) : DrawStyle {
-	override fun toString(): String {
-		return "Stroke(width=$width)"
-	}
+	/**
+	 * [DrawStyle] that provides information for drawing content with a stroke
+	 *
+	 * @param width Configure the width of the stroke in cells
+	 */
+	@Poko
+	public class Stroke(internal val width: Int = 1) : DrawStyle
 }

--- a/samples/robot/src/main/kotlin/example/robot.kt
+++ b/samples/robot/src/main/kotlin/example/robot.kt
@@ -3,7 +3,7 @@ package example
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
-import com.jakewharton.mosaic.layout.Stroke
+import com.jakewharton.mosaic.layout.DrawStyle
 import com.jakewharton.mosaic.layout.drawBehind
 import com.jakewharton.mosaic.layout.height
 import com.jakewharton.mosaic.layout.offset
@@ -17,6 +17,7 @@ import com.jakewharton.mosaic.ui.Spacer
 import com.jakewharton.mosaic.ui.Text
 import com.jakewharton.mosaic.ui.unit.IntOffset
 import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import org.jline.terminal.TerminalBuilder
 
@@ -39,15 +40,13 @@ fun main() = runMosaicBlocking {
 			Text("Use arrow keys to move the face. Press “q” to exit.")
 			Text("Position: $x, $y   Robot: $robotWidth, $robotHeight   World: $worldWidth, $worldHeight")
 			Spacer(Modifier.height(1))
-			// TODO https://github.com/JakeWharton/mosaic/issues/11
 			Box(
 				modifier = Modifier
-					.drawBehind { drawRect(worldBorderChar, drawStyle = Stroke(worldBorderWidth)) }
+					.drawBehind { drawRect(worldBorderChar, drawStyle = DrawStyle.Stroke(worldBorderWidth)) }
 					.padding(worldBorderWidth)
-					.size(worldWidth, worldHeight)
-					.offset { IntOffset(x, y) },
+					.size(worldWidth, worldHeight),
 			) {
-				Text("^_^")
+				Text("^_^", modifier = Modifier.offset { IntOffset(x, y) })
 			}
 		}
 	}
@@ -57,7 +56,7 @@ fun main() = runMosaicBlocking {
 		terminal.enterRawMode()
 		val reader = terminal.reader()
 
-		while (true) {
+		while (isActive) {
 			// TODO https://github.com/JakeWharton/mosaic/issues/10
 			when (reader.read()) {
 				'q'.code -> break


### PR DESCRIPTION
- Move `Fill` and `Stroke` inside the `DrawStyle` (https://github.com/JakeWharton/mosaic/pull/383#discussion_r1619704024)
- Remove `toString` from `DrawStyle.Stroke` because `@Poko` is already doing it (https://github.com/JakeWharton/mosaic/pull/383#discussion_r1619703595)
- In the robot sample, the use of the `offset` modifier in the robot (`Text`) (https://github.com/JakeWharton/mosaic/pull/383#discussion_r1619702850)
- Remove `TODO https://github.com/JakeWharton/mosaic/issues/11` in the robot sample, it seems that it is no longer relevant
- In the robot sample, add `isActive` check in the loop for keyboard input
- Fix in the `README.md` `mutableStateOf` to `mutableIntStateOf`, as is correct in newer versions
