### PR TITLE
Start parsing terminal events

### DIFF
--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -5,9 +5,17 @@ public final class com/jakewharton/mosaic/terminal/StdinReader : java/lang/AutoC
 	public final fun readWithTimeout ([BIII)I
 }
 
+public final class com/jakewharton/mosaic/terminal/TerminalParser {
+	public fun <init> (Lcom/jakewharton/mosaic/terminal/StdinReader;Z)V
+	public final fun next ()Lcom/jakewharton/mosaic/terminal/event/Event;
+}
+
 public final class com/jakewharton/mosaic/terminal/Tty {
 	public static final field INSTANCE Lcom/jakewharton/mosaic/terminal/Tty;
 	public static final fun enableRawMode ()Ljava/lang/AutoCloseable;
 	public static final fun stdinReader ()Lcom/jakewharton/mosaic/terminal/StdinReader;
+}
+
+public abstract interface class com/jakewharton/mosaic/terminal/event/Event {
 }
 

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -6,11 +6,19 @@
 // - Show declarations: true
 
 // Library unique name: <com.jakewharton.mosaic:mosaic-terminal>
+sealed interface com.jakewharton.mosaic.terminal.event/Event // com.jakewharton.mosaic.terminal.event/Event|null[0]
+
 final class com.jakewharton.mosaic.terminal/StdinReader : kotlin/AutoCloseable { // com.jakewharton.mosaic.terminal/StdinReader|null[0]
     final fun close() // com.jakewharton.mosaic.terminal/StdinReader.close|close(){}[0]
     final fun interrupt() // com.jakewharton.mosaic.terminal/StdinReader.interrupt|interrupt(){}[0]
     final fun read(kotlin/ByteArray, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.terminal/StdinReader.read|read(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
     final fun readWithTimeout(kotlin/ByteArray, kotlin/Int, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.terminal/StdinReader.readWithTimeout|readWithTimeout(kotlin.ByteArray;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+}
+
+final class com.jakewharton.mosaic.terminal/TerminalParser { // com.jakewharton.mosaic.terminal/TerminalParser|null[0]
+    constructor <init>(com.jakewharton.mosaic.terminal/StdinReader, kotlin/Boolean) // com.jakewharton.mosaic.terminal/TerminalParser.<init>|<init>(com.jakewharton.mosaic.terminal.StdinReader;kotlin.Boolean){}[0]
+
+    final fun next(): com.jakewharton.mosaic.terminal.event/Event // com.jakewharton.mosaic.terminal/TerminalParser.next|next(){}[0]
 }
 
 final object com.jakewharton.mosaic.terminal/Tty { // com.jakewharton.mosaic.terminal/Tty|null[0]

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/bytes.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/bytes.kt
@@ -1,14 +1,23 @@
 package com.jakewharton.mosaic.terminal
 
-internal fun ByteArray.indexOf(value: Byte, start: Int = 0, end: Int = size): Int {
-	return indexOfFirstOrElse(start, end, { it == value })
+internal fun ByteArray.indexOf(value: Byte, start: Int, end: Int): Int {
+	return indexOfOrDefault(value, start, end, -1)
+}
+
+internal fun ByteArray.indexOfOrDefault(
+	value: Byte,
+	start: Int,
+	end: Int,
+	default: Int,
+): Int {
+	return indexOfFirstOrElse(start, end, { it == value }, { default })
 }
 
 internal inline fun ByteArray.indexOfFirstOrElse(
-	start: Int = 0,
-	end: Int = size,
+	start: Int,
+	end: Int,
 	crossinline predicate: (Byte) -> Boolean,
-	orElse: () -> Int = { -1 },
+	orElse: () -> Int,
 ): Int {
 	for (i in start until end) {
 		if (predicate(this[i])) {
@@ -16,4 +25,13 @@ internal inline fun ByteArray.indexOfFirstOrElse(
 		}
 	}
 	return orElse()
+}
+
+internal fun ByteArray.parseIntDigits(start: Int, end: Int): Int {
+	var value = 0
+	for (i in start until end) {
+		value *= 10
+		value += this[i].toInt() - '0'.code
+	}
+	return value
 }

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/bytes.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/bytes.kt
@@ -1,0 +1,19 @@
+package com.jakewharton.mosaic.terminal
+
+internal fun ByteArray.indexOf(value: Byte, start: Int = 0, end: Int = size): Int {
+	return indexOfFirstOrElse(start, end, { it == value })
+}
+
+internal inline fun ByteArray.indexOfFirstOrElse(
+	start: Int = 0,
+	end: Int = size,
+	crossinline predicate: (Byte) -> Boolean,
+	orElse: () -> Int = { -1 },
+): Int {
+	for (i in start until end) {
+		if (predicate(this[i])) {
+			return i
+		}
+	}
+	return orElse()
+}

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
@@ -21,3 +21,74 @@ internal class UnknownEvent(
 }
 
 internal object KeyEscape : Event
+
+internal data class CodepointEvent(
+	val codepoint: Int,
+	val shift: Boolean = false,
+	val alt: Boolean = false,
+	val ctrl: Boolean = false,
+) : Event {
+	override fun toString() = buildString {
+		append("CodepointEvent(")
+		if (shift) append("Shift+")
+		if (ctrl) append("Ctrl+")
+		if (alt) append("Alt+")
+		append("0x")
+		append(codepoint.toString(16).uppercase())
+		append(')')
+	}
+}
+
+internal data class FocusEvent(
+	val focused: Boolean,
+) : Event
+
+internal data class PasteEvent(
+	val start: Boolean,
+) : Event
+
+internal data class PrimaryDeviceAttributes(
+	val data: String,
+) : Event
+
+internal data class DeviceStatusReportString(
+	val data: String,
+) : Event
+
+internal data class KittyGraphicsEvent(
+	val id: Int,
+	val message: String,
+) : Event
+
+internal data class ResizeEvent(
+	val rows: Int,
+	val cols: Int,
+	val height: Int,
+	val width: Int,
+) : Event
+
+internal data class DecModeReport(
+	val mode: Int,
+	val setting: Setting,
+) : Event {
+	enum class Setting {
+		NotRecognized, Set, Reset, PermanentlySet, PermanentlyReset,
+	}
+}
+
+internal data class MouseEvent(
+	val x: Int,
+	val y: Int,
+	val type: Type,
+	val button: Button,
+	val shift: Boolean,
+	val alt: Boolean,
+	val ctrl: Boolean,
+) : Event {
+	enum class Type {
+		Drag, Motion, Release, Press,
+	}
+	enum class Button {
+		Left, Middle, Right, None, WheelUp, WheelDown, Button8, Button9, Button10, Button11,
+	}
+}

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
@@ -1,6 +1,6 @@
 package com.jakewharton.mosaic.terminal.event
 
-internal sealed interface Event
+public sealed interface Event
 
 // Some temporary events while we spin up parsing...
 
@@ -92,3 +92,11 @@ internal data class MouseEvent(
 		Left, Middle, Right, None, WheelUp, WheelDown, Button8, Button9, Button10, Button11,
 	}
 }
+
+internal data class LinePositionAbsolute(
+	val row: Int,
+) : Event
+
+internal data class LinePositionRelative(
+	val rows: Int,
+) : Event

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
@@ -4,4 +4,20 @@ internal sealed interface Event
 
 // Some temporary events while we spin up parsing...
 
+internal class UnknownEvent(
+	val context: String,
+	val bytes: ByteArray,
+) : Event {
+	@OptIn(ExperimentalStdlibApi::class)
+	override fun toString(): String {
+		return buildString {
+			append("UnknownEvent(")
+			append(context)
+			append(' ')
+			append(bytes.toHexString())
+			append(')')
+		}
+	}
+}
+
 internal object KeyEscape : Event

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
@@ -37,6 +37,33 @@ internal data class CodepointEvent(
 		append(codepoint.toString(16).uppercase())
 		append(')')
 	}
+
+	companion object {
+		// These codepoints are defined by Kitty in the Unicode private space.
+		const val Insert = 57348
+		const val Delete = 57349
+		const val PageUp = 57354
+		const val PageDown = 57355
+		const val Up = 57352
+		const val Down = 57353
+		const val Right = 57351
+		const val Left = 57350
+		const val KpBegin = 57427
+		const val End = 57357
+		const val Home = 57356
+		const val F1 = 57364
+		const val F2 = 57365
+		const val F3 = 57366
+		const val F4 = 57367
+		const val F5 = 57368
+		const val F6 = 57369
+		const val F7 = 57370
+		const val F8 = 57371
+		const val F9 = 57372
+		const val F10 = 57373
+		const val F11 = 57374
+		const val F12 = 57375
+	}
 }
 
 internal data class FocusEvent(
@@ -72,7 +99,11 @@ internal data class DecModeReport(
 	val setting: Setting,
 ) : Event {
 	enum class Setting {
-		NotRecognized, Set, Reset, PermanentlySet, PermanentlyReset,
+		NotRecognized,
+		Set,
+		Reset,
+		PermanentlySet,
+		PermanentlyReset,
 	}
 }
 
@@ -86,10 +117,22 @@ internal data class MouseEvent(
 	val ctrl: Boolean,
 ) : Event {
 	enum class Type {
-		Drag, Motion, Release, Press,
+		Drag,
+		Motion,
+		Release,
+		Press,
 	}
 	enum class Button {
-		Left, Middle, Right, None, WheelUp, WheelDown, Button8, Button9, Button10, Button11,
+		Left,
+		Middle,
+		Right,
+		None,
+		WheelUp,
+		WheelDown,
+		Button8,
+		Button9,
+		Button10,
+		Button11,
 	}
 }
 

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
@@ -1,0 +1,7 @@
+package com.jakewharton.mosaic.terminal.event
+
+internal sealed interface Event
+
+// Some temporary events while we spin up parsing...
+
+internal object KeyEscape : Event

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/parser.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/parser.kt
@@ -1,0 +1,98 @@
+package com.jakewharton.mosaic.terminal
+
+import com.jakewharton.mosaic.terminal.event.Event
+import com.jakewharton.mosaic.terminal.event.KeyEscape
+
+private const val bufferSize = 8 * 1024
+private const val bareEscapeDisambiguationReadTimeoutMillis = 100
+
+internal class TerminalParser(
+	private val stdinReader: StdinReader,
+	private val isInRawMode: Boolean,
+) {
+	private val buffer = ByteArray(bufferSize)
+	private var offset = 0
+	private var limit = 0
+
+	fun next(): Event {
+		val buffer = buffer
+		var offset = offset
+		var limit = limit
+
+		while (true) {
+			if (offset < limit) {
+				parse(buffer, offset, limit)?.let { event ->
+					return event
+				}
+
+				// Underflow! Copy data to start of buffer (if not already there) in preparation for a read.
+				if (offset > 0) {
+					buffer.copyInto(buffer, 0, startIndex = offset, endIndex = limit)
+
+					// Do not write the new limit to the member property because the read code below will.
+					limit = limit - offset
+
+					offset = 0
+					this.offset = 0
+				}
+			}
+
+			if (isInRawMode) {
+				// Common case: we're in raw mode and can block filling the buffer as we never need to
+				// do a disambiguation read on a bare escape (it would have come as a keyboard event).
+				val read = stdinReader.read(buffer, limit, bufferSize)
+				limit += read
+				this.limit = limit
+				continue
+			}
+
+			val read: Int
+			if (limit == 1 && buffer[0].toInt() == 0x1B) {
+				// If we are not in raw mode and our only byte is an escape, perform a quick disambiguation
+				// read to see if we have any more bytes. This will allow us to determine whether the bare
+				// escape was truly an escape, or just the start of an escape sequence.
+				read = stdinReader.readWithTimeout(
+					buffer,
+					limit,
+					bufferSize,
+					bareEscapeDisambiguationReadTimeoutMillis
+				)
+				if (read == 0) {
+					// We know the offset is 0, so resetting the limit effectively consumes the byte.
+					this.limit = 0
+					return KeyEscape
+				}
+			} else {
+				read = stdinReader.read(buffer, limit, bufferSize)
+			}
+			limit += read
+			this.limit = limit
+		}
+	}
+
+	private fun parse(buffer: ByteArray, start: Int, limit: Int): Event? {
+		val b1 = buffer[start].toInt()
+		if (b1 == 0x1B) {
+			val b2Index = start + 1
+			// If this escape is at the end of the buffer, request another read to ensure we can
+			// differentiate between a bare escape and one starting a sequence. Note: The caller is
+			// expected to handle the case of a bare escape, as we will otherwise endlessly return null.
+			if (b2Index == limit) return null
+
+			when (val b2 = buffer[b2Index].toInt()) {
+//				0x4F -> parseSs3(buffer, start, limit)
+//				0x50 -> parseDcs(buffer, start, limit)
+//				0x58 -> parseUntilStringTerminator(buffer, start, limit)
+//				0x5B -> parseCsi(buffer, start, limit)
+//				0x5D -> TODO("Unhandled event")
+//				0x5E -> TODO("Unhandled event")
+//				0x5F -> parseApc(buffer, start, limit)
+//				else -> CodepointEvent(b2, alt = true)
+				else -> return TODO("Unhandled event")
+			}
+		}
+		when (b1) {
+			else -> return TODO("Unhandled event")
+		}
+	}
+}

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/parser.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/parser.kt
@@ -1,7 +1,16 @@
 package com.jakewharton.mosaic.terminal
 
+import com.jakewharton.mosaic.terminal.event.CodepointEvent
+import com.jakewharton.mosaic.terminal.event.DecModeReport
+import com.jakewharton.mosaic.terminal.event.DeviceStatusReportString
 import com.jakewharton.mosaic.terminal.event.Event
+import com.jakewharton.mosaic.terminal.event.FocusEvent
 import com.jakewharton.mosaic.terminal.event.KeyEscape
+import com.jakewharton.mosaic.terminal.event.KittyGraphicsEvent
+import com.jakewharton.mosaic.terminal.event.MouseEvent
+import com.jakewharton.mosaic.terminal.event.PasteEvent
+import com.jakewharton.mosaic.terminal.event.PrimaryDeviceAttributes
+import com.jakewharton.mosaic.terminal.event.ResizeEvent
 import com.jakewharton.mosaic.terminal.event.UnknownEvent
 
 private const val BufferSize = 8 * 1024
@@ -22,7 +31,7 @@ internal class TerminalParser(
 
 		while (true) {
 			if (offset < limit) {
-				parseEvent(buffer, offset, limit)?.let { event ->
+				parse(buffer, offset, limit)?.let { event ->
 					return event
 				}
 
@@ -71,7 +80,7 @@ internal class TerminalParser(
 		}
 	}
 
-	private fun parseEvent(buffer: ByteArray, start: Int, limit: Int): Event? {
+	private fun parse(buffer: ByteArray, start: Int, limit: Int): Event? {
 		val b1 = buffer[start].toInt()
 		if (b1 == 0x1B) {
 			val b2Index = start + 1
@@ -81,47 +90,418 @@ internal class TerminalParser(
 			if (b2Index == limit) return null
 
 			when (val b2 = buffer[b2Index].toInt()) {
-				// 0x4F -> parseSs3(buffer, start, limit)
-				// 0x50 -> parseDcs(buffer, start, limit)
-				0x58 -> return parseUntilStringTerminator(buffer, start, limit)
+				0x4F -> return parseSs3(buffer, start, limit)
+				0x50 -> return parseDcs(buffer, start, limit)
+				0x58 -> return parseSos(buffer, start, limit)
 				0x5B -> return parseCsi(buffer, start, limit)
-				// 0x5D -> TODO("Unhandled event")
-				// 0x5E -> TODO("Unhandled event")
-				// 0x5F -> parseApc(buffer, start, limit)
-				// else -> CodepointEvent(b2, alt = true)
-				else -> return TODO("Unhandled event")
+				0x5D -> return parseOsc(buffer, start, limit)
+				0x5E -> return parsePm(buffer, start, limit)
+				0x5F -> return parseApc(buffer, start, limit)
+				else -> {
+					offset = start + 2
+					return CodepointEvent(b2, alt = true)
+				}
 			}
 		} else {
-			when (b1) {
-				else -> return TODO("Unhandled event")
+			return parseGround(buffer, start, limit, b1)
+		}
+	}
+
+	private fun parseGround(buffer: ByteArray, start: Int, limit: Int, b1: Int): Event? {
+		val b2Index = start + 1
+
+		when (b1) {
+			0x00 -> {
+				offset = b2Index
+				return CodepointEvent('@'.code, ctrl = true)
+			}
+
+			// Backspace key canonicalization.
+			0x08 -> {
+				offset = b2Index
+				return CodepointEvent(0x7F)
+			}
+
+			// Enter key canonicalization.
+			0x0A -> {
+				offset = b2Index
+				return CodepointEvent(0x0D)
+			}
+
+			0x09, 0x0D, 0x1A -> {
+				offset = b2Index
+				return CodepointEvent(b1)
+			}
+
+			in 0x01..0x07,
+			0x0B,
+			0x0C,
+			in 0x0E..0x1A,
+				-> {
+				offset = b2Index
+				return CodepointEvent(b1 + 0x60, ctrl = true)
+			}
+
+			else -> {
+				// TODO Non-UTF-8 support?
+				// TODO validate continuation bytes?
+				val codepoint = when {
+					b1 and 0b10000000 == 0 -> {
+						offset = b2Index
+						b1
+					}
+					b1 and 0b11100000 == 0b11000000 -> {
+						if (b2Index == limit) return null
+						offset = start + 2
+						b1.and(0b00011111).shl(6) or
+							buffer[b2Index].toInt().and(0b00111111)
+					}
+					b1 and 0b11110000 == 0b11100000 -> {
+						val b3Index = start + 2
+						if (b3Index >= limit) return null
+						offset = start + 3
+						b1.and(0b00001111).shl(12) or
+							buffer[b2Index].toInt().and(0b00111111).shl(6) or
+							buffer[b3Index].toInt().and(0b00111111)
+					}
+					b1 and 0b11111000 == 0b11110000 -> {
+						val b4Index = start + 3
+						if (b4Index >= limit) return null
+						offset = start + 4
+						b1.and(0b00000111).shl(18) or
+							buffer[b2Index].toInt().and(0b00111111).shl(12) or
+							buffer[start + 2].toInt().and(0b00111111).shl(6) or
+							buffer[b4Index].toInt().and(0b00111111)
+					}
+					else -> TODO("Invalid UTF-8")
+				}
+				// TODO multi-codepoint grapheme support
+				return CodepointEvent(codepoint)
 			}
 		}
 	}
 
-	private fun parseCsi(buffer: ByteArray, start: Int, limit: Int): Event? {
-		val end = buffer.indexOfFirstOrElse(
-			// Skip leading 0x1B5B.
-			start = start + 2,
-			end = limit,
-			predicate = { it.toInt() in 0x40..0xFF },
-			orElse = { return null },
-		)
-		when (val final = buffer[end]) {
-			else -> {
-				offset = end
-				return UnknownEvent(
-					context = "CSI with unknown final byte",
+	private fun parseApc(buffer: ByteArray, start: Int, limit: Int): Event? {
+		// TODO https://stackoverflow.com/a/71632523/132047
+		return parseUntilStringTerminator(buffer, start, limit) { stIndex, end ->
+			val b3Index = start + 2
+			if (stIndex > b3Index && buffer[b3Index].toInt() == 'G'.code) {
+				val delimiter = buffer.indexOf(';'.code.toByte(), b3Index, stIndex)
+				val b5Index = start + 4
+				if (delimiter == -1 ||
+					delimiter <= b5Index ||
+					buffer[start + 3].toInt() != 'i'.code ||
+					buffer[b5Index].toInt() != '='.code
+				) {
+					UnknownEvent(
+						context = "Unknown Kitty graphics APC sequence",
+						bytes = buffer.copyOfRange(start, end),
+					)
+				} else {
+					KittyGraphicsEvent(
+						id = buffer.parseIntDigits(b5Index, delimiter),
+						message = buffer.decodeToString(delimiter + 1, stIndex),
+					)
+				}
+			} else {
+				UnknownEvent(
+					context = "Unknown APC sequence",
 					bytes = buffer.copyOfRange(start, end),
 				)
 			}
 		}
 	}
 
-	private fun parseUntilStringTerminator(
+	private fun parseCsi(buffer: ByteArray, start: Int, limit: Int): Event? {
+		val b3Index = start + 2
+		val finalIndex = buffer.indexOfFirstOrElse(
+			// Skip leading 0x1B5B.
+			start = b3Index,
+			end = limit,
+			predicate = { it.toInt() in 0x40..0xFF },
+			orElse = { return null },
+		)
+
+		val end = finalIndex + 1
+		offset = end
+
+		when (buffer[finalIndex].toInt()) {
+			// These codepoints are defined by Kitty in the Unicode private space.
+			'A'.code -> return parseCsiLegacy(buffer, start, end, 57352 /* up */)
+			'B'.code -> return parseCsiLegacy(buffer, start, end, 57353 /* down */)
+			'C'.code -> return parseCsiLegacy(buffer, start, end, 57351 /* right */)
+			'D'.code -> return parseCsiLegacy(buffer, start, end, 57350 /* left */)
+			'E'.code -> return parseCsiLegacy(buffer, start, end, 57427 /* kp_begin */)
+			'F'.code -> return parseCsiLegacy(buffer, start, end, 57457 /* end */)
+			'H'.code -> return parseCsiLegacy(buffer, start, end, 57456 /* home */)
+			'P'.code -> return parseCsiLegacy(buffer, start, end, 57364 /* f1 */)
+			'Q'.code -> return parseCsiLegacy(buffer, start, end, 57365 /* f2 */)
+			'R'.code -> return parseCsiLegacy(buffer, start, end, 57366 /* f3 */)
+			'S'.code -> return parseCsiLegacy(buffer, start, end, 57367 /* f4 */)
+
+			'~'.code -> {
+				val delimiter = buffer.indexOfOrDefault(';'.code.toByte(), b3Index, end, end)
+				val number = buffer.parseIntDigits(start = b3Index, end = delimiter)
+				val codepoint = when (number) {
+					2 -> 57348 /* insert */
+					3 -> 57349 /* delete */
+					5 -> 57354 /* page up */
+					6 -> 57355 /* page down */
+					7 -> 57356 /* home */
+					8 -> 57357 /* end */
+					11 -> 57364 /* f1 */
+					12 -> 57365 /* f2 */
+					13 -> 57366 /* f3 */
+					14 -> 57367 /* f4 */
+					15 -> 57368 /* f5 */
+					17 -> 57369 /* f6 */
+					18 -> 57370 /* f7 */
+					19 -> 57371 /* f8 */
+					20 -> 57372 /* f9 */
+					21 -> 57373 /* f10 */
+					23 -> 57374 /* f11 */
+					24 -> 57375 /* f12 */
+					200 -> return PasteEvent(start = true)
+					201 -> return PasteEvent(start = false)
+					57427 -> 57427 /* kp_begin */
+					else -> return UnknownEvent(
+						context = "Unknown CSI ~ codepoint",
+						bytes = buffer.copyOfRange(start, end),
+					)
+				}
+
+				// TODO parse rest of CSI ... ~
+				return CodepointEvent(codepoint)
+			}
+
+			// TODO validate no in-between bytes?
+			'I'.code -> {
+				offset = finalIndex + 1
+				return FocusEvent(focused = true)
+			}
+			'O'.code -> {
+				offset = finalIndex + 1
+				return FocusEvent(focused = false)
+			}
+
+			'm'.code,
+			'M'.code -> {
+				if (buffer[b3Index].toInt() != '<'.code) {
+					return UnknownEvent(
+						context = "TODO", // TODO
+						bytes = buffer.copyOfRange(start, end),
+					)
+				}
+
+				val delim1 = buffer.indexOf(';'.code.toByte(), start + 3, finalIndex)
+				val delim2 = buffer.indexOf(';'.code.toByte(), delim1 + 1, finalIndex)
+
+				val buttonBits = buffer.parseIntDigits(start = start + 3, end = delim1)
+
+				// Incoming values are 1-based.
+				val x = buffer.parseIntDigits(delim1 + 1, delim2) - 1
+				val y = buffer.parseIntDigits(delim2 + 1, end) - 1
+
+				val button = when (buttonBits and 0b11000011) {
+					0 -> MouseEvent.Button.Left
+					1 -> MouseEvent.Button.Middle
+					2 -> MouseEvent.Button.Right
+					3 -> MouseEvent.Button.None
+					64 -> MouseEvent.Button.WheelUp
+					65 -> MouseEvent.Button.WheelDown
+					128 -> MouseEvent.Button.Button8
+					129 -> MouseEvent.Button.Button9
+					130 -> MouseEvent.Button.Button10
+					131 -> MouseEvent.Button.Button11
+					else -> return UnknownEvent(
+						context = "Unknown mount button value",
+						bytes = buffer.copyOfRange(start, end),
+					)
+				}
+				val motion = (buttonBits and 0b00100000) != 0
+				val type = when {
+					motion && button != MouseEvent.Button.None -> MouseEvent.Type.Drag
+					motion && button == MouseEvent.Button.None -> MouseEvent.Type.Motion
+					buffer[finalIndex].toInt() == 'm'.code -> MouseEvent.Type.Release
+					else -> MouseEvent.Type.Press
+				}
+				val shift = (buttonBits and 0b00000100) != 0
+				val alt = (buttonBits and 0b00001000) != 0
+				val ctrl = (buttonBits and 0b00010000) != 0
+
+				return MouseEvent(
+					x = x,
+					y = y,
+					type = type,
+					button = button,
+					shift = shift,
+					alt = alt,
+					ctrl = ctrl,
+				)
+			}
+
+			'c'.code -> {
+				// TODO can we express this conditional with b3index in relation to end?
+				if (end - start < 4) return null
+				if (buffer[b3Index].toInt() == '?'.code) {
+					return PrimaryDeviceAttributes(
+						buffer.decodeToString(start + 3, end),
+					)
+				}
+				return UnknownEvent(
+					context = "CSI .. c sequence without leading ?",
+					bytes = buffer.copyOfRange(start, end),
+				)
+			}
+
+			't'.code -> {
+				// TODO validation. while(true) + indexOfOrElse + break + UnknownEvent
+				val modeDelim = buffer.indexOf(';'.code.toByte(), b3Index, finalIndex)
+				val rowDelim = buffer.indexOf(';'.code.toByte(), modeDelim + 1, finalIndex)
+				val colDelim = buffer.indexOf(';'.code.toByte(), rowDelim + 1, finalIndex)
+				val heightDelim = buffer.indexOf(';'.code.toByte(), colDelim + 1, finalIndex)
+				val widthDelim = buffer.indexOf(';'.code.toByte(), heightDelim + 1, finalIndex)
+				val mode = buffer.parseIntDigits(b3Index, modeDelim)
+				// TODO validate 48
+				val rows = buffer.parseIntDigits(modeDelim + 1, rowDelim)
+				val cols = buffer.parseIntDigits(rowDelim + 1, colDelim)
+				val height = buffer.parseIntDigits(colDelim + 1, heightDelim)
+				val width = buffer.parseIntDigits(heightDelim + 1, finalIndex)
+				return ResizeEvent(rows, cols, height, width)
+			}
+
+			'y'.code -> {
+				if (end < start + 7) return null
+				if (buffer[finalIndex].toInt() != '$'.code) {
+					return UnknownEvent(
+						context = "TODO", // TODO
+						bytes = buffer.copyOfRange(start, end),
+					)
+				}
+
+				if (buffer[b3Index].toInt() == '?'.code) {
+					if (end < start + 8) return null
+					val b4Index = start + 3
+					val semi = buffer.indexOf(';'.code.toByte(), b4Index, end)
+					val pd = buffer.parseIntDigits(b4Index, semi)
+					val ps = buffer.parseIntDigits(semi + 1, finalIndex)
+					val setting = when (ps) {
+						0 -> DecModeReport.Setting.NotRecognized
+						1 -> DecModeReport.Setting.Set
+						2 -> DecModeReport.Setting.Reset
+						3 -> DecModeReport.Setting.PermanentlySet
+						4 -> DecModeReport.Setting.PermanentlyReset
+						else -> return UnknownEvent(
+							context = "TODO", // TODO
+							bytes = buffer.copyOfRange(start, end),
+						)
+					}
+					return DecModeReport(
+						mode = pd,
+						setting = setting,
+					)
+				} else {
+					TODO("ANSI mode reporter")
+				}
+			}
+
+			else -> {
+				return UnknownEvent(
+					context = "Unknown CSI final byte",
+					bytes = buffer.copyOfRange(start, end),
+				)
+			}
+		}
+	}
+
+	private fun parseCsiLegacy(buffer: ByteArray, start: Int, limit: Int, codepoint: Int): CodepointEvent {
+		// TODO parse other shit
+		//  val delimiter = buffer.indexOf(';'.code.toByte(), start + 2, limit)
+		return CodepointEvent(codepoint)
+	}
+
+	private fun parseDcs(buffer: ByteArray, start: Int, limit: Int): Event? {
+		return parseUntilStringTerminator(buffer, start, limit) { stIndex, end ->
+			if (stIndex > start + 4 &&
+				buffer[start + 2].toInt() == '>'.code &&
+				buffer[start + 3].toInt() == '|'.code
+			) {
+				DeviceStatusReportString(
+					data = buffer.decodeToString(start + 4, stIndex),
+				)
+			} else {
+				UnknownEvent(
+					context = "Unknown DCS leading discriminator",
+					bytes = buffer.copyOfRange(start, end),
+				)
+			}
+		}
+	}
+
+	private fun parseOsc(buffer: ByteArray, start: Int, limit: Int): Event? {
+		TODO()
+	}
+
+	private fun parsePm(buffer: ByteArray, start: Int, limit: Int): Event? {
+		return parseUntilStringTerminator(buffer, start, limit) { _, end ->
+			UnknownEvent(
+				context = "Unknown PM sequence",
+				bytes = buffer.copyOfRange(start, end),
+			)
+		}
+	}
+
+	private fun parseSos(buffer: ByteArray, start: Int, limit: Int): Event? {
+		return parseUntilStringTerminator(buffer, start, limit) { _, end ->
+			UnknownEvent(
+				context = "Unknown SOS sequence",
+				bytes = buffer.copyOfRange(start, end),
+			)
+		}
+	}
+
+	private fun parseSs3(buffer: ByteArray, start: Int, limit: Int): Event? {
+		val end = start + 4
+		if (end > limit) return null
+
+		offset = end
+
+		val b3Index = start + 2
+		val codepoint = when (buffer[b3Index].toInt()) {
+			'A'.code -> 57352 /* up */
+			'B'.code -> 57353 /* down */
+			'C'.code -> 57351 /* right */
+			'D'.code -> 57350 /* left */
+			'F'.code -> 57357 /* end */
+			'H'.code -> 57356 /* home */
+			'P'.code -> 57364 /* f1 */
+			'Q'.code -> 57365 /* f2 */
+			'R'.code -> 57366 /* f3 */
+			'S'.code -> 57367 /* f3 */
+			0x1b -> {
+				// libvaxis added a guard against this case
+				// https://github.com/rockorager/libvaxis/commit/b68864c3babf2767c15c52911179e8ee9158e1d2
+				offset = b3Index
+				return UnknownEvent(
+					context = "First two bytes match SS3 but character byte was an escape",
+					bytes = buffer.copyOfRange(start, b3Index)
+				)
+			}
+			else -> {
+				return UnknownEvent(
+					context = "Unsupported SS3 character byte",
+					bytes = buffer.copyOfRange(start, end),
+				)
+			}
+		}
+		return CodepointEvent(codepoint)
+	}
+
+	private inline fun parseUntilStringTerminator(
 		buffer: ByteArray,
 		start: Int,
 		limit: Int,
-		handler: (stIndex: Int) -> Event? = { null },
+		crossinline handler: (stIndex: Int, end: Int) -> Event,
 	): Event? {
 		// TODO test string with 0x1b inside of it
 
@@ -142,11 +522,7 @@ internal class TerminalParser(
 			if (buffer[slashIndex] == '\\'.code.toByte()) {
 				val end = slashIndex + 2
 				offset = end
-				return handler(escIndex)
-					?: UnknownEvent(
-						context = "Unsupported string sequence",
-						bytes = buffer.copyOfRange(searchFrom, end),
-					)
+				return handler(escIndex, end)
 			}
 			searchFrom = slashIndex
 		}

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/parser.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/parser.kt
@@ -2,15 +2,16 @@ package com.jakewharton.mosaic.terminal
 
 import com.jakewharton.mosaic.terminal.event.Event
 import com.jakewharton.mosaic.terminal.event.KeyEscape
+import com.jakewharton.mosaic.terminal.event.UnknownEvent
 
-private const val bufferSize = 8 * 1024
-private const val bareEscapeDisambiguationReadTimeoutMillis = 100
+private const val BufferSize = 8 * 1024
+private const val BareEscapeDisambiguationReadTimeoutMillis = 100
 
 internal class TerminalParser(
 	private val stdinReader: StdinReader,
 	private val isInRawMode: Boolean,
 ) {
-	private val buffer = ByteArray(bufferSize)
+	private val buffer = ByteArray(BufferSize)
 	private var offset = 0
 	private var limit = 0
 
@@ -21,7 +22,7 @@ internal class TerminalParser(
 
 		while (true) {
 			if (offset < limit) {
-				parse(buffer, offset, limit)?.let { event ->
+				parseEvent(buffer, offset, limit)?.let { event ->
 					return event
 				}
 
@@ -40,7 +41,7 @@ internal class TerminalParser(
 			if (isInRawMode) {
 				// Common case: we're in raw mode and can block filling the buffer as we never need to
 				// do a disambiguation read on a bare escape (it would have come as a keyboard event).
-				val read = stdinReader.read(buffer, limit, bufferSize)
+				val read = stdinReader.read(buffer, limit, BufferSize)
 				limit += read
 				this.limit = limit
 				continue
@@ -54,8 +55,8 @@ internal class TerminalParser(
 				read = stdinReader.readWithTimeout(
 					buffer,
 					limit,
-					bufferSize,
-					bareEscapeDisambiguationReadTimeoutMillis
+					BufferSize,
+					BareEscapeDisambiguationReadTimeoutMillis
 				)
 				if (read == 0) {
 					// We know the offset is 0, so resetting the limit effectively consumes the byte.
@@ -63,14 +64,14 @@ internal class TerminalParser(
 					return KeyEscape
 				}
 			} else {
-				read = stdinReader.read(buffer, limit, bufferSize)
+				read = stdinReader.read(buffer, limit, BufferSize)
 			}
 			limit += read
 			this.limit = limit
 		}
 	}
 
-	private fun parse(buffer: ByteArray, start: Int, limit: Int): Event? {
+	private fun parseEvent(buffer: ByteArray, start: Int, limit: Int): Event? {
 		val b1 = buffer[start].toInt()
 		if (b1 == 0x1B) {
 			val b2Index = start + 1
@@ -80,19 +81,74 @@ internal class TerminalParser(
 			if (b2Index == limit) return null
 
 			when (val b2 = buffer[b2Index].toInt()) {
-//				0x4F -> parseSs3(buffer, start, limit)
-//				0x50 -> parseDcs(buffer, start, limit)
-//				0x58 -> parseUntilStringTerminator(buffer, start, limit)
-//				0x5B -> parseCsi(buffer, start, limit)
-//				0x5D -> TODO("Unhandled event")
-//				0x5E -> TODO("Unhandled event")
-//				0x5F -> parseApc(buffer, start, limit)
-//				else -> CodepointEvent(b2, alt = true)
+				// 0x4F -> parseSs3(buffer, start, limit)
+				// 0x50 -> parseDcs(buffer, start, limit)
+				0x58 -> return parseUntilStringTerminator(buffer, start, limit)
+				0x5B -> return parseCsi(buffer, start, limit)
+				// 0x5D -> TODO("Unhandled event")
+				// 0x5E -> TODO("Unhandled event")
+				// 0x5F -> parseApc(buffer, start, limit)
+				// else -> CodepointEvent(b2, alt = true)
+				else -> return TODO("Unhandled event")
+			}
+		} else {
+			when (b1) {
 				else -> return TODO("Unhandled event")
 			}
 		}
-		when (b1) {
-			else -> return TODO("Unhandled event")
+	}
+
+	private fun parseCsi(buffer: ByteArray, start: Int, limit: Int): Event? {
+		val end = buffer.indexOfFirstOrElse(
+			// Skip leading 0x1B5B.
+			start = start + 2,
+			end = limit,
+			predicate = { it.toInt() in 0x40..0xFF },
+			orElse = { return null },
+		)
+		when (val final = buffer[end]) {
+			else -> {
+				offset = end
+				return UnknownEvent(
+					context = "CSI with unknown final byte",
+					bytes = buffer.copyOfRange(start, end),
+				)
+			}
+		}
+	}
+
+	private fun parseUntilStringTerminator(
+		buffer: ByteArray,
+		start: Int,
+		limit: Int,
+		handler: (stIndex: Int) -> Event? = { null },
+	): Event? {
+		// TODO test string with 0x1b inside of it
+
+		// Skip leading discriminator.
+		var searchFrom = start + 2
+
+		while (true) {
+			val escIndex = buffer.indexOfFirstOrElse(
+				start = searchFrom,
+				end = limit,
+				predicate = { it == 0x1B.toByte() },
+				orElse = { return null },
+			)
+			// If found at end of range, underflow.
+			val slashIndex = escIndex + 1
+			if (slashIndex == limit) return null
+
+			if (buffer[slashIndex] == '\\'.code.toByte()) {
+				val end = slashIndex + 2
+				offset = end
+				return handler(escIndex)
+					?: UnknownEvent(
+						context = "Unsupported string sequence",
+						bytes = buffer.copyOfRange(searchFrom, end),
+					)
+			}
+			searchFrom = slashIndex
 		}
 	}
 }

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/parser.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/parser.kt
@@ -65,7 +65,7 @@ public class TerminalParser(
 					buffer,
 					limit,
 					BufferSize,
-					BareEscapeDisambiguationReadTimeoutMillis
+					BareEscapeDisambiguationReadTimeoutMillis,
 				)
 				if (read == 0) {
 					// We know the offset is 0, so resetting the limit effectively consumes the byte.
@@ -137,7 +137,7 @@ public class TerminalParser(
 			0x0B,
 			0x0C,
 			in 0x0E..0x1A,
-				-> {
+			-> {
 				offset = b2Index
 				return CodepointEvent(b1 + 0x60, ctrl = true)
 			}
@@ -226,44 +226,43 @@ public class TerminalParser(
 		offset = end
 
 		when (buffer[finalIndex].toInt()) {
-			// These codepoints are defined by Kitty in the Unicode private space.
-			'A'.code -> return parseCsiLegacy(buffer, start, end, 57352 /* up */)
-			'B'.code -> return parseCsiLegacy(buffer, start, end, 57353 /* down */)
-			'C'.code -> return parseCsiLegacy(buffer, start, end, 57351 /* right */)
-			'D'.code -> return parseCsiLegacy(buffer, start, end, 57350 /* left */)
-			'E'.code -> return parseCsiLegacy(buffer, start, end, 57427 /* kp_begin */)
-			'F'.code -> return parseCsiLegacy(buffer, start, end, 57457 /* end */)
-			'H'.code -> return parseCsiLegacy(buffer, start, end, 57456 /* home */)
-			'P'.code -> return parseCsiLegacy(buffer, start, end, 57364 /* f1 */)
-			'Q'.code -> return parseCsiLegacy(buffer, start, end, 57365 /* f2 */)
-			'R'.code -> return parseCsiLegacy(buffer, start, end, 57366 /* f3 */)
-			'S'.code -> return parseCsiLegacy(buffer, start, end, 57367 /* f4 */)
+			'A'.code -> return parseCsiLegacy(buffer, start, end, CodepointEvent.Up)
+			'B'.code -> return parseCsiLegacy(buffer, start, end, CodepointEvent.Down)
+			'C'.code -> return parseCsiLegacy(buffer, start, end, CodepointEvent.Right)
+			'D'.code -> return parseCsiLegacy(buffer, start, end, CodepointEvent.Left)
+			'E'.code -> return parseCsiLegacy(buffer, start, end, CodepointEvent.KpBegin)
+			'F'.code -> return parseCsiLegacy(buffer, start, end, CodepointEvent.End)
+			'H'.code -> return parseCsiLegacy(buffer, start, end, CodepointEvent.Home)
+			'P'.code -> return parseCsiLegacy(buffer, start, end, CodepointEvent.F1)
+			'Q'.code -> return parseCsiLegacy(buffer, start, end, CodepointEvent.F2)
+			'R'.code -> return parseCsiLegacy(buffer, start, end, CodepointEvent.F3)
+			'S'.code -> return parseCsiLegacy(buffer, start, end, CodepointEvent.F4)
 
 			'~'.code -> {
 				val delimiter = buffer.indexOfOrDefault(';'.code.toByte(), b3Index, end, end)
 				val number = buffer.parseIntDigits(start = b3Index, end = delimiter)
 				val codepoint = when (number) {
-					2 -> 57348 /* insert */
-					3 -> 57349 /* delete */
-					5 -> 57354 /* page up */
-					6 -> 57355 /* page down */
-					7 -> 57356 /* home */
-					8 -> 57357 /* end */
-					11 -> 57364 /* f1 */
-					12 -> 57365 /* f2 */
-					13 -> 57366 /* f3 */
-					14 -> 57367 /* f4 */
-					15 -> 57368 /* f5 */
-					17 -> 57369 /* f6 */
-					18 -> 57370 /* f7 */
-					19 -> 57371 /* f8 */
-					20 -> 57372 /* f9 */
-					21 -> 57373 /* f10 */
-					23 -> 57374 /* f11 */
-					24 -> 57375 /* f12 */
+					2 -> CodepointEvent.Insert
+					3 -> CodepointEvent.Delete
+					5 -> CodepointEvent.PageUp
+					6 -> CodepointEvent.PageDown
+					7 -> CodepointEvent.Home
+					8 -> CodepointEvent.End
+					11 -> CodepointEvent.F1
+					12 -> CodepointEvent.F2
+					13 -> CodepointEvent.F3
+					14 -> CodepointEvent.F4
+					15 -> CodepointEvent.F5
+					17 -> CodepointEvent.F6
+					18 -> CodepointEvent.F7
+					19 -> CodepointEvent.F8
+					20 -> CodepointEvent.F9
+					21 -> CodepointEvent.F10
+					23 -> CodepointEvent.F11
+					24 -> CodepointEvent.F12
 					200 -> return PasteEvent(start = true)
 					201 -> return PasteEvent(start = false)
-					57427 -> 57427 /* kp_begin */
+					57427 -> CodepointEvent.KpBegin
 					else -> return UnknownEvent(
 						context = "Unknown CSI ~ codepoint",
 						bytes = buffer.copyOfRange(start, end),
@@ -285,7 +284,8 @@ public class TerminalParser(
 			}
 
 			'm'.code,
-			'M'.code -> {
+			'M'.code,
+			-> {
 				if (buffer[b3Index].toInt() != '<'.code) {
 					return UnknownEvent(
 						context = "TODO", // TODO
@@ -484,7 +484,7 @@ public class TerminalParser(
 				offset = b3Index
 				return UnknownEvent(
 					context = "First two bytes match SS3 but character byte was an escape",
-					bytes = buffer.copyOfRange(start, b3Index)
+					bytes = buffer.copyOfRange(start, b3Index),
 				)
 			}
 			else -> {

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/parser.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/parser.kt
@@ -16,7 +16,7 @@ import com.jakewharton.mosaic.terminal.event.UnknownEvent
 private const val BufferSize = 8 * 1024
 private const val BareEscapeDisambiguationReadTimeoutMillis = 100
 
-internal class TerminalParser(
+public class TerminalParser(
 	private val stdinReader: StdinReader,
 	private val isInRawMode: Boolean,
 ) {
@@ -24,7 +24,7 @@ internal class TerminalParser(
 	private var offset = 0
 	private var limit = 0
 
-	fun next(): Event {
+	public fun next(): Event {
 		val buffer = buffer
 		var offset = offset
 		var limit = limit
@@ -520,7 +520,7 @@ internal class TerminalParser(
 			if (slashIndex == limit) return null
 
 			if (buffer[slashIndex] == '\\'.code.toByte()) {
-				val end = slashIndex + 2
+				val end = escIndex + 2
 				offset = end
 				return handler(escIndex, end)
 			}


### PR DESCRIPTION
This is working well enough to land so that I'm not maintaining a huge(er) diff.

```
❯ ./tools/raw-mode-echo/build/bin/macosArm64/releaseExecutable/raw-mode-echo.kexe --mode=event --all
PrimaryDeviceAttributes(data=62;22c)
UnknownEvent(Unknown CSI final byte 1b5b306e)
DeviceStatusReportString(data=ghostty 0.1.0-main+14f603e6)
UnknownEvent(TODO 1b5b3f313030343b322479)
FocusEvent(focused=true)
UnknownEvent(Unknown CSI final byte 1b5b3f3075)
UnknownEvent(TODO 1b5b3f323034383b322479)
ResizeEvent(rows=40, cols=214, height=720, width=1712)
UnknownEvent(Unknown CSI final byte 1b5b3f3939373b316e)
CodepointEvent(Ctrl+0x63)
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
