### PR TITLE
Parse Kitty keyboard query responses

### DIFF
--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -43,6 +43,19 @@ public final class com/jakewharton/mosaic/terminal/event/FocusEvent : com/jakewh
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/jakewharton/mosaic/terminal/event/KittyKeyboardQueryEvent : com/jakewharton/mosaic/terminal/event/Event {
+	public fun <init> (I)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisambiguateEscapeCodes ()Z
+	public final fun getFlags ()I
+	public final fun getReportAllKeysAsEscapeCodes ()Z
+	public final fun getReportAlternateKeys ()Z
+	public final fun getReportAssociatedText ()Z
+	public final fun getReportEventTypes ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/jakewharton/mosaic/terminal/event/PrimaryDeviceAttributesEvent : com/jakewharton/mosaic/terminal/event/Event {
 	public fun <init> (Ljava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -41,6 +41,27 @@ final class com.jakewharton.mosaic.terminal.event/FocusEvent : com.jakewharton.m
     final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/FocusEvent.toString|toString(){}[0]
 }
 
+final class com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent|null[0]
+    constructor <init>(kotlin/Int) // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.<init>|<init>(kotlin.Int){}[0]
+
+    final val disambiguateEscapeCodes // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.disambiguateEscapeCodes|{}disambiguateEscapeCodes[0]
+        final fun <get-disambiguateEscapeCodes>(): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.disambiguateEscapeCodes.<get-disambiguateEscapeCodes>|<get-disambiguateEscapeCodes>(){}[0]
+    final val flags // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.flags|{}flags[0]
+        final fun <get-flags>(): kotlin/Int // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.flags.<get-flags>|<get-flags>(){}[0]
+    final val reportAllKeysAsEscapeCodes // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.reportAllKeysAsEscapeCodes|{}reportAllKeysAsEscapeCodes[0]
+        final fun <get-reportAllKeysAsEscapeCodes>(): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.reportAllKeysAsEscapeCodes.<get-reportAllKeysAsEscapeCodes>|<get-reportAllKeysAsEscapeCodes>(){}[0]
+    final val reportAlternateKeys // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.reportAlternateKeys|{}reportAlternateKeys[0]
+        final fun <get-reportAlternateKeys>(): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.reportAlternateKeys.<get-reportAlternateKeys>|<get-reportAlternateKeys>(){}[0]
+    final val reportAssociatedText // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.reportAssociatedText|{}reportAssociatedText[0]
+        final fun <get-reportAssociatedText>(): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.reportAssociatedText.<get-reportAssociatedText>|<get-reportAssociatedText>(){}[0]
+    final val reportEventTypes // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.reportEventTypes|{}reportEventTypes[0]
+        final fun <get-reportEventTypes>(): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.reportEventTypes.<get-reportEventTypes>|<get-reportEventTypes>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/KittyKeyboardQueryEvent.toString|toString(){}[0]
+}
+
 final class com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent|null[0]
     constructor <init>(kotlin/String) // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent.<init>|<init>(kotlin.String){}[0]
 

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalParser.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalParser.kt
@@ -8,6 +8,7 @@ import com.jakewharton.mosaic.terminal.event.Event
 import com.jakewharton.mosaic.terminal.event.FocusEvent
 import com.jakewharton.mosaic.terminal.event.KeyEscape
 import com.jakewharton.mosaic.terminal.event.KittyGraphicsEvent
+import com.jakewharton.mosaic.terminal.event.KittyKeyboardQueryEvent
 import com.jakewharton.mosaic.terminal.event.MouseEvent
 import com.jakewharton.mosaic.terminal.event.PrimaryDeviceAttributesEvent
 import com.jakewharton.mosaic.terminal.event.ResizeEvent
@@ -393,6 +394,24 @@ public class TerminalParser(
 				val height = buffer.parseIntDigits(colDelim + 1, heightDelim)
 				val width = buffer.parseIntDigits(heightDelim + 1, finalIndex)
 				return ResizeEvent(rows, cols, height, width)
+			}
+
+			'u'.code -> {
+				if (buffer[b3Index].toInt() == '?'.code) {
+					val b4Index = start + 3
+					if (b4Index != finalIndex) {
+						val flags = buffer.parseIntDigits(b4Index, finalIndex)
+						return KittyKeyboardQueryEvent(flags)
+					}
+					return UnknownEvent(
+						context = "Malformed Kitty keyboard query response",
+						bytes = buffer.copyOfRange(start, end),
+					)
+				}
+				return UnknownEvent(
+					context = "Kitty keyboard sequence",
+					bytes = buffer.copyOfRange(start, end),
+				)
 			}
 
 			'y'.code -> {

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
@@ -90,6 +90,17 @@ public class DeviceStatusReportEvent(
 ) : Event
 
 @Poko
+public class KittyKeyboardQueryEvent(
+	public val flags: Int,
+) : Event {
+	public val disambiguateEscapeCodes: Boolean get() = (flags and 0b1) != 0
+	public val reportEventTypes: Boolean get() = (flags and 0b10) != 0
+	public val reportAlternateKeys: Boolean get() = (flags and 0b100) != 0
+	public val reportAllKeysAsEscapeCodes: Boolean get() = (flags and 0b1000) != 0
+	public val reportAssociatedText: Boolean get() = (flags and 0b10000) != 0
+}
+
+@Poko
 public class TerminalVersionEvent(
 	public val data: String,
 ) : Event

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiKittyKeyboardQueryEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiKittyKeyboardQueryEventTest.kt
@@ -1,0 +1,43 @@
+package com.jakewharton.mosaic.terminal
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jakewharton.mosaic.terminal.event.KittyKeyboardQueryEvent
+import com.jakewharton.mosaic.terminal.event.UnknownEvent
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalStdlibApi::class)
+class TerminalParserCsiKittyKeyboardQueryEventTest {
+	private val writer = Tty.stdinWriter()
+	private val parser = TerminalParser(writer.reader, true)
+
+	@AfterTest fun after() {
+		writer.close()
+	}
+
+	@Test fun flagsNone() {
+		writer.writeHex("1b5b3f3075")
+		assertThat(parser.next()).isEqualTo(KittyKeyboardQueryEvent(0))
+	}
+
+	@Test fun flagsAll() {
+		writer.writeHex("1b5b3f333175")
+		assertThat(parser.next()).isEqualTo(KittyKeyboardQueryEvent(31))
+	}
+
+	@Test fun flagsUnknown() {
+		writer.writeHex("1b5b3f31323875")
+		assertThat(parser.next()).isEqualTo(KittyKeyboardQueryEvent(128))
+	}
+
+	@Test fun flagsMissing() {
+		writer.writeHex("1b5b3f75")
+		assertThat(parser.next()).isEqualTo(
+			UnknownEvent(
+				context = "Malformed Kitty keyboard query response",
+				bytes = "1b5b3f75".hexToByteArray(),
+			),
+		)
+	}
+}

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/event/KittyKeyboardQueryEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/event/KittyKeyboardQueryEventTest.kt
@@ -1,0 +1,94 @@
+package com.jakewharton.mosaic.terminal.event
+
+import assertk.Assert
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import kotlin.test.Test
+
+class KittyKeyboardQueryEventTest {
+	@Test fun none() {
+		assertThat(KittyKeyboardQueryEvent(0)).hasFlags(
+			disambiguateEscapeCodes = false,
+			reportEventTypes = false,
+			reportAlternateKeys = false,
+			reportAllKeysAsEscapeCodes = false,
+			reportAssociatedText = false,
+		)
+	}
+
+	@Test fun disambiguateEscapeCodes() {
+		assertThat(KittyKeyboardQueryEvent(0b1)).hasFlags(
+			disambiguateEscapeCodes = true,
+			reportEventTypes = false,
+			reportAlternateKeys = false,
+			reportAllKeysAsEscapeCodes = false,
+			reportAssociatedText = false,
+		)
+	}
+
+	@Test fun reportEventTypes() {
+		assertThat(KittyKeyboardQueryEvent(0b10)).hasFlags(
+			disambiguateEscapeCodes = false,
+			reportEventTypes = true,
+			reportAlternateKeys = false,
+			reportAllKeysAsEscapeCodes = false,
+			reportAssociatedText = false,
+		)
+	}
+
+	@Test fun reportAlternateKeys() {
+		assertThat(KittyKeyboardQueryEvent(0b100)).hasFlags(
+			disambiguateEscapeCodes = false,
+			reportEventTypes = false,
+			reportAlternateKeys = true,
+			reportAllKeysAsEscapeCodes = false,
+			reportAssociatedText = false,
+		)
+	}
+
+	@Test fun reportAllKeysAsEscapeCodes() {
+		assertThat(KittyKeyboardQueryEvent(0b1000)).hasFlags(
+			disambiguateEscapeCodes = false,
+			reportEventTypes = false,
+			reportAlternateKeys = false,
+			reportAllKeysAsEscapeCodes = true,
+			reportAssociatedText = false,
+		)
+	}
+
+	@Test fun reportAssociatedText() {
+		assertThat(KittyKeyboardQueryEvent(0b10000)).hasFlags(
+			disambiguateEscapeCodes = false,
+			reportEventTypes = false,
+			reportAlternateKeys = false,
+			reportAllKeysAsEscapeCodes = false,
+			reportAssociatedText = true,
+		)
+	}
+
+	@Test fun unknownFlags() {
+		assertThat(KittyKeyboardQueryEvent(0b11111.inv())).hasFlags(
+			disambiguateEscapeCodes = false,
+			reportEventTypes = false,
+			reportAlternateKeys = false,
+			reportAllKeysAsEscapeCodes = false,
+			reportAssociatedText = false,
+		)
+	}
+
+	private fun Assert<KittyKeyboardQueryEvent>.hasFlags(
+		disambiguateEscapeCodes: Boolean,
+		reportEventTypes: Boolean,
+		reportAlternateKeys: Boolean,
+		reportAllKeysAsEscapeCodes: Boolean,
+		reportAssociatedText: Boolean,
+	) = all {
+		prop(KittyKeyboardQueryEvent::disambiguateEscapeCodes).isEqualTo(disambiguateEscapeCodes)
+		prop(KittyKeyboardQueryEvent::reportEventTypes).isEqualTo(reportEventTypes)
+		prop(KittyKeyboardQueryEvent::reportAlternateKeys).isEqualTo(reportAlternateKeys)
+		prop(KittyKeyboardQueryEvent::reportAllKeysAsEscapeCodes).isEqualTo(reportAllKeysAsEscapeCodes)
+		prop(KittyKeyboardQueryEvent::reportAssociatedText).isEqualTo(reportAssociatedText)
+	}
+}


### PR DESCRIPTION
```
❯ ./tools/raw-mode-echo/build/bin/macosArm64/releaseExecutable/raw-mode-echo.kexe --mode=event --all
PrimaryDeviceAttributesEvent(data=62;22)
UnknownEvent(CSI .. n sequence without leading ? 1b5b306e)
TerminalVersionEvent(data=ghostty 0.1.0-main+63bf16ff)
UnknownEvent(TODO 1b5b3f313030343b322479)
FocusEvent(focused=true)
KittyKeyboardQueryEvent(flags=0)
UnknownEvent(TODO 1b5b3f323034383b322479)
ResizeEvent(rows=40, cols=214, height=720, width=1712)
SystemThemeEvent(isDark=true)
CodepointEvent(Ctrl+0x63)
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
