### PR TITLE
Parse system theme events

### DIFF
--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -24,6 +24,14 @@ public final class com/jakewharton/mosaic/terminal/event/BracketedPasteEvent : c
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/jakewharton/mosaic/terminal/event/DeviceStatusReportEvent : com/jakewharton/mosaic/terminal/event/Event {
+	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/jakewharton/mosaic/terminal/event/Event {
 }
 
@@ -40,6 +48,14 @@ public final class com/jakewharton/mosaic/terminal/event/PrimaryDeviceAttributes
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Ljava/lang/String;
 	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/jakewharton/mosaic/terminal/event/SystemThemeEvent : com/jakewharton/mosaic/terminal/event/Event {
+	public fun <init> (Z)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun isDark ()Z
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -19,6 +19,17 @@ final class com.jakewharton.mosaic.terminal.event/BracketedPasteEvent : com.jake
     final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/BracketedPasteEvent.toString|toString(){}[0]
 }
 
+final class com.jakewharton.mosaic.terminal.event/DeviceStatusReportEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/DeviceStatusReportEvent|null[0]
+    constructor <init>(kotlin/String) // com.jakewharton.mosaic.terminal.event/DeviceStatusReportEvent.<init>|<init>(kotlin.String){}[0]
+
+    final val data // com.jakewharton.mosaic.terminal.event/DeviceStatusReportEvent.data|{}data[0]
+        final fun <get-data>(): kotlin/String // com.jakewharton.mosaic.terminal.event/DeviceStatusReportEvent.data.<get-data>|<get-data>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/DeviceStatusReportEvent.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.jakewharton.mosaic.terminal.event/DeviceStatusReportEvent.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/DeviceStatusReportEvent.toString|toString(){}[0]
+}
+
 final class com.jakewharton.mosaic.terminal.event/FocusEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/FocusEvent|null[0]
     constructor <init>(kotlin/Boolean) // com.jakewharton.mosaic.terminal.event/FocusEvent.<init>|<init>(kotlin.Boolean){}[0]
 
@@ -39,6 +50,17 @@ final class com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent :
     final fun equals(kotlin/Any?): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent.toString|toString(){}[0]
+}
+
+final class com.jakewharton.mosaic.terminal.event/SystemThemeEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/SystemThemeEvent|null[0]
+    constructor <init>(kotlin/Boolean) // com.jakewharton.mosaic.terminal.event/SystemThemeEvent.<init>|<init>(kotlin.Boolean){}[0]
+
+    final val isDark // com.jakewharton.mosaic.terminal.event/SystemThemeEvent.isDark|{}isDark[0]
+        final fun <get-isDark>(): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/SystemThemeEvent.isDark.<get-isDark>|<get-isDark>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/SystemThemeEvent.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.jakewharton.mosaic.terminal.event/SystemThemeEvent.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/SystemThemeEvent.toString|toString(){}[0]
 }
 
 final class com.jakewharton.mosaic.terminal.event/UnknownEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/UnknownEvent|null[0]

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/bytes.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/bytes.kt
@@ -29,6 +29,8 @@ internal inline fun ByteArray.indexOfFirstOrElse(
 }
 
 internal fun ByteArray.parseIntDigits(start: Int, end: Int): Int {
+	// TODO This needs an orElse path for parsing failure on non-digits.
+
 	var value = 0
 	for (i in start until end) {
 		value *= 10

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
@@ -84,8 +84,14 @@ public class PrimaryDeviceAttributesEvent(
 	public val data: String,
 ) : Event
 
-internal data class DeviceStatusReportString(
-	val data: String,
+@Poko
+public class DeviceStatusReportEvent(
+	public val data: String,
+) : Event
+
+@Poko
+public class SystemThemeEvent(
+	public val isDark: Boolean,
 ) : Event
 
 internal data class KittyGraphicsEvent(

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiSystemThemeEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiSystemThemeEventTest.kt
@@ -1,0 +1,58 @@
+package com.jakewharton.mosaic.terminal
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jakewharton.mosaic.terminal.event.SystemThemeEvent
+import com.jakewharton.mosaic.terminal.event.UnknownEvent
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalStdlibApi::class)
+class TerminalParserCsiSystemThemeEventTest {
+	private val writer = Tty.stdinWriter()
+	private val parser = TerminalParser(writer.reader, true)
+
+	@AfterTest fun after() {
+		writer.close()
+	}
+
+	@Test fun dark() {
+		writer.writeHex("1b5b3f3939373b316e")
+		assertThat(parser.next()).isEqualTo(SystemThemeEvent(isDark = true))
+	}
+
+	@Test fun light() {
+		writer.writeHex("1b5b3f3939373b326e")
+		assertThat(parser.next()).isEqualTo(SystemThemeEvent(isDark = false))
+	}
+
+	@Test fun missingP2() {
+		writer.writeHex("1b5b3f3939373b6e")
+		assertThat(parser.next()).isEqualTo(
+			UnknownEvent(
+				context = "CSI ? 997 ; p2 n sequence has invalid p2",
+				bytes = "1b5b3f3939373b6e".hexToByteArray(),
+			),
+		)
+	}
+
+	@Test fun unknownP2() {
+		writer.writeHex("1b5b3f3939373b346e")
+		assertThat(parser.next()).isEqualTo(
+			UnknownEvent(
+				context = "CSI ? 997 ; p2 n sequence has invalid p2",
+				bytes = "1b5b3f3939373b346e".hexToByteArray(),
+			),
+		)
+	}
+
+	@Test fun tooLongP2() {
+		writer.writeHex("1b5b3f3939373b31316e")
+		assertThat(parser.next()).isEqualTo(
+			UnknownEvent(
+				context = "CSI ? 997 ; p2 n sequence has invalid p2",
+				bytes = "1b5b3f3939373b31316e".hexToByteArray(),
+			),
+		)
+	}
+}

--- a/tools/raw-mode-echo/src/commonMain/kotlin/example/main.kt
+++ b/tools/raw-mode-echo/src/commonMain/kotlin/example/main.kt
@@ -75,6 +75,7 @@ private class RawModeEchoCommand : CliktCommand("raw-mode-echo") {
 				}
 				if (all || colorQuery) {
 					print("\u001b[?996n") // Color scheme request
+					print("\u001b[?2031h") // Color scheme enable
 				}
 
 				val reader = Tty.stdinReader()


### PR DESCRIPTION
```
❯ ./tools/raw-mode-echo/build/bin/macosArm64/releaseExecutable/raw-mode-echo.kexe --mode=event --all
PrimaryDeviceAttributesEvent(data=62;22)
UnknownEvent(CSI .. n sequence without leading ? 1b5b306e)
DeviceStatusReportEvent(data=ghostty 0.1.0-main+63bf16ff)
UnknownEvent(TODO 1b5b3f313030343b322479)
FocusEvent(focused=true)
UnknownEvent(Unknown CSI final byte 1b5b3f3075)
UnknownEvent(TODO 1b5b3f323034383b322479)
ResizeEvent(rows=40, cols=214, height=720, width=1712)
SystemThemeEvent(isDark=true)
CodepointEvent(Ctrl+0x63)
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
