### PR TITLE
Remove test report upload

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,13 +70,6 @@ jobs:
 
       - run: ./gradlew jvmTest ${{ matrix.platform-test }}
 
-      - uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: ${{ matrix.os }} Tests
-          path: '**/build/test-results/**/TEST-*.xml'
-          reporter: java-junit
-
   binaries:
     runs-on: macos-15
     needs:


### PR DESCRIPTION
Doesn't work on PRs from external collaborators.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
