### PR TITLE
Reuse updater lambdas and eliminate backing field for efficiency

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Node.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Node.kt
@@ -104,24 +104,22 @@ internal class MosaicNode(
 	override var parentData: Any? = null
 		private set
 
-	var modifier: Modifier = Modifier
-		set(value) {
-			topLayer = value.foldOut(bottomLayer) { element, lowerLayer ->
-				when (element) {
-					is LayoutModifier -> LayoutLayer(element, lowerLayer)
+	fun setModifier(modifier: Modifier) {
+		topLayer = modifier.foldOut(bottomLayer) { element, nextLayer ->
+			when (element) {
+				is LayoutModifier -> LayoutLayer(element, nextLayer)
 
-					is DrawModifier -> DrawLayer(element, lowerLayer)
+				is DrawModifier -> DrawLayer(element, nextLayer)
 
-					is ParentDataModifier -> {
-						parentData = element.modifyParentData(parentData)
-						lowerLayer
-					}
-
-					else -> lowerLayer
+				is ParentDataModifier -> {
+					parentData = element.modifyParentData(parentData)
+					nextLayer
 				}
+
+				else -> nextLayer
 			}
-			field = value
 		}
+	}
 
 	override fun measure(constraints: Constraints): Placeable =
 		topLayer.apply { measure(constraints) }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Node.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Node.kt
@@ -11,6 +11,7 @@ import com.jakewharton.mosaic.layout.MeasureScope
 import com.jakewharton.mosaic.layout.MosaicNode
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.ui.unit.Constraints
+import kotlin.jvm.JvmField
 
 @Composable
 @MosaicComposable
@@ -27,13 +28,20 @@ internal inline fun Node(
 	ComposeNode<MosaicNode, Applier<Any>>(
 		factory = factory,
 		update = {
-			set(measurePolicy) { this.measurePolicy = measurePolicy }
-			set(modifier) { this.modifier = modifier }
-			set(debugPolicy) { this.debugPolicy = debugPolicy }
+			set(measurePolicy, SetMeasurePolicy)
+			set(modifier, SetModifier)
+			set(debugPolicy, SetDebugPolicy)
 		},
 		content = content,
 	)
 }
+
+@JvmField
+internal val SetModifier: MosaicNode.(Modifier) -> Unit = { setModifier(it) }
+@JvmField
+internal val SetMeasurePolicy: MosaicNode.(MeasurePolicy) -> Unit = { measurePolicy = it }
+@JvmField
+internal val SetDebugPolicy: MosaicNode.(DebugPolicy) -> Unit = { debugPolicy = it }
 
 internal val NodeFactory: () -> MosaicNode = {
 	MosaicNode(

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Node.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Node.kt
@@ -38,8 +38,10 @@ internal inline fun Node(
 
 @JvmField
 internal val SetModifier: MosaicNode.(Modifier) -> Unit = { setModifier(it) }
+
 @JvmField
 internal val SetMeasurePolicy: MosaicNode.(MeasurePolicy) -> Unit = { measurePolicy = it }
+
 @JvmField
 internal val SetDebugPolicy: MosaicNode.(DebugPolicy) -> Unit = { debugPolicy = it }
 


### PR DESCRIPTION
Use the same lambda instances for all nodes to update their modifier, measure policy, or debug policy. Also eliminate the Modifier backing field and instead just recompute the layers.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
