### PR TITLE
Add overload of `stdinReader` which takes a path to stdin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
+kotlinx-io = "org.jetbrains.kotlinx:kotlinx-io-core:0.5.4"
+
 compose-collection = { module = "org.jetbrains.compose.collection-internal:collection", version.ref = "compose" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
 

--- a/mosaic-terminal/build.gradle
+++ b/mosaic-terminal/build.gradle
@@ -27,6 +27,7 @@ kotlin {
 		commonTest {
 			dependencies {
 				implementation libs.kotlin.test
+				implementation libs.kotlinx.io
 				implementation libs.assertk
 			}
 		}

--- a/mosaic-terminal/src/c/mosaic.h
+++ b/mosaic-terminal/src/c/mosaic.h
@@ -38,7 +38,7 @@ typedef struct stdinRead {
 	platformError error;
 } stdinRead;
 
-stdinReaderResult stdinReader_init();
+stdinReaderResult stdinReader_init(const char *path);
 stdinRead stdinReader_read(stdinReader *reader, void *buffer, int count);
 stdinRead stdinReader_readWithTimeout(stdinReader *reader, void *buffer, int count, int timeoutMillis);
 platformError stdinReader_interrupt(stdinReader* reader);

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
@@ -26,6 +26,8 @@ public expect object Tty {
 	 * Use with [enableRawMode] to read input byte-by-byte.
 	 */
 	public fun stdinReader(): StdinReader
+
+	internal fun stdinReader(path: String?): StdinReader
 }
 
 public expect class StdinReader : AutoCloseable {

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TtyTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TtyTest.kt
@@ -1,0 +1,28 @@
+package com.jakewharton.mosaic.terminal
+
+import assertk.assertThat
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isZero
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.measureTime
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemTemporaryDirectory
+
+@OptIn(ExperimentalUuidApi::class)
+class TtyTest {
+	private val stdinReader = Tty.stdinReader(
+		path = Path(SystemTemporaryDirectory, Uuid.random().toString()).toString(),
+	)
+
+	@Test fun readWithTimeoutReturnsZeroOnTimeout() {
+		val read: Int
+		val took = measureTime {
+			read = stdinReader.readWithTimeout(ByteArray(10), 0, 10, 100)
+		}
+		assertThat(read).isZero()
+		assertThat(took).isGreaterThan(100.milliseconds)
+	}
+}

--- a/mosaic-terminal/src/jvmMain/jni/mosaic-jni.c
+++ b/mosaic-terminal/src/jvmMain/jni/mosaic-jni.c
@@ -43,12 +43,24 @@ Java_com_jakewharton_mosaic_terminal_Tty_exitRawMode(JNIEnv *env, jclass type, j
 }
 
 JNIEXPORT jlong JNICALL
-Java_com_jakewharton_mosaic_terminal_Tty_stdinReaderInit(JNIEnv *env, jclass type) {
-	stdinReaderResult result = stdinReader_init();
+Java_com_jakewharton_mosaic_terminal_Tty_stdinReaderInit(JNIEnv *env, jclass type, jstring path) {
+	const char* pathChars = NULL;
+	if (path) {
+		pathChars = (*env)->GetStringUTFChars(env, path, NULL);
+		if (!pathChars) goto err;
+	}
+
+	stdinReaderResult result = stdinReader_init(pathChars);
+
+	if (pathChars) {
+		(*env)->ReleaseStringUTFChars(env, path, pathChars);
+	}
+
 	if (likely(!result.error)) {
 		return (jlong) result.reader;
 	}
 
+	err:
 	// This throw can fail, but the only condition that should cause that is OOM which
 	// will occur from returning 0 (which is otherwise ignored if the throw succeeds).
 	throwIse(env, result.error, "Unable to create stdin reader");

--- a/mosaic-terminal/src/jvmMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
+++ b/mosaic-terminal/src/jvmMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
@@ -26,8 +26,11 @@ public actual object Tty {
 		}
 	}
 
-	public actual fun stdinReader(): StdinReader {
-		val reader = stdinReaderInit()
+	public actual fun stdinReader(): StdinReader = stdinReader(null)
+
+	@JvmSynthetic // Hide from Java callers.
+	internal actual fun stdinReader(path: String?): StdinReader {
+		val reader = stdinReaderInit(path)
 		if (reader == 0L) throw OutOfMemoryError()
 		return StdinReader(reader)
 	}
@@ -39,7 +42,7 @@ public actual object Tty {
 	private external fun exitRawMode(savedConfig: Long): Int
 
 	@JvmStatic
-	private external fun stdinReaderInit(): Long
+	private external fun stdinReaderInit(path: String?): Long
 
 	@JvmStatic
 	@JvmSynthetic // Hide from Java callers.

--- a/mosaic-terminal/src/nativeMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
+++ b/mosaic-terminal/src/nativeMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
@@ -25,8 +25,10 @@ public actual object Tty {
 		}
 	}
 
-	public actual fun stdinReader(): StdinReader {
-		val reader = stdinReader_init().useContents {
+	public actual fun stdinReader(): StdinReader = stdinReader(null)
+
+	internal actual fun stdinReader(path: String?): StdinReader {
+		val reader = stdinReader_init(path).useContents {
 			check(error == 0U) { "Unable to create stdin reader: $error" }
 			reader ?: throw OutOfMemoryError()
 		}


### PR DESCRIPTION
This facilitates testing, since stdin isn't normally available in test harnesses.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
