### PR TITLE
Parameter is a count, not a length

### DIFF
--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
@@ -32,16 +32,16 @@ public expect object Tty {
 
 public expect class StdinReader : AutoCloseable {
 	/**
-	 * Read up to [length] bytes into [buffer] at [offset]. The number of bytes read will be returned.
+	 * Read up to [count] bytes into [buffer] at [offset]. The number of bytes read will be returned.
 	 * 0 will be returned if [interrupt] is called while waiting for input. -1 will be returned if
 	 * the input stream is closed.
 	 *
 	 * @see readWithTimeout
 	 */
-	public fun read(buffer: ByteArray, offset: Int, length: Int): Int
+	public fun read(buffer: ByteArray, offset: Int, count: Int): Int
 
 	/**
-	 * Read up to [length] bytes into [buffer] at [offset]. The number of bytes read will be returned.
+	 * Read up to [count] bytes into [buffer] at [offset]. The number of bytes read will be returned.
 	 * 0 will be returned if [interrupt] is called while waiting for input, or if at least
 	 * [timeoutMillis] have passed without data. -1 will be returned if the input stream is closed.
 	 *
@@ -50,7 +50,7 @@ public expect class StdinReader : AutoCloseable {
 	 * value is not validated.
 	 * @see read
 	 */
-	public fun readWithTimeout(buffer: ByteArray, offset: Int, length: Int, timeoutMillis: Int): Int
+	public fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int
 
 	/** Signal blocking calls to [read] to wake up and return 0. */
 	public fun interrupt()

--- a/mosaic-terminal/src/jvmMain/jni/mosaic-jni.c
+++ b/mosaic-terminal/src/jvmMain/jni/mosaic-jni.c
@@ -65,12 +65,12 @@ Java_com_jakewharton_mosaic_terminal_Tty_stdinReaderRead(
 	jlong ptr,
 	jbyteArray buffer,
 	jint offset,
-	jint length
+	jint count
 ) {
 	jbyte *nativeBuffer = (*env)->GetByteArrayElements(env, buffer, NULL);
 	jbyte *nativeBufferAtOffset = nativeBuffer + offset;
 
-	stdinRead read = stdinReader_read((stdinReader *) ptr, nativeBufferAtOffset, length);
+	stdinRead read = stdinReader_read((stdinReader *) ptr, nativeBufferAtOffset, count);
 
 	(*env)->ReleaseByteArrayElements(env, buffer, nativeBuffer, 0);
 
@@ -91,7 +91,7 @@ Java_com_jakewharton_mosaic_terminal_Tty_stdinReaderReadWithTimeout(
 	jlong ptr,
 	jbyteArray buffer,
 	jint offset,
-	jint length,
+	jint count,
 	jint timeoutMillis
 ) {
 	jbyte *nativeBuffer = (*env)->GetByteArrayElements(env, buffer, NULL);
@@ -100,7 +100,7 @@ Java_com_jakewharton_mosaic_terminal_Tty_stdinReaderReadWithTimeout(
 	stdinRead read = stdinReader_readWithTimeout(
 		(stdinReader *) ptr,
 		nativeBufferAtOffset,
-		length,
+		count,
 		timeoutMillis
 	);
 

--- a/mosaic-terminal/src/jvmMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
+++ b/mosaic-terminal/src/jvmMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
@@ -57,7 +57,7 @@ public actual object Tty {
 		reader: Long,
 		buffer: ByteArray,
 		offset: Int,
-		length: Int,
+		count: Int,
 	): Int
 
 	@JvmStatic
@@ -67,7 +67,7 @@ public actual object Tty {
 		reader: Long,
 		buffer: ByteArray,
 		offset: Int,
-		length: Int,
+		count: Int,
 		timeoutMillis: Int,
 	): Int
 
@@ -133,12 +133,12 @@ public actual object Tty {
 public actual class StdinReader internal constructor(
 	private val readerPtr: Long,
 ) : AutoCloseable {
-	public actual fun read(buffer: ByteArray, offset: Int, length: Int): Int {
-		return Tty.stdinReaderRead(readerPtr, buffer, offset, length)
+	public actual fun read(buffer: ByteArray, offset: Int, count: Int): Int {
+		return Tty.stdinReaderRead(readerPtr, buffer, offset, count)
 	}
 
-	public actual fun readWithTimeout(buffer: ByteArray, offset: Int, length: Int, timeoutMillis: Int): Int {
-		return Tty.stdinReaderReadWithTimeout(readerPtr, buffer, offset, length, timeoutMillis)
+	public actual fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int {
+		return Tty.stdinReaderReadWithTimeout(readerPtr, buffer, offset, count, timeoutMillis)
 	}
 
 	public actual fun interrupt() {

--- a/mosaic-terminal/src/nativeMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
+++ b/mosaic-terminal/src/nativeMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
@@ -52,19 +52,19 @@ public actual object Tty {
 public actual class StdinReader internal constructor(
 	private var ref: CPointer<stdinReader>?,
 ) : AutoCloseable {
-	public actual fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+	public actual fun read(buffer: ByteArray, offset: Int, count: Int): Int {
 		buffer.usePinned {
-			stdinReader_read(ref, it.addressOf(offset), length).useContents {
-				if (error == 0U) return count
+			stdinReader_read(ref, it.addressOf(offset), count).useContents {
+				if (error == 0U) return this.count
 				Tty.throwError(error)
 			}
 		}
 	}
 
-	public actual fun readWithTimeout(buffer: ByteArray, offset: Int, length: Int, timeoutMillis: Int): Int {
+	public actual fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int {
 		buffer.usePinned {
-			stdinReader_readWithTimeout(ref, it.addressOf(offset), length, timeoutMillis).useContents {
-				if (error == 0U) return count
+			stdinReader_readWithTimeout(ref, it.addressOf(offset), count, timeoutMillis).useContents {
+				if (error == 0U) return this.count
 				Tty.throwError(error)
 			}
 		}


### PR DESCRIPTION
Behavior was correct by callers and implementation, but API reflected old name.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
