### PR TITLE
Add Linux RISC-V support for JVM

### DIFF
--- a/mosaic-terminal/build.zig
+++ b/mosaic-terminal/build.zig
@@ -6,6 +6,7 @@ pub fn build(b: *std.Build) !void {
 	b.getInstallStep().dependOn(&deleteLib.step);
 
 	setupMosaicTarget(b, &deleteLib.step, .linux, .aarch64, "arm64");
+	setupMosaicTarget(b, &deleteLib.step, .linux, .riscv64, "riscv");
 	setupMosaicTarget(b, &deleteLib.step, .linux, .x86_64, "x86_64");
 	setupMosaicTarget(b, &deleteLib.step, .macos, .aarch64, "aarch64");
 	setupMosaicTarget(b, &deleteLib.step, .macos, .x86_64, "x86_64");


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
