### PR TITLE
Use `runMosaicTest` for all unit tests

### DIFF
--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/CounterTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/CounterTest.kt
@@ -17,6 +17,7 @@ import com.jakewharton.mosaic.ui.unit.IntSize
 import kotlin.test.Test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 
 class CounterTest {
@@ -24,7 +25,7 @@ class CounterTest {
 		runMosaicTest {
 			setCounter()
 			for (count in 0..20) {
-				assertThat(awaitSnapshot()).isEqualTo("The count is: $count")
+				assertThat(awaitRenderSnapshot()).isEqualTo("The count is: $count")
 			}
 		}
 	}
@@ -32,14 +33,14 @@ class CounterTest {
 	@Test fun counterWithAnsi() = runTest {
 		runMosaicTest(withAnsi = true) {
 			setCounter()
-			assertThat(awaitSnapshot()).isEqualTo(
+			assertThat(awaitRenderSnapshot()).isEqualTo(
 				"""
 				|${ansiBeginSynchronizedUpdate}The count is: 0
 				|$ansiEndSynchronizedUpdate
 				""".trimMargin().replaceLineEndingsWithCRLF(),
 			)
 			for (i in 1..20) {
-				assertThat(awaitSnapshot()).isEqualTo(
+				assertThat(awaitRenderSnapshot()).isEqualTo(
 					"""
 					|${ansiBeginSynchronizedUpdate}${cursorUp}The count is: ${i}$clearLine
 					|$ansiEndSynchronizedUpdate
@@ -50,10 +51,10 @@ class CounterTest {
 	}
 
 	@Test fun counterInTerminalCenter() = runTest {
-		runMosaicTest(terminalSize = IntSize(width = 30, height = 1)) {
+		runMosaicTest(initialTerminalSize = IntSize(width = 30, height = 1)) {
 			setCounterInTerminalCenter()
 			for (count in 0..9) {
-				assertThat(awaitSnapshot()).isEqualTo("        The count is: $count       ")
+				assertThat(awaitRenderSnapshot()).isEqualTo("        The count is: $count       ")
 			}
 
 			changeTerminalSize(width = 20, height = 1)
@@ -61,10 +62,10 @@ class CounterTest {
 			// after changing the terminal size, we wait for the counter to increase before getting
 			// a new snapshot, otherwise there will be the previous value (9) and a different output size
 			@OptIn(ExperimentalCoroutinesApi::class)
-			testScheduler.advanceTimeBy(250L)
+			advanceTimeBy(250L)
 
 			for (count in 10..20) {
-				assertThat(awaitSnapshot()).isEqualTo("  The count is: $count  ")
+				assertThat(awaitRenderSnapshot()).isEqualTo("  The count is: $count  ")
 			}
 		}
 	}
@@ -73,15 +74,15 @@ class CounterTest {
 		runMosaicTest {
 			setCounter()
 			for (count in 0..9) {
-				assertThat(awaitSnapshot()).isEqualTo("The count is: $count")
+				assertThat(awaitRenderSnapshot()).isEqualTo("The count is: $count")
 			}
 			setChangedCounter()
 			for (count in 0..20) {
-				assertThat(awaitSnapshot()).isEqualTo(
+				assertThat(awaitRenderSnapshot()).isEqualTo(
 					"""
 					|The count is: $count      $s
 					|The second count is: $count
-					""".trimMargin().replaceLineEndingsWithCRLF(),
+					""".trimMargin(),
 				)
 			}
 		}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/DebugRenderingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/DebugRenderingTest.kt
@@ -24,7 +24,7 @@ class DebugRenderingTest {
 	private val rendering = DebugRendering(timeSource)
 
 	@Test fun drawFailureStillRendersMeasuredAndPlacedNodes() {
-		val nodes = mosaicNodes {
+		val rootNode = renderMosaicNode {
 			Row {
 				Text("Hello ")
 				Layout(modifier = Modifier.drawBehind { throw UnsupportedOperationException() }) {
@@ -34,7 +34,7 @@ class DebugRenderingTest {
 		}
 
 		assertFailure {
-			rendering.render(nodes)
+			rendering.render(rootNode)
 		}.isInstanceOf<RuntimeException>()
 			.message()
 			.isNotNull()
@@ -54,14 +54,14 @@ class DebugRenderingTest {
 	}
 
 	@Test fun framesIncludeStatics() {
-		val nodes = mosaicNodes {
+		val rootNode = renderMosaicNode {
 			Text("Hello")
 			Static(snapshotStateListOf("Static")) {
 				Text(it)
 			}
 		}
 
-		assertThat(rendering.render(nodes)).isEqualTo(
+		assertThat(rendering.render(rootNode)).isEqualTo(
 			"""
 			|NODES:
 			|Text("Hello") x=0 y=0 w=5 h=1 DrawBehind
@@ -79,11 +79,11 @@ class DebugRenderingTest {
 	}
 
 	@Test fun framesAfterFirstHaveTimeHeader() {
-		val hello = mosaicNodes {
+		val rootNode = renderMosaicNode {
 			Text("Hello")
 		}
 
-		assertThat(rendering.render(hello)).isEqualTo(
+		assertThat(rendering.render(rootNode)).isEqualTo(
 			"""
 			|NODES:
 			|Text("Hello") x=0 y=0 w=5 h=1 DrawBehind
@@ -95,7 +95,7 @@ class DebugRenderingTest {
 		)
 
 		timeSource += 100.milliseconds
-		assertThat(rendering.render(hello)).isEqualTo(
+		assertThat(rendering.render(rootNode)).isEqualTo(
 			"""
 			|~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ +100ms
 			|NODES:

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/LayoutTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/LayoutTest.kt
@@ -9,128 +9,140 @@ import com.jakewharton.mosaic.ui.Layout
 import com.jakewharton.mosaic.ui.Row
 import com.jakewharton.mosaic.ui.Text
 import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 
 class LayoutTest {
-	@Test fun layoutDebugInfo() {
-		val node = mosaicNodes {
-			Layout(
-				content = {
-					Text("Hi!")
-					Text("Hey!")
-				},
-				debugInfo = { "Custom()" },
-			) { _, _ ->
-				layout(0, 0) {
-				}
-			}
-		}
-		val expected = """
-			|Custom() x=0 y=0 w=0 h=0
-			|  Text("Hi!") x=0 y=0 w=0 h=0 DrawBehind
-			|  Text("Hey!") x=0 y=0 w=0 h=0 DrawBehind
-		""".trimMargin()
-		assertThat(node.toString()).isEqualTo(expected)
-	}
-
-	@Test fun noMeasureNoDraw() {
-		val actual = renderMosaic {
-			Layout({
-				Text("CCC")
-				Text("BB")
-				Text("A")
-			}) { _, _ ->
-				layout(3, 1) {
-				}
-			}
-		}
-		val expected = """
-			|  $s
-			|
-		""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF()
-		assertThat(actual).isEqualTo(expected)
-	}
-
-	@Test fun noPlacementOverlaps() {
-		val actual = renderMosaic {
-			Layout({
-				Text("CCC")
-				Text("BB")
-				Text("A")
-			}) { measurables, constraints ->
-				for (measurable in measurables) {
-					measurable.measure(constraints)
-				}
-				layout(3, 1) {
-				}
-			}
-		}
-		val expected = """
-			|ABC
-			|
-		""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF()
-		assertThat(actual).isEqualTo(expected)
-	}
-
-	@Test fun placementWorks() {
-		val actual = renderMosaic {
-			Layout({
-				Text("CCC")
-				Text("BB")
-				Text("A")
-			}) { measurables, constraints ->
-				val (c, b, a) = measurables.map { it.measure(constraints) }
-				layout(8, 3) {
-					a.place(0, 2)
-					b.place(2, 1)
-					c.place(5, 0)
-				}
-			}
-		}
-		val expected = """
-			|     CCC
-			|  BB   $s
-			|A      $s
-			|
-		""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF()
-		assertThat(actual).isEqualTo(expected)
-	}
-
-	@Test fun canvasIsNotClipped() {
-		val actual = renderMosaic {
-			Column {
-				Row {
-					// Force the width of the canvas to be 6.
-					Text("123456")
-				}
-				Row {
-					Text("..")
-					Layout(
-						modifier = Modifier.drawBehind {
-							repeat(4) { row ->
-								drawText(row, 0, "XXXX")
-							}
-						},
-					) {
-						layout(2, 2)
+	@Test fun layoutDebugInfo() = runTest {
+		runMosaicTest {
+			setContent {
+				Layout(
+					content = {
+						Text("Hi!")
+						Text("Hey!")
+					},
+					debugInfo = { "Custom()" },
+				) { _, _ ->
+					layout(0, 0) {
 					}
-					Text(".")
-				}
-				Row {
-					Text("...")
-				}
-				Row {
-					Text(".....")
 				}
 			}
+			assertThat(awaitNodeSnapshot().toString()).isEqualTo(
+				"""
+				|Custom() x=0 y=0 w=0 h=0
+				|  Text("Hi!") x=0 y=0 w=0 h=0 DrawBehind
+				|  Text("Hey!") x=0 y=0 w=0 h=0 DrawBehind
+				""".trimMargin(),
+			)
 		}
-		val expected = """
-			|123456
-			|..XX.X
-			|  XXXX
-			|...XXX
-			|.....X
-			|
-		""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF()
-		assertThat(actual).isEqualTo(expected)
+	}
+
+	@Test fun noMeasureNoDraw() = runTest {
+		runMosaicTest {
+			setContent {
+				Layout({
+					Text("CCC")
+					Text("BB")
+					Text("A")
+				}) { _, _ ->
+					layout(3, 1) {
+					}
+				}
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|  $s
+				""".trimMargin(),
+			)
+		}
+	}
+
+	@Test fun noPlacementOverlaps() = runTest {
+		runMosaicTest {
+			setContent {
+				Layout({
+					Text("CCC")
+					Text("BB")
+					Text("A")
+				}) { measurables, constraints ->
+					for (measurable in measurables) {
+						measurable.measure(constraints)
+					}
+					layout(3, 1) {
+					}
+				}
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|ABC
+				""".trimMargin(),
+			)
+		}
+	}
+
+	@Test fun placementWorks() = runTest {
+		runMosaicTest {
+			setContent {
+				Layout({
+					Text("CCC")
+					Text("BB")
+					Text("A")
+				}) { measurables, constraints ->
+					val (c, b, a) = measurables.map { it.measure(constraints) }
+					layout(8, 3) {
+						a.place(0, 2)
+						b.place(2, 1)
+						c.place(5, 0)
+					}
+				}
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|     CCC
+				|  BB   $s
+				|A      $s
+				""".trimMargin(),
+			)
+		}
+	}
+
+	@Test fun canvasIsNotClipped() = runTest {
+		runMosaicTest {
+			setContent {
+				Column {
+					Row {
+						// Force the width of the canvas to be 6.
+						Text("123456")
+					}
+					Row {
+						Text("..")
+						Layout(
+							modifier = Modifier.drawBehind {
+								repeat(4) { row ->
+									drawText(row, 0, "XXXX")
+								}
+							},
+						) {
+							layout(2, 2)
+						}
+						Text(".")
+					}
+					Row {
+						Text("...")
+					}
+					Row {
+						Text(".....")
+					}
+				}
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|123456
+				|..XX.X
+				|  XXXX
+				|...XXX
+				|.....X
+				""".trimMargin(),
+			)
+		}
 	}
 }

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/MosaicTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/MosaicTest.kt
@@ -1,13 +1,27 @@
 package com.jakewharton.mosaic
 
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.ui.Column
 import com.jakewharton.mosaic.ui.Text
 import kotlin.test.Test
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 
 class MosaicTest {
-	@Test fun render() {
+	@Test fun renderMosaicSimple() {
 		val actual = renderMosaic {
 			Column {
 				Text("One")
@@ -23,5 +37,152 @@ class MosaicTest {
 			|
 			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
 		)
+	}
+
+	@Test fun renderMosaicIgnoreLaunchedEffect() {
+		val actual = renderMosaic {
+			var count by remember { mutableIntStateOf(0) }
+
+			Column {
+				Text("One")
+				Text("Two")
+				Text("Three")
+				repeat(count) {
+					Text("Any number")
+				}
+			}
+
+			LaunchedEffect(Unit) {
+				while (true) {
+					count++
+					delay(50L)
+				}
+			}
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|One $s
+			|Two $s
+			|Three
+			|
+			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
+		)
+	}
+
+	@Test fun renderMosaicIgnoreDisposableEffect() {
+		val actual = renderMosaic {
+			var count by remember { mutableIntStateOf(0) }
+
+			Column {
+				Text("One")
+				Text("Two")
+				Text("Three")
+				repeat(count) {
+					Text("Any number")
+				}
+			}
+
+			DisposableEffect(Unit) {
+				count++
+				onDispose {
+					count++
+				}
+			}
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|One $s
+			|Two $s
+			|Three
+			|
+			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
+		)
+	}
+
+	@Test fun renderMosaicIgnoreMultipleEffects() {
+		val actual = renderMosaic {
+			var count by remember { mutableIntStateOf(0) }
+
+			DisposableEffect(Unit) {
+				count = 1
+				onDispose {
+					count = 2
+				}
+			}
+
+			LaunchedEffect(Unit) {
+				count = 3
+			}
+
+			SideEffect {
+				count = 4
+			}
+
+			Column {
+				Text("One")
+				Text("Two")
+				Text("Three")
+				repeat(count) {
+					Text("Any number")
+				}
+			}
+
+			LaunchedEffect(Unit) {
+				count = 5
+			}
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|One $s
+			|Two $s
+			|Three
+			|
+			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
+		)
+	}
+
+	@Test fun renderMosaicInDefaultCoroutineDispatcher() = runTest {
+		val actual = withContext(Dispatchers.Default) {
+			renderMosaic {
+				Column {
+					Text("One")
+					Text("Two")
+					Text("Three")
+				}
+			}
+		}
+		assertThat(actual).isEqualTo(
+			"""
+			|One $s
+			|Two $s
+			|Three
+			|
+			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
+		)
+	}
+
+	@Test fun renderMosaicConcurrently() = runTest {
+		val actuals = List(100) {
+			async(Dispatchers.Default, start = CoroutineStart.LAZY) {
+				renderMosaic {
+					Column {
+						Text("One")
+						Text("Two")
+						Text("Three")
+					}
+				}
+			}
+		}.awaitAll()
+
+		actuals.forEach { actual ->
+			assertThat(actual).isEqualTo(
+				"""
+				|One $s
+				|Two $s
+				|Three
+				|
+				""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
+			)
+		}
 	}
 }

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/TestMosaicComposition.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/TestMosaicComposition.kt
@@ -1,9 +1,12 @@
 package com.jakewharton.mosaic
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import com.jakewharton.mosaic.layout.MosaicNode
 import com.jakewharton.mosaic.ui.AnsiLevel
 import com.jakewharton.mosaic.ui.unit.IntSize
+import kotlin.time.Duration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -13,55 +16,100 @@ private val DefaultTestTerminalSize = IntSize(80, 20)
 
 internal suspend fun runMosaicTest(
 	withAnsi: Boolean = false,
-	terminalSize: IntSize = DefaultTestTerminalSize,
+	initialTerminalSize: IntSize = DefaultTestTerminalSize,
+	withRenderSnapshots: Boolean = true,
 	block: suspend TestMosaicComposition.() -> Unit,
 ) {
 	coroutineScope {
-		val mosaicComposition = TestMosaicComposition(this, withAnsi, terminalSize)
+		val mosaicComposition = RealTestMosaicComposition(
+			coroutineScope = this,
+			withAnsi = withAnsi,
+			initialTerminalSize = initialTerminalSize,
+			withRenderSnapshots = withRenderSnapshots,
+		)
 		block.invoke(mosaicComposition)
-		mosaicComposition.awaitComplete()
+		mosaicComposition.cancel()
 	}
 }
 
-internal class TestMosaicComposition(
+private class RealTestMosaicComposition(
 	coroutineScope: CoroutineScope,
-	withAnsi: Boolean = false,
-	terminalSize: IntSize = DefaultTestTerminalSize,
-) : BaseMosaicComposition(coroutineScope) {
+	withAnsi: Boolean,
+	initialTerminalSize: IntSize,
+	withRenderSnapshots: Boolean,
+) : MosaicComposition(coroutineScope),
+	TestMosaicComposition {
+
+	private var contentSet = false
 
 	/** Channel with the most recent snapshot, if any. */
-	private val snapshots = Channel<String>(Channel.CONFLATED)
+	private val nodeSnapshots = Channel<MosaicNode>(Channel.CONFLATED)
 
-	override val onRender: (CharSequence) -> Unit = { render ->
-		val stringRender = if (withAnsi) {
-			render.toString()
-		} else {
-			render.toString()
-				.replace(ansiBeginSynchronizedUpdate, "")
-				.replace(ansiEndSynchronizedUpdate, "")
-				.replace(clearLine, "")
-				.replace(cursorUp, "")
-				.removeSuffix("\r\n")
+	/** Channel with the most recent snapshot, if any. */
+	private val renderSnapshots = Channel<String>(Channel.CONFLATED)
+
+	private val rendering: Rendering = if (withRenderSnapshots) {
+		AnsiRendering(ansiLevel = if (withAnsi) AnsiLevel.TRUECOLOR else AnsiLevel.NONE)
+	} else {
+		object : Rendering {
+			override fun render(node: MosaicNode): CharSequence {
+				throw UnsupportedOperationException("Rendering disabled by `withRenderSnapshots`")
+			}
 		}
-		snapshots.trySend(stringRender)
 	}
 
-	override val terminalInfo: MutableState<Terminal> = mutableStateOf(Terminal(size = terminalSize))
+	override val onEndChanges: (MosaicNode) -> Unit = { rootNode ->
+		nodeSnapshots.trySend(rootNode)
+		if (withRenderSnapshots) {
+			val stringRender = if (withAnsi) {
+				rendering.render(rootNode).toString()
+			} else {
+				rendering.render(rootNode).toString()
+					.removeSurrounding(ansiBeginSynchronizedUpdate, ansiEndSynchronizedUpdate)
+					.removeSuffix("\r\n") // without last line break for simplicity
+					.replace(clearLine, "")
+					.replace(cursorUp, "")
+					.replace("\r\n", "\n") // CRLF to LF for simplicity
+			}
+			renderSnapshots.trySend(stringRender)
+		}
+	}
 
-	override val rendering: Rendering = AnsiRendering(
-		ansiLevel = if (withAnsi) AnsiLevel.TRUECOLOR else AnsiLevel.NONE,
+	override val terminalInfo: MutableState<Terminal> = mutableStateOf(
+		Terminal(size = initialTerminalSize),
 	)
 
-	fun changeTerminalSize(width: Int, height: Int) {
+	override fun setContent(content: @Composable () -> Unit) {
+		contentSet = true
+		super.setContent(content)
+	}
+
+	override fun changeTerminalSize(width: Int, height: Int) {
 		terminalInfo.value = Terminal(size = IntSize(width, height))
 	}
 
-	suspend fun awaitSnapshot(): String {
+	override suspend fun awaitNodeSnapshot(duration: Duration): MosaicNode {
+		return awaitSnapshot(duration) { nodeSnapshots.receive() }
+	}
+
+	override suspend fun awaitRenderSnapshot(duration: Duration): String {
+		return awaitSnapshot(duration) { renderSnapshots.receive() }
+	}
+
+	override suspend fun awaitNodeRenderSnapshot(duration: Duration): TestMosaicComposition.NodeRenderSnapshot {
+		return awaitSnapshot(duration) {
+			TestMosaicComposition.NodeRenderSnapshot(nodeSnapshots.receive(), renderSnapshots.receive())
+		}
+	}
+
+	private suspend fun <T> awaitSnapshot(duration: Duration, block: suspend () -> T): T {
+		check(contentSet) { "setContent must be called first!" }
+
 		// Await at least one change, sending frames while we wait.
-		return withTimeout(1000L) {
+		return withTimeout(duration) {
 			val sendFramesJob = sendFrames()
 			try {
-				snapshots.receive()
+				block()
 			} finally {
 				sendFramesJob.cancel()
 			}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/AspectRatioTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/AspectRatioTest.kt
@@ -13,6 +13,7 @@ import com.jakewharton.mosaic.ui.unit.Constraints
 import com.jakewharton.mosaic.ui.unit.IntSize
 import kotlin.test.Test
 import kotlin.test.assertFails
+import kotlinx.coroutines.test.runTest
 
 class AspectRatioTest {
 	@Test fun aspectRatioNegative() {
@@ -27,7 +28,7 @@ class AspectRatioTest {
 		}
 	}
 
-	@Test fun aspectRatioDefault() {
+	@Test fun aspectRatioDefault() = runTest {
 		assertThat(getSize(1f, Constraints(maxWidth = 30))).isEqualTo(IntSize(30, 30))
 		assertThat(getSize(2f, Constraints(maxWidth = 30))).isEqualTo(IntSize(30, 15))
 		assertThat(getSize(1f, Constraints(maxWidth = 30, maxHeight = 10))).isEqualTo(IntSize(10, 10))
@@ -38,7 +39,7 @@ class AspectRatioTest {
 		assertThat(getSize(2f, Constraints(minWidth = 50, minHeight = 20))).isEqualTo(IntSize(50, 25))
 	}
 
-	@Test fun aspectRatioMatchHeightConstraintsFirstTrue() {
+	@Test fun aspectRatioMatchHeightConstraintsFirstTrue() = runTest {
 		assertThat(getSize(1f, Constraints(maxHeight = 30), true)).isEqualTo(IntSize(30, 30))
 		assertThat(getSize(0.5f, Constraints(maxHeight = 30), true)).isEqualTo(IntSize(15, 30))
 		assertThat(getSize(1f, Constraints(maxWidth = 10, maxHeight = 30), true))
@@ -55,7 +56,7 @@ class AspectRatioTest {
 			.isEqualTo(IntSize(25, 50))
 	}
 
-	@Test fun aspectRatioIntrinsicDimensions() {
+	@Test fun aspectRatioIntrinsicDimensions() = runTest {
 		testIntrinsics(
 			{
 				Container(modifier = Modifier.aspectRatio(2f), width = 30, height = 40)
@@ -83,7 +84,7 @@ class AspectRatioTest {
 		assertThat(actual).isEqualTo("AspectRatio(1.5, matchHeightConstraintsFirst=true)")
 	}
 
-	private fun getSize(
+	private suspend fun getSize(
 		aspectRatio: Float,
 		childContraints: Constraints,
 		matchHeightConstraintsFirst: Boolean = false,

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/OffsetTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/OffsetTest.kt
@@ -5,128 +5,142 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.TestChar
 import com.jakewharton.mosaic.TestFiller
 import com.jakewharton.mosaic.modifier.Modifier
-import com.jakewharton.mosaic.renderMosaic
-import com.jakewharton.mosaic.replaceLineEndingsWithCRLF
+import com.jakewharton.mosaic.runMosaicTest
 import com.jakewharton.mosaic.s
 import com.jakewharton.mosaic.ui.Box
 import com.jakewharton.mosaic.ui.unit.IntOffset
-import com.jakewharton.mosaic.wrapWithAnsiSynchronizedUpdate
 import kotlin.test.Test
 import kotlin.test.assertFails
+import kotlinx.coroutines.test.runTest
 
 class OffsetTest {
-	@Test fun offsetHorizontalFixed() {
-		val actual = renderMosaic {
-			Box(modifier = Modifier.size(6).offset(3, 0)) {
-				TestFiller(modifier = Modifier.size(1))
+	@Test fun offsetHorizontalFixed() = runTest {
+		runMosaicTest {
+			setContent {
+				Box(modifier = Modifier.size(6).offset(3, 0)) {
+					TestFiller(modifier = Modifier.size(1))
+				}
 			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|   $TestChar $s
+				|     $s
+				|     $s
+				|     $s
+				|     $s
+				|     $s
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|   $TestChar $s
-			|     $s
-			|     $s
-			|     $s
-			|     $s
-			|     $s
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun offsetHorizontalFixedBeyondBorders() {
+	@Test fun offsetHorizontalFixedBeyondBorders() = runTest {
 		assertFails {
-			renderMosaic {
-				Box(modifier = Modifier.size(6).offset(30, 0)) {
-					TestFiller(modifier = Modifier.size(1))
+			runMosaicTest {
+				setContent {
+					Box(modifier = Modifier.size(6).offset(30, 0)) {
+						TestFiller(modifier = Modifier.size(1))
+					}
 				}
 			}
 		}
 	}
 
-	@Test fun offsetHorizontalFixedNegativeBeyondBorders() {
+	@Test fun offsetHorizontalFixedNegativeBeyondBorders() = runTest {
 		assertFails {
-			renderMosaic {
-				Box(modifier = Modifier.size(6).offset(-3, 0)) {
-					TestFiller(modifier = Modifier.size(1))
+			runMosaicTest {
+				setContent {
+					Box(modifier = Modifier.size(6).offset(-3, 0)) {
+						TestFiller(modifier = Modifier.size(1))
+					}
 				}
 			}
 		}
 	}
 
-	@Test fun offsetVerticalFixed() {
-		val actual = renderMosaic {
-			Box(modifier = Modifier.size(6).offset(0, 4)) {
-				TestFiller(modifier = Modifier.size(1))
+	@Test fun offsetVerticalFixed() = runTest {
+		runMosaicTest {
+			setContent {
+				Box(modifier = Modifier.size(6).offset(0, 4)) {
+					TestFiller(modifier = Modifier.size(1))
+				}
 			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|     $s
+				|     $s
+				|     $s
+				|     $s
+				|$TestChar    $s
+				|     $s
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|     $s
-			|     $s
-			|     $s
-			|     $s
-			|$TestChar    $s
-			|     $s
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun offsetVerticalFixedBeyondBorders() {
+	@Test fun offsetVerticalFixedBeyondBorders() = runTest {
 		assertFails {
-			renderMosaic {
-				Box(modifier = Modifier.size(6).offset(0, 40)) {
-					TestFiller(modifier = Modifier.size(1))
+			runMosaicTest {
+				setContent {
+					Box(modifier = Modifier.size(6).offset(0, 40)) {
+						TestFiller(modifier = Modifier.size(1))
+					}
 				}
 			}
 		}
 	}
 
-	@Test fun offsetVerticalFixedNegativeBeyondBorders() {
+	@Test fun offsetVerticalFixedNegativeBeyondBorders() = runTest {
 		assertFails {
-			renderMosaic {
-				Box(modifier = Modifier.size(6).offset(0, -4)) {
-					TestFiller(modifier = Modifier.size(1))
+			runMosaicTest {
+				setContent {
+					Box(modifier = Modifier.size(6).offset(0, -4)) {
+						TestFiller(modifier = Modifier.size(1))
+					}
 				}
 			}
 		}
 	}
 
-	@Test fun offsetFixed() {
-		val actual = renderMosaic {
-			Box(modifier = Modifier.size(6).offset(3, 4)) {
-				TestFiller(modifier = Modifier.size(1))
+	@Test fun offsetFixed() = runTest {
+		runMosaicTest {
+			setContent {
+				Box(modifier = Modifier.size(6).offset(3, 4)) {
+					TestFiller(modifier = Modifier.size(1))
+				}
 			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|     $s
+				|     $s
+				|     $s
+				|     $s
+				|   $TestChar $s
+				|     $s
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|     $s
-			|     $s
-			|     $s
-			|     $s
-			|   $TestChar $s
-			|     $s
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun offsetFixedBeyondBorders() {
+	@Test fun offsetFixedBeyondBorders() = runTest {
 		assertFails {
-			renderMosaic {
-				Box(modifier = Modifier.size(6).offset(30, 40)) {
-					TestFiller(modifier = Modifier.size(1))
+			runMosaicTest {
+				setContent {
+					Box(modifier = Modifier.size(6).offset(30, 40)) {
+						TestFiller(modifier = Modifier.size(1))
+					}
 				}
 			}
 		}
 	}
 
-	@Test fun offsetFixedNegativeBeyondBorders() {
+	@Test fun offsetFixedNegativeBeyondBorders() = runTest {
 		assertFails {
-			renderMosaic {
-				Box(modifier = Modifier.size(6).offset(-3, -4)) {
-					TestFiller(modifier = Modifier.size(1))
+			runMosaicTest {
+				setContent {
+					Box(modifier = Modifier.size(6).offset(-3, -4)) {
+						TestFiller(modifier = Modifier.size(1))
+					}
 				}
 			}
 		}
@@ -137,118 +151,133 @@ class OffsetTest {
 		assertThat(actual).isEqualTo("Offset(x=3, y=4)")
 	}
 
-	@Test fun offsetHorizontalModifiable() {
-		val actual = renderMosaic {
-			Box(modifier = Modifier.size(6).offset { IntOffset(3, 0) }) {
-				TestFiller(modifier = Modifier.size(1))
+	@Test fun offsetHorizontalModifiable() = runTest {
+		runMosaicTest {
+			setContent {
+				Box(modifier = Modifier.size(6).offset { IntOffset(3, 0) }) {
+					TestFiller(modifier = Modifier.size(1))
+				}
 			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|   $TestChar $s
+				|     $s
+				|     $s
+				|     $s
+				|     $s
+				|     $s
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|   $TestChar $s
-			|     $s
-			|     $s
-			|     $s
-			|     $s
-			|     $s
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun offsetHorizontalModifiableBeyondBorders() {
+	@Test fun offsetHorizontalModifiableBeyondBorders() = runTest {
 		assertFails {
-			renderMosaic {
-				Box(modifier = Modifier.size(6).offset { IntOffset(30, 0) }) {
-					TestFiller(modifier = Modifier.size(1))
+			runMosaicTest {
+				setContent {
+					Box(modifier = Modifier.size(6).offset { IntOffset(30, 0) }) {
+						TestFiller(modifier = Modifier.size(1))
+					}
 				}
 			}
 		}
 	}
 
-	@Test fun offsetHorizontalModifiableNegativeBeyondBorders() {
+	@Test fun offsetHorizontalModifiableNegativeBeyondBorders() = runTest {
 		assertFails {
-			renderMosaic {
-				Box(modifier = Modifier.size(6).offset { IntOffset(-3, 0) }) {
-					TestFiller(modifier = Modifier.size(1))
+			runMosaicTest {
+				setContent {
+					Box(modifier = Modifier.size(6).offset { IntOffset(-3, 0) }) {
+						TestFiller(modifier = Modifier.size(1))
+					}
 				}
 			}
 		}
 	}
 
-	@Test fun offsetVerticalModifiable() {
-		val actual = renderMosaic {
-			Box(modifier = Modifier.size(6).offset { IntOffset(0, 4) }) {
-				TestFiller(modifier = Modifier.size(1))
+	@Test fun offsetVerticalModifiable() = runTest {
+		runMosaicTest {
+			setContent {
+				Box(modifier = Modifier.size(6).offset { IntOffset(0, 4) }) {
+					TestFiller(modifier = Modifier.size(1))
+				}
 			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|     $s
+				|     $s
+				|     $s
+				|     $s
+				|$TestChar    $s
+				|     $s
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|     $s
-			|     $s
-			|     $s
-			|     $s
-			|$TestChar    $s
-			|     $s
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun offsetVerticalModifiableBeyondBorders() {
+	@Test fun offsetVerticalModifiableBeyondBorders() = runTest {
 		assertFails {
-			renderMosaic {
-				Box(modifier = Modifier.size(6).offset { IntOffset(0, 40) }) {
-					TestFiller(modifier = Modifier.size(1))
+			runMosaicTest {
+				setContent {
+					Box(modifier = Modifier.size(6).offset { IntOffset(0, 40) }) {
+						TestFiller(modifier = Modifier.size(1))
+					}
 				}
 			}
 		}
 	}
 
-	@Test fun offsetVerticalModifiableNegativeBeyondBorders() {
+	@Test fun offsetVerticalModifiableNegativeBeyondBorders() = runTest {
 		assertFails {
-			renderMosaic {
-				Box(modifier = Modifier.size(6).offset { IntOffset(0, -4) }) {
-					TestFiller(modifier = Modifier.size(1))
+			runMosaicTest {
+				setContent {
+					Box(modifier = Modifier.size(6).offset { IntOffset(0, -4) }) {
+						TestFiller(modifier = Modifier.size(1))
+					}
 				}
 			}
 		}
 	}
 
-	@Test fun offsetModifiable() {
-		val actual = renderMosaic {
-			Box(modifier = Modifier.size(6).offset { IntOffset(3, 4) }) {
-				TestFiller(modifier = Modifier.size(1))
+	@Test fun offsetModifiable() = runTest {
+		runMosaicTest {
+			setContent {
+				Box(modifier = Modifier.size(6).offset { IntOffset(3, 4) }) {
+					TestFiller(modifier = Modifier.size(1))
+				}
 			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|     $s
+				|     $s
+				|     $s
+				|     $s
+				|   $TestChar $s
+				|     $s
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|     $s
-			|     $s
-			|     $s
-			|     $s
-			|   $TestChar $s
-			|     $s
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun offsetModifiableBeyondBorders() {
+	@Test fun offsetModifiableBeyondBorders() = runTest {
 		assertFails {
-			renderMosaic {
-				Box(modifier = Modifier.size(6).offset { IntOffset(30, 40) }) {
-					TestFiller(modifier = Modifier.size(1))
+			runMosaicTest {
+				setContent {
+					Box(modifier = Modifier.size(6).offset { IntOffset(30, 40) }) {
+						TestFiller(modifier = Modifier.size(1))
+					}
 				}
 			}
 		}
 	}
 
-	@Test fun offsetModifiableNegativeBeyondBorders() {
+	@Test fun offsetModifiableNegativeBeyondBorders() = runTest {
 		assertFails {
-			renderMosaic {
-				Box(modifier = Modifier.size(6).offset { IntOffset(-3, -4) }) {
-					TestFiller(modifier = Modifier.size(1))
+			runMosaicTest {
+				setContent {
+					Box(modifier = Modifier.size(6).offset { IntOffset(-3, -4) }) {
+						TestFiller(modifier = Modifier.size(1))
+					}
 				}
 			}
 		}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/PaddingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/PaddingTest.kt
@@ -7,15 +7,14 @@ import com.jakewharton.mosaic.Container
 import com.jakewharton.mosaic.TestChar
 import com.jakewharton.mosaic.TestFiller
 import com.jakewharton.mosaic.modifier.Modifier
-import com.jakewharton.mosaic.renderMosaic
-import com.jakewharton.mosaic.replaceLineEndingsWithCRLF
+import com.jakewharton.mosaic.runMosaicTest
 import com.jakewharton.mosaic.s
 import com.jakewharton.mosaic.testIntrinsics
 import com.jakewharton.mosaic.ui.Layout
 import com.jakewharton.mosaic.ui.unit.Constraints
-import com.jakewharton.mosaic.wrapWithAnsiSynchronizedUpdate
 import kotlin.test.Test
 import kotlin.test.assertFails
+import kotlinx.coroutines.test.runTest
 
 class PaddingTest {
 	@Test fun paddingAllEqualsToPaddingWithExplicitSides() {
@@ -34,28 +33,30 @@ class PaddingTest {
 		}
 	}
 
-	@Test fun paddingLeftZero() {
-		val actual = renderMosaic {
-			SingleFiller(Modifier.padding(left = 0))
+	@Test fun paddingLeftZero() = runTest {
+		runMosaicTest {
+			setContent {
+				SingleFiller(Modifier.padding(left = 0))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|$TestChar
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|$TestChar
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun paddingLeft() {
-		val actual = renderMosaic {
-			SingleFiller(Modifier.padding(left = 2))
+	@Test fun paddingLeft() = runTest {
+		runMosaicTest {
+			setContent {
+				SingleFiller(Modifier.padding(left = 2))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|  $TestChar
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|  $TestChar
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
 	@Test fun paddingLeftDebug() {
@@ -69,30 +70,32 @@ class PaddingTest {
 		}
 	}
 
-	@Test fun paddingTopZero() {
-		val actual = renderMosaic {
-			SingleFiller(Modifier.padding(top = 0))
+	@Test fun paddingTopZero() = runTest {
+		runMosaicTest {
+			setContent {
+				SingleFiller(Modifier.padding(top = 0))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|$TestChar
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|$TestChar
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun paddingTop() {
-		val actual = renderMosaic {
-			SingleFiller(Modifier.padding(top = 2))
+	@Test fun paddingTop() = runTest {
+		runMosaicTest {
+			setContent {
+				SingleFiller(Modifier.padding(top = 2))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|$s
+				|$s
+				|$TestChar
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|$s
-			|$s
-			|$TestChar
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
 	@Test fun paddingTopDebug() {
@@ -106,31 +109,33 @@ class PaddingTest {
 		}
 	}
 
-	@Test fun paddingRightZero() {
-		val actual = renderMosaic {
-			SingleFiller(Modifier.padding(right = 0))
+	@Test fun paddingRightZero() = runTest {
+		runMosaicTest {
+			setContent {
+				SingleFiller(Modifier.padding(right = 0))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|$TestChar
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|$TestChar
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun paddingRight() {
-		val actual = renderMosaic {
-			SingleFiller(Modifier.padding(right = 2))
+	@Test fun paddingRight() = runTest {
+		runMosaicTest {
+			setContent {
+				SingleFiller(Modifier.padding(right = 2))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|$TestChar $s
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|$TestChar $s
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun paddingRightDebug() {
+	@Test fun paddingRightDebug() = runTest {
 		val actual = Modifier.padding(right = 2).toString()
 		assertThat(actual).isEqualTo("Padding(l=0, t=0, r=2, b=0)")
 	}
@@ -141,30 +146,32 @@ class PaddingTest {
 		}
 	}
 
-	@Test fun paddingBottomZero() {
-		val actual = renderMosaic {
-			SingleFiller(Modifier.padding(bottom = 0))
+	@Test fun paddingBottomZero() = runTest {
+		runMosaicTest {
+			setContent {
+				SingleFiller(Modifier.padding(bottom = 0))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|$TestChar
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|$TestChar
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun paddingBottom() {
-		val actual = renderMosaic {
-			SingleFiller(Modifier.padding(bottom = 2))
+	@Test fun paddingBottom() = runTest {
+		runMosaicTest {
+			setContent {
+				SingleFiller(Modifier.padding(bottom = 2))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|$TestChar
+				|$s
+				|$s
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|$TestChar
-			|$s
-			|$s
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
 	@Test fun paddingBottomDebug() {
@@ -178,30 +185,32 @@ class PaddingTest {
 		}
 	}
 
-	@Test fun paddingLeftBottomZero() {
-		val actual = renderMosaic {
-			SingleFiller(Modifier.padding(left = 0, bottom = 0))
+	@Test fun paddingLeftBottomZero() = runTest {
+		runMosaicTest {
+			setContent {
+				SingleFiller(Modifier.padding(left = 0, bottom = 0))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|$TestChar
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			|$TestChar
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun paddingLeftBottom() {
-		val actual = renderMosaic {
-			SingleFiller(Modifier.padding(left = 1, bottom = 2))
+	@Test fun paddingLeftBottom() = runTest {
+		runMosaicTest {
+			setContent {
+				SingleFiller(Modifier.padding(left = 1, bottom = 2))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				| $TestChar
+				| $s
+				| $s
+				""".trimMargin(),
+			)
 		}
-		assertThat(actual).isEqualTo(
-			"""
-			| $TestChar
-			| $s
-			| $s
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
 	@Test fun paddingLeftBottomDebug() {
@@ -224,7 +233,7 @@ class PaddingTest {
 		assertThat(actual).isEqualTo("Padding(h=0, v=2)")
 	}
 
-	@Test fun intrinsicMeasurements() {
+	@Test fun intrinsicMeasurements() = runTest {
 		val padding = 100
 
 		testIntrinsics(

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/FillerTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/FillerTest.kt
@@ -10,63 +10,59 @@ import com.jakewharton.mosaic.layout.padding
 import com.jakewharton.mosaic.layout.size
 import com.jakewharton.mosaic.layout.width
 import com.jakewharton.mosaic.modifier.Modifier
-import com.jakewharton.mosaic.mosaicNodes
 import com.jakewharton.mosaic.mosaicNodesWithMeasureAndPlace
-import com.jakewharton.mosaic.renderMosaic
-import com.jakewharton.mosaic.replaceLineEndingsWithCRLF
+import com.jakewharton.mosaic.runMosaicTest
 import com.jakewharton.mosaic.s
 import com.jakewharton.mosaic.size
 import com.jakewharton.mosaic.ui.unit.Constraints
 import com.jakewharton.mosaic.ui.unit.IntSize
-import com.jakewharton.mosaic.wrapWithAnsiSynchronizedUpdate
 import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 
 class FillerTest {
 	private val bigConstraints = Constraints(maxWidth = 5000, maxHeight = 5000)
 
-	@Test fun fillerFixed() {
+	@Test fun fillerFixed() = runTest {
 		val width = 4
 		val height = 6
-
-		val actual = renderMosaic {
-			TestFiller(Modifier.size(width = width, height = height))
+		runMosaicTest {
+			setContent {
+				TestFiller(Modifier.size(width = width, height = height))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|$TestChar$TestChar$TestChar$TestChar
+				|$TestChar$TestChar$TestChar$TestChar
+				|$TestChar$TestChar$TestChar$TestChar
+				|$TestChar$TestChar$TestChar$TestChar
+				|$TestChar$TestChar$TestChar$TestChar
+				|$TestChar$TestChar$TestChar$TestChar
+				""".trimMargin(),
+			)
 		}
-
-		assertThat(actual).isEqualTo(
-			"""
-			|$TestChar$TestChar$TestChar$TestChar
-			|$TestChar$TestChar$TestChar$TestChar
-			|$TestChar$TestChar$TestChar$TestChar
-			|$TestChar$TestChar$TestChar$TestChar
-			|$TestChar$TestChar$TestChar$TestChar
-			|$TestChar$TestChar$TestChar$TestChar
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun fillerFixedWithPadding() {
+	@Test fun fillerFixedWithPadding() = runTest {
 		val width = 4
 		val height = 6
-
-		val actual = renderMosaic {
-			TestFiller(Modifier.size(width = width, height = height).padding(1))
+		runMosaicTest {
+			setContent {
+				TestFiller(Modifier.size(width = width, height = height).padding(1))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|   $s
+				| $TestChar$TestChar$s
+				| $TestChar$TestChar$s
+				| $TestChar$TestChar$s
+				| $TestChar$TestChar$s
+				|   $s
+				""".trimMargin(),
+			)
 		}
-
-		assertThat(actual).isEqualTo(
-			"""
-			|   $s
-			| $TestChar$TestChar$s
-			| $TestChar$TestChar$s
-			| $TestChar$TestChar$s
-			| $TestChar$TestChar$s
-			|   $s
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun fillerFixedSize() {
+	@Test fun fillerFixedSize() = runTest {
 		val width = 40
 		val height = 71
 
@@ -80,7 +76,7 @@ class FillerTest {
 		assertThat(fillerNode.size).isEqualTo(IntSize(width, height))
 	}
 
-	@Test fun fillerFixedWithSmallerContainer() {
+	@Test fun fillerFixedWithSmallerContainer() = runTest {
 		val width = 40
 		val height = 71
 
@@ -104,7 +100,7 @@ class FillerTest {
 		assertThat(fillerNode.size).isEqualTo(IntSize(containerWidth, containerHeight))
 	}
 
-	@Test fun fillerWidth() {
+	@Test fun fillerWidth() = runTest {
 		val width = 71
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -117,7 +113,7 @@ class FillerTest {
 		assertThat(fillerNode.size).isEqualTo(IntSize(width, 0))
 	}
 
-	@Test fun fillerWidthWithSmallerContainer() {
+	@Test fun fillerWidthWithSmallerContainer() = runTest {
 		val width = 40
 
 		val containerWidth = 5
@@ -140,7 +136,7 @@ class FillerTest {
 		assertThat(fillerNode.size).isEqualTo(IntSize(containerWidth, 0))
 	}
 
-	@Test fun fillerHeight() {
+	@Test fun fillerHeight() = runTest {
 		val height = 7
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -153,7 +149,7 @@ class FillerTest {
 		assertThat(fillerNode.size).isEqualTo(IntSize(0, height))
 	}
 
-	@Test fun fillerHeightWithSmallerContainer() {
+	@Test fun fillerHeightWithSmallerContainer() = runTest {
 		val height = 23
 
 		val containerWidth = 5
@@ -176,15 +172,16 @@ class FillerTest {
 		assertThat(fillerNode.size).isEqualTo(IntSize(0, containerHeight))
 	}
 
-	@Test fun fillerDebug() {
-		val actual = mosaicNodes {
-			TestFiller()
+	@Test fun fillerDebug() = runTest {
+		runMosaicTest {
+			setContent {
+				TestFiller()
+			}
+			assertThat(awaitNodeSnapshot().toString()).isEqualTo(
+				"""
+				|Filler('$TestChar') x=0 y=0 w=0 h=0 DrawBehind
+				""".trimMargin(),
+			)
 		}
-
-		assertThat(actual.toString()).isEqualTo(
-			"""
-			|Filler('$TestChar') x=0 y=0 w=0 h=0 DrawBehind
-			""".trimMargin(),
-		)
 	}
 }

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/RowColumnModifierTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/RowColumnModifierTest.kt
@@ -14,9 +14,10 @@ import com.jakewharton.mosaic.layout.wrapContentWidth
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.mosaicNodesWithMeasureAndPlace
 import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 
 class RowColumnModifierTest {
-	@Test fun rowUpdatesOnAlignmentChange() {
+	@Test fun rowUpdatesOnAlignmentChange() = runTest {
 		val count = 5
 		var alignment by mutableStateOf(Alignment.Top)
 
@@ -43,7 +44,7 @@ class RowColumnModifierTest {
 		}
 	}
 
-	@Test fun rowUpdatesOnWeightChange() {
+	@Test fun rowUpdatesOnWeightChange() = runTest {
 		val count = 5
 		var fill by mutableStateOf(false)
 
@@ -74,7 +75,7 @@ class RowColumnModifierTest {
 		}
 	}
 
-	@Test fun rowUpdatesOnWeightAndAlignmentChange() {
+	@Test fun rowUpdatesOnWeightAndAlignmentChange() = runTest {
 		val count = 5
 		var fill by mutableStateOf(false)
 		var alignment by mutableStateOf(Alignment.Top)
@@ -115,7 +116,7 @@ class RowColumnModifierTest {
 		}
 	}
 
-	@Test fun columnUpdatesOnAlignmentChange() {
+	@Test fun columnUpdatesOnAlignmentChange() = runTest {
 		val count = 5
 		var alignment by mutableStateOf(Alignment.Start)
 
@@ -142,7 +143,7 @@ class RowColumnModifierTest {
 		}
 	}
 
-	@Test fun columnUpdatesOnWeightChange() {
+	@Test fun columnUpdatesOnWeightChange() = runTest {
 		val count = 5
 		var fill by mutableStateOf(false)
 
@@ -173,7 +174,7 @@ class RowColumnModifierTest {
 		}
 	}
 
-	@Test fun columnUpdatesOnWeightAndAlignmentChange() {
+	@Test fun columnUpdatesOnWeightAndAlignmentChange() = runTest {
 		val count = 5
 		var fill by mutableStateOf(false)
 		var alignment by mutableStateOf(Alignment.Start)

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/RowColumnTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/RowColumnTest.kt
@@ -30,10 +30,11 @@ import com.jakewharton.mosaic.ui.unit.IntSize
 import kotlin.math.min
 import kotlin.test.Test
 import kotlin.test.assertFails
+import kotlinx.coroutines.test.runTest
 
 class RowColumnTest {
 	// region Size and position tests for Row and Column
-	@Test fun testRow() {
+	@Test fun testRow() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -54,7 +55,7 @@ class RowColumnTest {
 		assertThat(secondChildContainerNode.position).isEqualTo(IntOffset(size, 0))
 	}
 
-	@Test fun testRow_withChildrenWithWeight() {
+	@Test fun testRow_withChildrenWithWeight() = runTest {
 		val width = 50
 		val height = 80
 
@@ -78,7 +79,7 @@ class RowColumnTest {
 		assertThat(secondChildContainerNode.position).isEqualTo(IntOffset(rootWidth / 3, 0))
 	}
 
-	@Test fun testRow_withChildrenWithWeightNonFilling() {
+	@Test fun testRow_withChildrenWithWeightNonFilling() = runTest {
 		val width = 50
 		val height = 80
 
@@ -107,7 +108,7 @@ class RowColumnTest {
 		assertThat(secondChildContainerNode.position).isEqualTo(IntOffset(width, 0))
 	}
 
-	@Test fun testRow_withChildrenWithMaxValueWeight() {
+	@Test fun testRow_withChildrenWithMaxValueWeight() = runTest {
 		val width = 50
 		val height = 80
 
@@ -131,7 +132,7 @@ class RowColumnTest {
 		assertThat(secondChildContainerNode.position).isEqualTo(IntOffset(rootWidth, 0))
 	}
 
-	@Test fun testRow_withChildrenWithPositiveInfinityWeight() {
+	@Test fun testRow_withChildrenWithPositiveInfinityWeight() = runTest {
 		val width = 50
 		val height = 80
 
@@ -173,7 +174,7 @@ class RowColumnTest {
 		}
 	}
 
-	@Test fun testColumn() {
+	@Test fun testColumn() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -194,7 +195,7 @@ class RowColumnTest {
 		assertThat(secondChildContainerNode.position).isEqualTo(IntOffset(0, size))
 	}
 
-	@Test fun testColumn_withChildrenWithWeight() {
+	@Test fun testColumn_withChildrenWithWeight() = runTest {
 		val width = 80
 		val height = 50
 
@@ -218,7 +219,7 @@ class RowColumnTest {
 		assertThat(secondChildContainerNode.position).isEqualTo(IntOffset(0, rootHeight / 3))
 	}
 
-	@Test fun testColumn_withChildrenWithWeightNonFilling() {
+	@Test fun testColumn_withChildrenWithWeightNonFilling() = runTest {
 		val width = 80
 		val height = 50
 
@@ -243,7 +244,7 @@ class RowColumnTest {
 		assertThat(secondChildContainerNode.position).isEqualTo(IntOffset(0, height))
 	}
 
-	@Test fun testColumn_withChildrenWithMaxValueWeight() {
+	@Test fun testColumn_withChildrenWithMaxValueWeight() = runTest {
 		val width = 80
 		val height = 50
 
@@ -267,7 +268,7 @@ class RowColumnTest {
 		assertThat(secondChildContainerNode.position).isEqualTo(IntOffset(0, rootHeight))
 	}
 
-	@Test fun testColumn_withChildrenWithPositiveInfinityWeight() {
+	@Test fun testColumn_withChildrenWithPositiveInfinityWeight() = runTest {
 		val width = 80
 		val height = 50
 
@@ -309,7 +310,7 @@ class RowColumnTest {
 		}
 	}
 
-	@Test fun testRow_doesNotPlaceChildrenOutOfBounds_becauseOfRoundings() {
+	@Test fun testRow_doesNotPlaceChildrenOutOfBounds_becauseOfRoundings() = runTest {
 		val expectedRowWidth = 11
 		val leftPadding = 1
 
@@ -336,7 +337,7 @@ class RowColumnTest {
 			.isEqualTo(rowNode.width - leftPadding)
 	}
 
-	@Test fun testRow_isNotLargerThanItsChildren_becauseOfRoundings() {
+	@Test fun testRow_isNotLargerThanItsChildren_becauseOfRoundings() = runTest {
 		val expectedRowWidth = 8
 		val leftPadding = 1
 
@@ -367,7 +368,7 @@ class RowColumnTest {
 			.isEqualTo(firstChildContainerNode.width + secondChildContainerNode.width + thirdChildContainerNode.width)
 	}
 
-	@Test fun testColumn_isNotLargetThanItsChildren_becauseOfRoundings() {
+	@Test fun testColumn_isNotLargetThanItsChildren_becauseOfRoundings() = runTest {
 		val expectedColumnHeight = 8
 		val topPadding = 1
 
@@ -398,7 +399,7 @@ class RowColumnTest {
 			.isEqualTo(firstChildContainerNode.height + secondChildContainerNode.height + thirdChildContainerNode.height)
 	}
 
-	@Test fun testColumn_doesNotPlaceChildrenOutOfBounds_becauseOfRoundings() {
+	@Test fun testColumn_doesNotPlaceChildrenOutOfBounds_becauseOfRoundings() = runTest {
 		val expectedColumnHeight = 11
 		val topPadding = 1
 
@@ -428,7 +429,7 @@ class RowColumnTest {
 	// endregion
 
 	// region Cross axis alignment tests in Row
-	@Test fun testRow_withStretchCrossAxisAlignment() {
+	@Test fun testRow_withStretchCrossAxisAlignment() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -449,7 +450,7 @@ class RowColumnTest {
 		assertThat(secondChildContainerNode.position).isEqualTo(IntOffset(size, 0))
 	}
 
-	@Test fun testRow_withGravityModifier_andGravityParameter() {
+	@Test fun testRow_withGravityModifier_andGravityParameter() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -479,7 +480,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(size * 2, rootHeight - size))
 	}
 
-	@Test fun testRow_withGravityModifier() {
+	@Test fun testRow_withGravityModifier() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -515,7 +516,7 @@ class RowColumnTest {
 	// endregion
 
 	// region Cross axis alignment tests in Column
-	@Test fun testColumn_withStretchCrossAxisAlignment() {
+	@Test fun testColumn_withStretchCrossAxisAlignment() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -536,7 +537,7 @@ class RowColumnTest {
 		assertThat(secondChildContainerNode.position).isEqualTo(IntOffset(0, size))
 	}
 
-	@Test fun testColumn_withGravityModifier() {
+	@Test fun testColumn_withGravityModifier() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -565,7 +566,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(rootWidth - size, size * 2))
 	}
 
-	@Test fun testColumn_withGravityModifier_andGravityParameter() {
+	@Test fun testColumn_withGravityModifier_andGravityParameter() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -592,7 +593,7 @@ class RowColumnTest {
 	// endregion
 
 	// region Size tests in Row
-	@Test fun testRow_expandedWidth_withExpandedModifier() {
+	@Test fun testRow_expandedWidth_withExpandedModifier() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -609,7 +610,7 @@ class RowColumnTest {
 		assertThat(rootNode.width).isEqualTo(rowNode.width)
 	}
 
-	@Test fun testRow_wrappedWidth_withNoWeightChildren() {
+	@Test fun testRow_wrappedWidth_withNoWeightChildren() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -626,7 +627,7 @@ class RowColumnTest {
 		assertThat(rowNode.width).isEqualTo(size * 3)
 	}
 
-	@Test fun testRow_expandedWidth_withWeightChildren() {
+	@Test fun testRow_expandedWidth_withWeightChildren() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -643,7 +644,7 @@ class RowColumnTest {
 		assertThat(rowNode.width).isEqualTo(rootNode.width)
 	}
 
-	@Test fun testRow_withMaxCrossAxisSize() {
+	@Test fun testRow_withMaxCrossAxisSize() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -660,7 +661,7 @@ class RowColumnTest {
 		assertThat(rowNode.height).isEqualTo(rootNode.height)
 	}
 
-	@Test fun testRow_withMinCrossAxisSize() {
+	@Test fun testRow_withMinCrossAxisSize() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -677,7 +678,7 @@ class RowColumnTest {
 		assertThat(rowNode.height).isEqualTo(size * 2)
 	}
 
-	@Test fun testRow_withExpandedModifier_respectsMaxWidthConstraint() {
+	@Test fun testRow_withExpandedModifier_respectsMaxWidthConstraint() = runTest {
 		val size = 50
 		val rowWidth = 250
 
@@ -697,7 +698,7 @@ class RowColumnTest {
 		assertThat(rowNode.width).isEqualTo(rootNode.width)
 	}
 
-	@Test fun testRow_withChildrenWithWeight_respectsMaxWidthConstraint() {
+	@Test fun testRow_withChildrenWithWeight_respectsMaxWidthConstraint() = runTest {
 		val size = 50
 		val rowWidth = 250
 
@@ -717,7 +718,7 @@ class RowColumnTest {
 		assertThat(rowNode.width).isEqualTo(min(rootNode.width, rowWidth))
 	}
 
-	@Test fun testRow_withNoWeightChildren_respectsMinWidthConstraint() {
+	@Test fun testRow_withNoWeightChildren_respectsMinWidthConstraint() = runTest {
 		val size = 50
 		val rowWidth = 250
 
@@ -737,7 +738,7 @@ class RowColumnTest {
 		assertThat(rowNode.width).isEqualTo(rowWidth)
 	}
 
-	@Test fun testRow_withMaxCrossAxisSize_respectsMaxHeightConstraint() {
+	@Test fun testRow_withMaxCrossAxisSize_respectsMaxHeightConstraint() = runTest {
 		val size = 50
 		val rowHeight = 250
 
@@ -757,7 +758,7 @@ class RowColumnTest {
 		assertThat(rowNode.height).isEqualTo(min(rootNode.height, rowHeight))
 	}
 
-	@Test fun testRow_withMinCrossAxisSize_respectsMinHeightConstraint() {
+	@Test fun testRow_withMinCrossAxisSize_respectsMinHeightConstraint() = runTest {
 		val size = 50
 		val rowHeight = 150
 
@@ -777,7 +778,7 @@ class RowColumnTest {
 		assertThat(rowNode.height).isEqualTo(rowHeight)
 	}
 
-	@Test fun testRow_protectsAgainstOverflow() {
+	@Test fun testRow_protectsAgainstOverflow() = runTest {
 		val rowMinWidth = 0
 		val counter = Holder(3)
 
@@ -809,7 +810,7 @@ class RowColumnTest {
 		assertThat(counter.value).isZero()
 	}
 
-	@Test fun testRow_doesNotExpand_whenWeightChildrenDoNotFill() {
+	@Test fun testRow_doesNotExpand_whenWeightChildrenDoNotFill() = runTest {
 		val size = 10
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -821,7 +822,7 @@ class RowColumnTest {
 		assertThat(rootNode.width).isEqualTo(size)
 	}
 
-	@Test fun testRow_includesSpacing_withWeightChildren() {
+	@Test fun testRow_includesSpacing_withWeightChildren() = runTest {
 		val rowWidth = 40
 		val space = 8
 
@@ -846,7 +847,7 @@ class RowColumnTest {
 	// endregion
 
 	// region Size tests in Column
-	@Test fun testColumn_expandedHeight_withExpandedModifier() {
+	@Test fun testColumn_expandedHeight_withExpandedModifier() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -863,7 +864,7 @@ class RowColumnTest {
 		assertThat(columnNode.height).isEqualTo(rootNode.height)
 	}
 
-	@Test fun testColumn_wrappedHeight_withNoChildrenWithWeight() {
+	@Test fun testColumn_wrappedHeight_withNoChildrenWithWeight() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -880,7 +881,7 @@ class RowColumnTest {
 		assertThat(columnNode.height).isEqualTo(size * 3)
 	}
 
-	@Test fun testColumn_expandedHeight_withWeightChildren() {
+	@Test fun testColumn_expandedHeight_withWeightChildren() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -897,7 +898,7 @@ class RowColumnTest {
 		assertThat(columnNode.height).isEqualTo(rootNode.height)
 	}
 
-	@Test fun testColumn_withMaxCrossAxisSize() {
+	@Test fun testColumn_withMaxCrossAxisSize() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -914,7 +915,7 @@ class RowColumnTest {
 		assertThat(columnNode.width).isEqualTo(rootNode.width)
 	}
 
-	@Test fun testColumn_withMinCrossAxisSize() {
+	@Test fun testColumn_withMinCrossAxisSize() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -931,7 +932,7 @@ class RowColumnTest {
 		assertThat(columnNode.width).isEqualTo(size * 2)
 	}
 
-	@Test fun testColumn_withExpandedModifier_respectsMaxHeightConstraint() {
+	@Test fun testColumn_withExpandedModifier_respectsMaxHeightConstraint() = runTest {
 		val size = 50
 		val columnHeight = 250
 
@@ -951,7 +952,7 @@ class RowColumnTest {
 		assertThat(columnNode.height).isEqualTo(min(rootNode.height, columnHeight))
 	}
 
-	@Test fun testColumn_withWeightChildren_respectsMaxHeightConstraint() {
+	@Test fun testColumn_withWeightChildren_respectsMaxHeightConstraint() = runTest {
 		val size = 50
 		val columnHeight = 250
 
@@ -971,7 +972,7 @@ class RowColumnTest {
 		assertThat(columnNode.height).isEqualTo(min(rootNode.height, columnHeight))
 	}
 
-	@Test fun testColumn_withChildren_respectsMinHeightConstraint() {
+	@Test fun testColumn_withChildren_respectsMinHeightConstraint() = runTest {
 		val size = 50
 		val columnHeight = 250
 
@@ -991,7 +992,7 @@ class RowColumnTest {
 		assertThat(columnNode.height).isEqualTo(columnHeight)
 	}
 
-	@Test fun testColumn_withMaxCrossAxisSize_respectsMaxWidthConstraint() {
+	@Test fun testColumn_withMaxCrossAxisSize_respectsMaxWidthConstraint() = runTest {
 		val size = 50
 		val columnWidth = 250
 
@@ -1011,7 +1012,7 @@ class RowColumnTest {
 		assertThat(columnNode.width).isEqualTo(min(rootNode.width, columnWidth))
 	}
 
-	@Test fun testColumn_withMinCrossAxisSize_respectsMinWidthConstraint() {
+	@Test fun testColumn_withMinCrossAxisSize_respectsMinWidthConstraint() = runTest {
 		val size = 50
 		val columnWidth = 150
 
@@ -1031,7 +1032,7 @@ class RowColumnTest {
 		assertThat(columnNode.width).isEqualTo(columnWidth)
 	}
 
-	@Test fun testColumn_doesNotExpand_whenWeightChildrenDoNotFill() {
+	@Test fun testColumn_doesNotExpand_whenWeightChildrenDoNotFill() = runTest {
 		val size = 10
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1043,7 +1044,7 @@ class RowColumnTest {
 		assertThat(rootNode.height).isEqualTo(size)
 	}
 
-	@Test fun testColumn_includesSpacing_withWeightChildren() {
+	@Test fun testColumn_includesSpacing_withWeightChildren() = runTest {
 		val columnHeight = 40
 		val space = 8
 
@@ -1068,7 +1069,7 @@ class RowColumnTest {
 	// endregion
 
 	// region Main axis alignment tests in Row
-	@Test fun testRow_withStartArrangement() {
+	@Test fun testRow_withStartArrangement() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1090,7 +1091,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(size * 2, 0))
 	}
 
-	@Test fun testRow_withEndArrangement() {
+	@Test fun testRow_withEndArrangement() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1115,7 +1116,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(rootNode.width - size, 0))
 	}
 
-	@Test fun testRow_withCenterArrangement() {
+	@Test fun testRow_withCenterArrangement() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1147,7 +1148,7 @@ class RowColumnTest {
 		)
 	}
 
-	@Test fun testRow_withSpaceEvenlyArrangement() {
+	@Test fun testRow_withSpaceEvenlyArrangement() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1174,7 +1175,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(size * 2 + gap * 3, 0))
 	}
 
-	@Test fun testRow_withSpaceBetweenArrangement_singleItem() {
+	@Test fun testRow_withSpaceBetweenArrangement_singleItem() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1193,7 +1194,7 @@ class RowColumnTest {
 		assertThat(childContainerNode.position).isEqualTo(IntOffset.Zero)
 	}
 
-	@Test fun testRow_withSpaceBetweenArrangement_multipleItems() {
+	@Test fun testRow_withSpaceBetweenArrangement_multipleItems() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1220,7 +1221,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(gap * 2 + size * 2, 0))
 	}
 
-	@Test fun testRow_withSpaceAroundArrangement() {
+	@Test fun testRow_withSpaceAroundArrangement() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1247,7 +1248,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset((gap * 5 / 2) + size * 2, 0))
 	}
 
-	@Test fun testRow_withSpacedByArrangement() {
+	@Test fun testRow_withSpacedByArrangement() = runTest {
 		val space = 10
 		val size = 20
 
@@ -1267,7 +1268,7 @@ class RowColumnTest {
 		assertThat(secondChildBoxNode.x).isEqualTo(size + space)
 	}
 
-	@Test fun testRow_withSpacedByAlignedArrangement() {
+	@Test fun testRow_withSpacedByAlignedArrangement() = runTest {
 		val space = 10
 		val size = 20
 		val rowSize = 50
@@ -1294,7 +1295,7 @@ class RowColumnTest {
 		assertThat(secondChildBoxNode.x).isEqualTo(rowSize - size)
 	}
 
-	@Test fun testRow_withSpacedByArrangement_insufficientSpace() {
+	@Test fun testRow_withSpacedByArrangement_insufficientSpace() = runTest {
 		val space = 15
 		val size = 20
 		val rowSize = 50
@@ -1327,7 +1328,7 @@ class RowColumnTest {
 		assertThat(thirdChildBoxNode.x).isEqualTo(rowSize)
 	}
 
-	@Test fun testRow_withAlignedArrangement() {
+	@Test fun testRow_withAlignedArrangement() = runTest {
 		val size = 20
 		val rowSize = 50
 
@@ -1357,7 +1358,7 @@ class RowColumnTest {
 	// endregion
 
 	// region Main axis alignment tests in Column
-	@Test fun testColumn_withTopArrangement() {
+	@Test fun testColumn_withTopArrangement() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1379,7 +1380,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(0, size * 2))
 	}
 
-	@Test fun testColumn_withBottomArrangement() {
+	@Test fun testColumn_withBottomArrangement() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1406,7 +1407,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(0, rootHeight - size))
 	}
 
-	@Test fun testColumn_withCenterArrangement() {
+	@Test fun testColumn_withCenterArrangement() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1438,7 +1439,7 @@ class RowColumnTest {
 		)
 	}
 
-	@Test fun testColumn_withSpaceEvenlyArrangement() {
+	@Test fun testColumn_withSpaceEvenlyArrangement() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1465,7 +1466,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(0, size * 2 + gap * 3))
 	}
 
-	@Test fun testColumn_withSpaceBetweenArrangement() {
+	@Test fun testColumn_withSpaceBetweenArrangement() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1492,7 +1493,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(0, size * 2 + gap * 2))
 	}
 
-	@Test fun testColumn_withSpaceAroundArrangement() {
+	@Test fun testColumn_withSpaceAroundArrangement() = runTest {
 		val size = 50
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -1519,7 +1520,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(0, size * 2 + (gap * 5 / 2)))
 	}
 
-	@Test fun testColumn_withSpacedByArrangement() {
+	@Test fun testColumn_withSpacedByArrangement() = runTest {
 		val space = 10
 		val size = 20
 
@@ -1542,7 +1543,7 @@ class RowColumnTest {
 		assertThat(secondChildBoxNode.y).isEqualTo(size + space)
 	}
 
-	@Test fun testColumn_withSpacedByAlignedArrangement() {
+	@Test fun testColumn_withSpacedByAlignedArrangement() = runTest {
 		val space = 10
 		val size = 20
 		val columnSize = 50
@@ -1569,7 +1570,7 @@ class RowColumnTest {
 		assertThat(secondChildBoxNode.y).isEqualTo(columnSize - size)
 	}
 
-	@Test fun testColumn_withSpacedByArrangement_insufficientSpace() {
+	@Test fun testColumn_withSpacedByArrangement_insufficientSpace() = runTest {
 		val space = 15
 		val size = 20
 		val columnSize = 50
@@ -1602,7 +1603,7 @@ class RowColumnTest {
 		assertThat(thirdChildBoxNode.y).isEqualTo(columnSize)
 	}
 
-	@Test fun testColumn_withAlignedArrangement() {
+	@Test fun testColumn_withAlignedArrangement() = runTest {
 		val size = 20
 		val columnSize = 50
 
@@ -1628,7 +1629,7 @@ class RowColumnTest {
 		assertThat(secondChildBoxNode.y).isEqualTo(columnSize - size)
 	}
 
-	@Test fun testRow_doesNotUseMinConstraintsOnChildren() {
+	@Test fun testRow_doesNotUseMinConstraintsOnChildren() = runTest {
 		val size = 50
 		val childSize = 30
 
@@ -1647,7 +1648,7 @@ class RowColumnTest {
 		assertThat(spacerNode.size).isEqualTo(IntSize(childSize, childSize))
 	}
 
-	@Test fun testColumn_doesNotUseMinConstraintsOnChildren() {
+	@Test fun testColumn_doesNotUseMinConstraintsOnChildren() = runTest {
 		val size = 50
 		val childSize = 30
 
@@ -1668,7 +1669,7 @@ class RowColumnTest {
 	// endregion
 
 	// region Intrinsic measurement tests
-	@Test fun testRow_withNoWeightChildren_hasCorrectIntrinsicMeasurements() {
+	@Test fun testRow_withNoWeightChildren_hasCorrectIntrinsicMeasurements() = runTest {
 		testIntrinsics(
 			@Composable {
 				Row {
@@ -1756,7 +1757,7 @@ class RowColumnTest {
 		}
 	}
 
-	@Test fun testRow_withWeightChildren_hasCorrectIntrinsicMeasurements() {
+	@Test fun testRow_withWeightChildren_hasCorrectIntrinsicMeasurements() = runTest {
 		testIntrinsics(
 			@Composable {
 				Row {
@@ -1906,7 +1907,7 @@ class RowColumnTest {
 		}
 	}
 
-	@Test fun testRow_withArrangementSpacing() {
+	@Test fun testRow_withArrangementSpacing() = runTest {
 		val spacing = 5
 		val childSize = 10
 		testIntrinsics(
@@ -1923,7 +1924,7 @@ class RowColumnTest {
 		}
 	}
 
-	@Test fun testColumn_withNoWeightChildren_hasCorrectIntrinsicMeasurements() {
+	@Test fun testColumn_withNoWeightChildren_hasCorrectIntrinsicMeasurements() = runTest {
 		testIntrinsics(
 			@Composable {
 				Column {
@@ -2008,7 +2009,7 @@ class RowColumnTest {
 		}
 	}
 
-	@Test fun testColumn_withWeightChildren_hasCorrectIntrinsicMeasurements() {
+	@Test fun testColumn_withWeightChildren_hasCorrectIntrinsicMeasurements() = runTest {
 		testIntrinsics(
 			@Composable {
 				Column {
@@ -2158,7 +2159,7 @@ class RowColumnTest {
 		}
 	}
 
-	@Test fun testColumn_withArrangementSpacing() {
+	@Test fun testColumn_withArrangementSpacing() = runTest {
 		val spacing = 5
 		val childSize = 10
 		testIntrinsics(
@@ -2177,7 +2178,7 @@ class RowColumnTest {
 	// endregion
 
 	// region Modifiers specific tests
-	@Test fun testRowColumnModifiersChain_leftMostWins() {
+	@Test fun testRowColumnModifiersChain_leftMostWins() = runTest {
 		val columnHeight = 24
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -2196,7 +2197,7 @@ class RowColumnTest {
 	// endregion
 
 	// region AbsoluteArrangement tests
-	@Test fun testRow_absoluteArrangementLeft() {
+	@Test fun testRow_absoluteArrangementLeft() = runTest {
 		val size = 100
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -2219,7 +2220,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(size * 2, 0))
 	}
 
-	@Test fun testRow_absoluteArrangementRight() {
+	@Test fun testRow_absoluteArrangementRight() = runTest {
 		val size = 100
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -2244,7 +2245,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(rootWidth - size, 0))
 	}
 
-	@Test fun testRow_absoluteArrangementCenter() {
+	@Test fun testRow_absoluteArrangementCenter() = runTest {
 		val size = 100
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -2274,7 +2275,7 @@ class RowColumnTest {
 		)
 	}
 
-	@Test fun testRow_absoluteArrangementSpaceEvenly() {
+	@Test fun testRow_absoluteArrangementSpaceEvenly() = runTest {
 		val size = 100
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -2299,7 +2300,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(size * 2 + gap * 3, 0))
 	}
 
-	@Test fun testRow_absoluteArrangementSpaceBetween() {
+	@Test fun testRow_absoluteArrangementSpaceBetween() = runTest {
 		val size = 100
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -2324,7 +2325,7 @@ class RowColumnTest {
 		assertThat(thirdChildContainerNode.position).isEqualTo(IntOffset(gap * 2 + size * 2, 0))
 	}
 
-	@Test fun testRow_absoluteArrangementSpaceAround() {
+	@Test fun testRow_absoluteArrangementSpaceAround() = runTest {
 		val size = 100
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/SpacerTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/SpacerTest.kt
@@ -7,42 +7,40 @@ import com.jakewharton.mosaic.layout.height
 import com.jakewharton.mosaic.layout.size
 import com.jakewharton.mosaic.layout.width
 import com.jakewharton.mosaic.modifier.Modifier
-import com.jakewharton.mosaic.mosaicNodes
 import com.jakewharton.mosaic.mosaicNodesWithMeasureAndPlace
-import com.jakewharton.mosaic.renderMosaic
-import com.jakewharton.mosaic.replaceLineEndingsWithCRLF
+import com.jakewharton.mosaic.runMosaicTest
 import com.jakewharton.mosaic.s
 import com.jakewharton.mosaic.size
 import com.jakewharton.mosaic.ui.unit.Constraints
 import com.jakewharton.mosaic.ui.unit.IntSize
-import com.jakewharton.mosaic.wrapWithAnsiSynchronizedUpdate
 import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 
 class SpacerTest {
 	private val bigConstraints = Constraints(maxWidth = 5000, maxHeight = 5000)
 
-	@Test fun spacerFixed() {
+	@Test fun spacerFixed() = runTest {
 		val width = 4
 		val height = 6
 
-		val actual = renderMosaic {
-			Spacer(Modifier.size(width = width, height = height))
+		runMosaicTest {
+			setContent {
+				Spacer(Modifier.size(width = width, height = height))
+			}
+			assertThat(awaitRenderSnapshot()).isEqualTo(
+				"""
+				|   $s
+				|   $s
+				|   $s
+				|   $s
+				|   $s
+				|   $s
+				""".trimMargin(),
+			)
 		}
-
-		assertThat(actual).isEqualTo(
-			"""
-			|   $s
-			|   $s
-			|   $s
-			|   $s
-			|   $s
-			|   $s
-			|
-			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
-		)
 	}
 
-	@Test fun spacerFixedSize() {
+	@Test fun spacerFixedSize() = runTest {
 		val width = 40
 		val height = 71
 
@@ -56,7 +54,7 @@ class SpacerTest {
 		assertThat(spacerNode.size).isEqualTo(IntSize(width, height))
 	}
 
-	@Test fun spacerFixedWithSmallerContainer() {
+	@Test fun spacerFixedWithSmallerContainer() = runTest {
 		val width = 40
 		val height = 71
 
@@ -80,7 +78,7 @@ class SpacerTest {
 		assertThat(spacerNode.size).isEqualTo(IntSize(containerWidth, containerHeight))
 	}
 
-	@Test fun spacerWidth() {
+	@Test fun spacerWidth() = runTest {
 		val width = 71
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -93,7 +91,7 @@ class SpacerTest {
 		assertThat(spacerNode.size).isEqualTo(IntSize(width, 0))
 	}
 
-	@Test fun spacerWidthWithSmallerContainer() {
+	@Test fun spacerWidthWithSmallerContainer() = runTest {
 		val width = 40
 
 		val containerWidth = 5
@@ -116,7 +114,7 @@ class SpacerTest {
 		assertThat(spacerNode.size).isEqualTo(IntSize(containerWidth, 0))
 	}
 
-	@Test fun spacerHeight() {
+	@Test fun spacerHeight() = runTest {
 		val height = 7
 
 		val rootNode = mosaicNodesWithMeasureAndPlace {
@@ -129,7 +127,7 @@ class SpacerTest {
 		assertThat(spacerNode.size).isEqualTo(IntSize(0, height))
 	}
 
-	@Test fun spacerHeightWithSmallerContainer() {
+	@Test fun spacerHeightWithSmallerContainer() = runTest {
 		val height = 23
 
 		val containerWidth = 5
@@ -152,15 +150,16 @@ class SpacerTest {
 		assertThat(spacerNode.size).isEqualTo(IntSize(0, containerHeight))
 	}
 
-	@Test fun spacerDebug() {
-		val actual = mosaicNodes {
-			Spacer()
+	@Test fun spacerDebug() = runTest {
+		runMosaicTest {
+			setContent {
+				Spacer()
+			}
+			assertThat(awaitNodeSnapshot().toString()).isEqualTo(
+				"""
+				|Spacer() x=0 y=0 w=0 h=0
+				""".trimMargin(),
+			)
 		}
-
-		assertThat(actual.toString()).isEqualTo(
-			"""
-			|Spacer() x=0 y=0 w=0 h=0
-			""".trimMargin(),
-		)
 	}
 }


### PR DESCRIPTION
- Rename `BaseMosaicComposition` to `MosaicComposition`, and `MosaicComposition` to `RenderingMosaicComposition` (with some changes)
- Use `RenderingMosaicComposition` in `renderMosaic` instead of `mosaicNodes`
- Use `runMosaicTest` in unit tests instead of `mosaicNodes`
- Remove `mosaicNodes`
- Create an `internal` `TestMosaicComposition` interface with the implementation of `RealTestMosaicComposition`
- Add unit tests for synchronous `renderMosaic`

---
The main number of changes is simply the transfer of tests to `runMosaicTest`.

---
- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
