### PR TITLE
Use a separate wait handle from the read handle

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 23
-      - uses: gradle/actions/setup-gradle@v4
 
       - run: ./gradlew jvmTest ${{ matrix.platform-test }}
 

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/StdinReaderTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/StdinReaderTest.kt
@@ -5,7 +5,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
 import assertk.assertions.isZero
 import kotlin.test.AfterTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
@@ -27,7 +26,6 @@ class StdinReaderTest {
 		assertThat(buffer.decodeToString(endIndex = read)).isEqualTo("hello")
 	}
 
-	@Ignore // Pipe in the Windows StdinWriter doesn't work with StdinReader signal waiting.
 	@Test fun readWithTimeoutReturnsZeroOnTimeout() {
 		val read: Int
 		val took = measureTime {


### PR DESCRIPTION
This allows our test writer to use an anonymous pipe plus a separate event to send data. Using only the pipe does not work, as it is always in the signaled state.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
