### PR TITLE
Ignore one test on Windows for now

### DIFF
--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/StdinReaderTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/StdinReaderTest.kt
@@ -26,6 +26,7 @@ class StdinReaderTest {
 		assertThat(buffer.decodeToString(endIndex = read)).isEqualTo("hello")
 	}
 
+	@WindowsIgnore // Pipe in the StdinWriter doesn't work with StdinReader signal waiting.
 	@Test fun readWithTimeoutReturnsZeroOnTimeout() {
 		val read: Int
 		val took = measureTime {

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/WindowsIgnore.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/WindowsIgnore.kt
@@ -1,0 +1,5 @@
+package com.jakewharton.mosaic.terminal
+
+@OptIn(ExperimentalMultiplatform::class)
+@OptionalExpectation
+expect annotation class WindowsIgnore()

--- a/mosaic-terminal/src/mingwTest/kotlin/com/jakewharton/mosaic/terminal/WindowsIgnore.kt
+++ b/mosaic-terminal/src/mingwTest/kotlin/com/jakewharton/mosaic/terminal/WindowsIgnore.kt
@@ -1,0 +1,3 @@
+package com.jakewharton.mosaic.terminal
+
+actual typealias WindowsIgnore = kotlin.test.Ignore


### PR DESCRIPTION
We have to change our strategy fundamentally, and I'd rather just have it working for now.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
