### PR TITLE
Using print for output

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,6 @@ spotless-gradlePlugin = "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
 ktlint-core = "com.pinterest.ktlint:ktlint-cli:1.3.1"
 ktlint-composeRules = "io.nlopez.compose.rules:ktlint:0.4.10"
 
-jansi = "org.fusesource.jansi:jansi:2.4.1"
 mordant = "com.github.ajalt.mordant:mordant:2.7.2"
 codepoints = "de.cketti.unicode:kotlin-codepoints:0.9.0"
 

--- a/mosaic-runtime/build.gradle
+++ b/mosaic-runtime/build.gradle
@@ -35,9 +35,6 @@ kotlin {
 
 		jvmMain {
 			dependsOn(concurrentMain)
-			dependencies {
-				implementation libs.jansi
-			}
 		}
 		nonJvmMain {
 			dependsOn(commonMain)

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -57,7 +57,7 @@ public suspend fun runMosaic(content: @Composable () -> Unit) {
 			coroutineScope = this,
 			terminalState = terminalState,
 			onEndChanges = { rootNode ->
-				platformDisplay(rendering.render(rootNode))
+				print(rendering.render(rootNode))
 			},
 		)
 		mosaicComposition.sendFrames()

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/platform.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/platform.kt
@@ -1,7 +1,5 @@
 package com.jakewharton.mosaic
 
-internal expect fun platformDisplay(chars: CharSequence)
-
 internal expect class AtomicBoolean(initialValue: Boolean) {
 
 	fun set(value: Boolean)

--- a/mosaic-runtime/src/jvmMain/kotlin/com/jakewharton/mosaic/platform.kt
+++ b/mosaic-runtime/src/jvmMain/kotlin/com/jakewharton/mosaic/platform.kt
@@ -1,26 +1,6 @@
 package com.jakewharton.mosaic
 
-import java.nio.CharBuffer
-import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.atomic.AtomicBoolean as JavaAtomicBoolean
-import org.fusesource.jansi.AnsiConsole
-
-private val out = AnsiConsole.out()!!.also { AnsiConsole.systemInstall() }
-private val encoder = UTF_8.newEncoder()!!
-
-internal actual fun platformDisplay(chars: CharSequence) {
-	// Write a single byte array to stdout to create an atomic visual change. If you instead write
-	// the string, it will be UTF-8 encoded using an intermediate buffer that appears to be
-	// periodically flushed to the underlying byte stream. This will cause fraction-of-a-second
-	// flickers of broken content. Note that this only occurs with the AnsiConsole stream, but
-	// there's no harm in doing it unconditionally.
-	val bytes = encoder.encode(CharBuffer.wrap(chars))
-	out.write(bytes.array(), 0, bytes.limit())
-
-	// Explicitly flush to ensure the trailing line clear is sent. Empirically, this appears to be
-	// buffered and not processed until the next frame, or not at all on the final frame.
-	out.flush()
-}
 
 internal actual class AtomicBoolean actual constructor(initialValue: Boolean) {
 	private val delegate = JavaAtomicBoolean(initialValue)

--- a/mosaic-runtime/src/nonJvmMain/kotlin/com/jakewharton/mosaic/platform.kt
+++ b/mosaic-runtime/src/nonJvmMain/kotlin/com/jakewharton/mosaic/platform.kt
@@ -1,9 +1,5 @@
 package com.jakewharton.mosaic
 
-internal actual fun platformDisplay(chars: CharSequence) {
-	print(chars.toString())
-}
-
 internal actual class AtomicBoolean actual constructor(initialValue: Boolean) {
 	private var value: Boolean = initialValue
 


### PR DESCRIPTION
I tried to compare the option before and the option after, I didn't really see the difference, maybe there are cases when it is noticeable? I'll be glad if you tell me.

I wanted to make an issue with the question first, but decided that it would be faster, because there are minimal changes and immediately, if everything is good, we can apply them.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
