### PR TITLE
Parse Kitty keyboard event type

### DIFF
--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -67,13 +67,14 @@ public final class com/jakewharton/mosaic/terminal/event/KeyboardEvent : com/jak
 	public static final field ModifierNumLock I
 	public static final field ModifierShift I
 	public static final field ModifierSuper I
-	public fun <init> (II)V
-	public synthetic fun <init> (IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (III)V
+	public synthetic fun <init> (IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAlt ()Z
 	public final fun getCapsLock ()Z
 	public final fun getCodepoint ()I
 	public final fun getCtrl ()Z
+	public final fun getEventType ()I
 	public final fun getHyper ()Z
 	public final fun getMeta ()Z
 	public final fun getModifiers ()I

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -58,7 +58,7 @@ final class com.jakewharton.mosaic.terminal.event/FocusEvent : com.jakewharton.m
 }
 
 final class com.jakewharton.mosaic.terminal.event/KeyboardEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/KeyboardEvent|null[0]
-    constructor <init>(kotlin/Int, kotlin/Int = ...) // com.jakewharton.mosaic.terminal.event/KeyboardEvent.<init>|<init>(kotlin.Int;kotlin.Int){}[0]
+    constructor <init>(kotlin/Int, kotlin/Int = ..., kotlin/Int = ...) // com.jakewharton.mosaic.terminal.event/KeyboardEvent.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int){}[0]
 
     final val alt // com.jakewharton.mosaic.terminal.event/KeyboardEvent.alt|{}alt[0]
         final fun <get-alt>(): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/KeyboardEvent.alt.<get-alt>|<get-alt>(){}[0]
@@ -68,6 +68,8 @@ final class com.jakewharton.mosaic.terminal.event/KeyboardEvent : com.jakewharto
         final fun <get-codepoint>(): kotlin/Int // com.jakewharton.mosaic.terminal.event/KeyboardEvent.codepoint.<get-codepoint>|<get-codepoint>(){}[0]
     final val ctrl // com.jakewharton.mosaic.terminal.event/KeyboardEvent.ctrl|{}ctrl[0]
         final fun <get-ctrl>(): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/KeyboardEvent.ctrl.<get-ctrl>|<get-ctrl>(){}[0]
+    final val eventType // com.jakewharton.mosaic.terminal.event/KeyboardEvent.eventType|{}eventType[0]
+        final fun <get-eventType>(): kotlin/Int // com.jakewharton.mosaic.terminal.event/KeyboardEvent.eventType.<get-eventType>|<get-eventType>(){}[0]
     final val hyper // com.jakewharton.mosaic.terminal.event/KeyboardEvent.hyper|{}hyper[0]
         final fun <get-hyper>(): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/KeyboardEvent.hyper.<get-hyper>|<get-hyper>(){}[0]
     final val meta // com.jakewharton.mosaic.terminal.event/KeyboardEvent.meta|{}meta[0]

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
@@ -25,6 +25,7 @@ public class UnknownEvent(
 public class KeyboardEvent(
 	public val codepoint: Int,
 	public val modifiers: Int = 0,
+	public val eventType: Int = 1,
 ) : Event {
 	public val shift: Boolean get() = (modifiers and ModifierShift) != 0
 	public val alt: Boolean get() = (modifiers and ModifierAlt) != 0
@@ -38,6 +39,12 @@ public class KeyboardEvent(
 	override fun toString(): String = buildString {
 		append(__TYPE__)
 		append('(')
+		when (eventType) {
+			1 -> append("Press")
+			2 -> append("Repeat")
+			3 -> append("Release")
+		}
+		append(' ')
 		if (shift) append("Shift+")
 		if (alt) append("Alt+")
 		if (ctrl) append("Ctrl+")


### PR DESCRIPTION
With `print("\u001b[>10u")`:
```
KeyboardEvent(Press 0xE008)
KeyboardEvent(Repeat 0xE008)
KeyboardEvent(Repeat 0xE008)
KeyboardEvent(Repeat 0xE008)
KeyboardEvent(Repeat 0xE008)
KeyboardEvent(Repeat 0xE008)
KeyboardEvent(Repeat 0xE008)
KeyboardEvent(Repeat 0xE008)
KeyboardEvent(Release 0xE008)
KeyboardEvent(Press 0x68)
KeyboardEvent(Press 0x61)
KeyboardEvent(Release 0x68)
KeyboardEvent(Release 0x61)
KeyboardEvent(Press Ctrl+0x63)
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
