### PR TITLE
Some quick mouse fixes

### DIFF
--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalParser.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalParser.kt
@@ -286,7 +286,7 @@ public class TerminalParser(
 
 					// Incoming values are 1-based.
 					val x = buffer.parseIntDigits(delim1 + 1, delim2) - 1
-					val y = buffer.parseIntDigits(delim2 + 1, end) - 1
+					val y = buffer.parseIntDigits(delim2 + 1, finalIndex) - 1
 
 					val button = when (buttonBits and 0b11000011) {
 						0 -> MouseEvent.Button.Left

--- a/tools/raw-mode-echo/src/commonMain/kotlin/example/main.kt
+++ b/tools/raw-mode-echo/src/commonMain/kotlin/example/main.kt
@@ -65,6 +65,7 @@ private class RawModeEchoCommand : CliktCommand("raw-mode-echo") {
 				}
 				if (all || mouseEvents) {
 					print("\u001b[?1003h") // Any-event enable
+					print("\u001b[?1006h") // SGR extended coordinates enable
 				}
 				if (all || inBandResize) {
 					print("\u001b[?2048\$p") // In-band resize query


### PR DESCRIPTION
```
❯ gw -q :tools:r-m-e:installDist && ./tools/raw-mode-echo/build/install/raw-mode-echo/bin/raw-mode-echo --mode=event --all
PrimaryDeviceAttributesEvent(data=62;22)
OperatingStatusResponseEvent(ok=true)
TerminalVersionEvent(data=ghostty 0.1.0-main+a733ea38)
DecModeReportEvent(mode=1004, setting=Reset)
FocusEvent(focused=true)
KittyKeyboardQueryEvent(flags=0)
DecModeReportEvent(mode=2048, setting=Reset)
ResizeEvent(rows=40, cols=214, height=720, width=1712)
SystemThemeEvent(isDark=true)
MouseEvent(x=25, y=29, type=Motion, button=None, shift=false, alt=false, ctrl=false)
MouseEvent(x=26, y=29, type=Motion, button=None, shift=false, alt=false, ctrl=false)
MouseEvent(x=27, y=29, type=Motion, button=None, shift=false, alt=false, ctrl=false)
MouseEvent(x=27, y=29, type=Press, button=Left, shift=false, alt=false, ctrl=false)
MouseEvent(x=27, y=29, type=Release, button=Left, shift=false, alt=false, ctrl=false)
MouseEvent(x=27, y=29, type=Press, button=Right, shift=false, alt=false, ctrl=false)
MouseEvent(x=27, y=29, type=Release, button=Right, shift=false, alt=false, ctrl=false)
MouseEvent(x=28, y=29, type=Motion, button=None, shift=true, alt=false, ctrl=false)
MouseEvent(x=29, y=29, type=Motion, button=None, shift=true, alt=false, ctrl=false)
MouseEvent(x=30, y=29, type=Motion, button=None, shift=false, alt=false, ctrl=true)
MouseEvent(x=31, y=29, type=Motion, button=None, shift=false, alt=false, ctrl=true)
MouseEvent(x=32, y=29, type=Motion, button=None, shift=false, alt=true, ctrl=false)
MouseEvent(x=33, y=29, type=Motion, button=None, shift=false, alt=true, ctrl=false)
MouseEvent(x=34, y=29, type=Motion, button=None, shift=false, alt=true, ctrl=false)
MouseEvent(x=35, y=29, type=Motion, button=None, shift=false, alt=true, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelDown, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelDown, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelDown, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelDown, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelDown, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelDown, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelDown, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelUp, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelUp, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelUp, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelUp, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelUp, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelUp, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelUp, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelUp, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelUp, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=WheelUp, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Press, button=Middle, shift=false, alt=false, ctrl=false)
MouseEvent(x=35, y=29, type=Release, button=Middle, shift=false, alt=false, ctrl=false)
CodepointEvent(Ctrl+0x63)
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
