### PR TITLE
Start testing the terminal parser

### DIFF
--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -16,6 +16,31 @@ public final class com/jakewharton/mosaic/terminal/Tty {
 	public static final fun stdinReader ()Lcom/jakewharton/mosaic/terminal/StdinReader;
 }
 
+public final class com/jakewharton/mosaic/terminal/event/BracketedPasteEvent : com/jakewharton/mosaic/terminal/event/Event {
+	public fun <init> (Z)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStart ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/jakewharton/mosaic/terminal/event/Event {
+}
+
+public final class com/jakewharton/mosaic/terminal/event/FocusEvent : com/jakewharton/mosaic/terminal/event/Event {
+	public fun <init> (Z)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFocused ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/jakewharton/mosaic/terminal/event/UnknownEvent : com/jakewharton/mosaic/terminal/event/Event {
+	public fun <init> (Ljava/lang/String;[B)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytes ()[B
+	public final fun getContext ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -8,6 +8,41 @@
 // Library unique name: <com.jakewharton.mosaic:mosaic-terminal>
 sealed interface com.jakewharton.mosaic.terminal.event/Event // com.jakewharton.mosaic.terminal.event/Event|null[0]
 
+final class com.jakewharton.mosaic.terminal.event/BracketedPasteEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/BracketedPasteEvent|null[0]
+    constructor <init>(kotlin/Boolean) // com.jakewharton.mosaic.terminal.event/BracketedPasteEvent.<init>|<init>(kotlin.Boolean){}[0]
+
+    final val start // com.jakewharton.mosaic.terminal.event/BracketedPasteEvent.start|{}start[0]
+        final fun <get-start>(): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/BracketedPasteEvent.start.<get-start>|<get-start>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/BracketedPasteEvent.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.jakewharton.mosaic.terminal.event/BracketedPasteEvent.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/BracketedPasteEvent.toString|toString(){}[0]
+}
+
+final class com.jakewharton.mosaic.terminal.event/FocusEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/FocusEvent|null[0]
+    constructor <init>(kotlin/Boolean) // com.jakewharton.mosaic.terminal.event/FocusEvent.<init>|<init>(kotlin.Boolean){}[0]
+
+    final val focused // com.jakewharton.mosaic.terminal.event/FocusEvent.focused|{}focused[0]
+        final fun <get-focused>(): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/FocusEvent.focused.<get-focused>|<get-focused>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/FocusEvent.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.jakewharton.mosaic.terminal.event/FocusEvent.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/FocusEvent.toString|toString(){}[0]
+}
+
+final class com.jakewharton.mosaic.terminal.event/UnknownEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/UnknownEvent|null[0]
+    constructor <init>(kotlin/String, kotlin/ByteArray) // com.jakewharton.mosaic.terminal.event/UnknownEvent.<init>|<init>(kotlin.String;kotlin.ByteArray){}[0]
+
+    final val bytes // com.jakewharton.mosaic.terminal.event/UnknownEvent.bytes|{}bytes[0]
+        final fun <get-bytes>(): kotlin/ByteArray // com.jakewharton.mosaic.terminal.event/UnknownEvent.bytes.<get-bytes>|<get-bytes>(){}[0]
+    final val context // com.jakewharton.mosaic.terminal.event/UnknownEvent.context|{}context[0]
+        final fun <get-context>(): kotlin/String // com.jakewharton.mosaic.terminal.event/UnknownEvent.context.<get-context>|<get-context>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/UnknownEvent.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.jakewharton.mosaic.terminal.event/UnknownEvent.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/UnknownEvent.toString|toString(){}[0]
+}
+
 final class com.jakewharton.mosaic.terminal/StdinReader : kotlin/AutoCloseable { // com.jakewharton.mosaic.terminal/StdinReader|null[0]
     final fun close() // com.jakewharton.mosaic.terminal/StdinReader.close|close(){}[0]
     final fun interrupt() // com.jakewharton.mosaic.terminal/StdinReader.interrupt|interrupt(){}[0]

--- a/mosaic-terminal/build.gradle
+++ b/mosaic-terminal/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply from: "$rootDir/addAllTargets.gradle"
 apply from: "$rootDir/publish.gradle"
 apply plugin: 'co.touchlab.cklib'
+apply plugin: 'dev.drewhamilton.poko'
 
 kotlin {
 	explicitApi()

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/bytes.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/bytes.kt
@@ -1,5 +1,6 @@
 package com.jakewharton.mosaic.terminal
 
+// TODO https://youtrack.jetbrains.com/issue/KT-7067
 internal fun ByteArray.indexOf(value: Byte, start: Int, end: Int): Int {
 	return indexOfOrDefault(value, start, end, -1)
 }

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
@@ -1,12 +1,15 @@
 package com.jakewharton.mosaic.terminal.event
 
+import dev.drewhamilton.poko.ArrayContentBased
+import dev.drewhamilton.poko.Poko
+
 public sealed interface Event
 
-// Some temporary events while we spin up parsing...
-
-internal class UnknownEvent(
-	val context: String,
-	val bytes: ByteArray,
+@Poko
+public class UnknownEvent(
+	public val context: String,
+	// TODO ByteString once it moves into the stdlib.
+	@ArrayContentBased public val bytes: ByteArray,
 ) : Event {
 	@OptIn(ExperimentalStdlibApi::class)
 	override fun toString(): String {
@@ -20,7 +23,7 @@ internal class UnknownEvent(
 	}
 }
 
-internal object KeyEscape : Event
+internal data object KeyEscape : Event
 
 internal data class CodepointEvent(
 	val codepoint: Int,
@@ -34,7 +37,7 @@ internal data class CodepointEvent(
 		if (ctrl) append("Ctrl+")
 		if (alt) append("Alt+")
 		append("0x")
-		append(codepoint.toString(16).uppercase())
+		append(codepoint.toString(16).uppercase().padStart(2, '0'))
 		append(')')
 	}
 
@@ -66,12 +69,14 @@ internal data class CodepointEvent(
 	}
 }
 
-internal data class FocusEvent(
-	val focused: Boolean,
+@Poko
+public class FocusEvent(
+	public val focused: Boolean,
 ) : Event
 
-internal data class PasteEvent(
-	val start: Boolean,
+@Poko
+public class BracketedPasteEvent(
+	public val start: Boolean,
 ) : Event
 
 internal data class PrimaryDeviceAttributes(
@@ -135,11 +140,3 @@ internal data class MouseEvent(
 		Button11,
 	}
 }
-
-internal data class LinePositionAbsolute(
-	val row: Int,
-) : Event
-
-internal data class LinePositionRelative(
-	val rows: Int,
-) : Event

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiBracketedPasteEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiBracketedPasteEventTest.kt
@@ -1,0 +1,26 @@
+package com.jakewharton.mosaic.terminal
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jakewharton.mosaic.terminal.event.BracketedPasteEvent
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+class TerminalParserCsiBracketedPasteEventTest {
+	private val writer = Tty.stdinWriter()
+	private val parser = TerminalParser(writer.reader, true)
+
+	@AfterTest fun after() {
+		writer.close()
+	}
+
+	@Test fun pasteStart() {
+		writer.writeHex("1b5b3230307e")
+		assertThat(parser.next()).isEqualTo(BracketedPasteEvent(start = true))
+	}
+
+	@Test fun pasteEnd() {
+		writer.writeHex("1b5b3230317e")
+		assertThat(parser.next()).isEqualTo(BracketedPasteEvent(start = false))
+	}
+}

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiFocusEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiFocusEventTest.kt
@@ -1,0 +1,26 @@
+package com.jakewharton.mosaic.terminal
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jakewharton.mosaic.terminal.event.FocusEvent
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+class TerminalParserCsiFocusEventTest {
+	private val writer = Tty.stdinWriter()
+	private val parser = TerminalParser(writer.reader, true)
+
+	@AfterTest fun after() {
+		writer.close()
+	}
+
+	@Test fun focusedTrue() {
+		writer.writeHex("1b5b49")
+		assertThat(parser.next()).isEqualTo(FocusEvent(focused = true))
+	}
+
+	@Test fun focusedFalse() {
+		writer.writeHex("1b5b4f")
+		assertThat(parser.next()).isEqualTo(FocusEvent(focused = false))
+	}
+}

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/testUtil.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/testUtil.kt
@@ -1,0 +1,6 @@
+package com.jakewharton.mosaic.terminal
+
+@OptIn(ExperimentalStdlibApi::class)
+internal fun StdinWriter.writeHex(hex: String) {
+	write(hex.hexToByteArray())
+}


### PR DESCRIPTION
Fix a bug in the "CSI ... ~" logic which defaulted to a fallback index that included the tilde, rather than the index of the tilde itself.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
