### PR TITLE
Put resource file check on resource task

### DIFF
--- a/mosaic-terminal/build.gradle
+++ b/mosaic-terminal/build.gradle
@@ -11,10 +11,10 @@ kotlin {
 	explicitApi()
 
 	jvm {
-		compilations.main.compileTaskProvider.configure {
+		tasks.named(compilations.main.processResourcesTaskName).configure {
 			doFirst {
 				def files = project.fileTree('src/jvmMain/resources').files
-				if (files.size() != 6) {
+				if (files.size() != 7) {
 					throw new RuntimeException(
 						"Missing native libraries. Run `zig build -p src/jvmMain/resources/jni`. Found: $files",
 					)


### PR DESCRIPTION
Also update now that we have a RISC-V binary.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
