### PR TITLE
Use dedicated event for terminal version

### DIFF
--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -59,6 +59,14 @@ public final class com/jakewharton/mosaic/terminal/event/SystemThemeEvent : com/
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/jakewharton/mosaic/terminal/event/TerminalVersionEvent : com/jakewharton/mosaic/terminal/event/Event {
+	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/jakewharton/mosaic/terminal/event/UnknownEvent : com/jakewharton/mosaic/terminal/event/Event {
 	public fun <init> (Ljava/lang/String;[B)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -63,6 +63,17 @@ final class com.jakewharton.mosaic.terminal.event/SystemThemeEvent : com.jakewha
     final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/SystemThemeEvent.toString|toString(){}[0]
 }
 
+final class com.jakewharton.mosaic.terminal.event/TerminalVersionEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/TerminalVersionEvent|null[0]
+    constructor <init>(kotlin/String) // com.jakewharton.mosaic.terminal.event/TerminalVersionEvent.<init>|<init>(kotlin.String){}[0]
+
+    final val data // com.jakewharton.mosaic.terminal.event/TerminalVersionEvent.data|{}data[0]
+        final fun <get-data>(): kotlin/String // com.jakewharton.mosaic.terminal.event/TerminalVersionEvent.data.<get-data>|<get-data>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/TerminalVersionEvent.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.jakewharton.mosaic.terminal.event/TerminalVersionEvent.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/TerminalVersionEvent.toString|toString(){}[0]
+}
+
 final class com.jakewharton.mosaic.terminal.event/UnknownEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/UnknownEvent|null[0]
     constructor <init>(kotlin/String, kotlin/ByteArray) // com.jakewharton.mosaic.terminal.event/UnknownEvent.<init>|<init>(kotlin.String;kotlin.ByteArray){}[0]
 

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalParser.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalParser.kt
@@ -12,6 +12,7 @@ import com.jakewharton.mosaic.terminal.event.MouseEvent
 import com.jakewharton.mosaic.terminal.event.PrimaryDeviceAttributesEvent
 import com.jakewharton.mosaic.terminal.event.ResizeEvent
 import com.jakewharton.mosaic.terminal.event.SystemThemeEvent
+import com.jakewharton.mosaic.terminal.event.TerminalVersionEvent
 import com.jakewharton.mosaic.terminal.event.UnknownEvent
 
 private const val BufferSize = 8 * 1024
@@ -446,11 +447,12 @@ public class TerminalParser(
 
 	private fun parseDcs(buffer: ByteArray, start: Int, limit: Int): Event? {
 		return parseUntilStringTerminator(buffer, start, limit) { stIndex, end ->
-			if (stIndex > start + 4 &&
+			val b4Index = start + 3
+			if (stIndex > b4Index &&
 				buffer[start + 2].toInt() == '>'.code &&
-				buffer[start + 3].toInt() == '|'.code
+				buffer[b4Index].toInt() == '|'.code
 			) {
-				DeviceStatusReportEvent(
+				TerminalVersionEvent(
 					data = buffer.decodeToString(start + 4, stIndex),
 				)
 			} else {

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
@@ -90,6 +90,11 @@ public class DeviceStatusReportEvent(
 ) : Event
 
 @Poko
+public class TerminalVersionEvent(
+	public val data: String,
+) : Event
+
+@Poko
 public class SystemThemeEvent(
 	public val isDark: Boolean,
 ) : Event

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserDcsTerminalVersionEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserDcsTerminalVersionEventTest.kt
@@ -1,0 +1,26 @@
+package com.jakewharton.mosaic.terminal
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jakewharton.mosaic.terminal.event.TerminalVersionEvent
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+class TerminalParserDcsTerminalVersionEventTest {
+	private val writer = Tty.stdinWriter()
+	private val parser = TerminalParser(writer.reader, true)
+
+	@AfterTest fun after() {
+		writer.close()
+	}
+
+	@Test fun empty() {
+		writer.writeHex("1b503e7c1b5c")
+		assertThat(parser.next()).isEqualTo(TerminalVersionEvent(""))
+	}
+
+	@Test fun text() {
+		writer.writeHex("1b503e7c68656c6c6f1b5c")
+		assertThat(parser.next()).isEqualTo(TerminalVersionEvent("hello"))
+	}
+}


### PR DESCRIPTION
The xterm spec says this is a 'DSR sequence' which is why the DSR event was used previously, but the format is completely different than the other DSR-based responses.

```
❯ ./tools/raw-mode-echo/build/bin/macosArm64/releaseExecutable/raw-mode-echo.kexe --mode=event --all
PrimaryDeviceAttributesEvent(data=62;22)
UnknownEvent(CSI .. n sequence without leading ? 1b5b306e)
TerminalVersionEvent(data=ghostty 0.1.0-main+63bf16ff)
UnknownEvent(TODO 1b5b3f313030343b322479)
FocusEvent(focused=true)
UnknownEvent(Unknown CSI final byte 1b5b3f3075)
UnknownEvent(TODO 1b5b3f323034383b322479)
ResizeEvent(rows=40, cols=214, height=720, width=1712)
SystemThemeEvent(isDark=true)
CodepointEvent(Ctrl+0x63)
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
