### PR TITLE
Output bytes with parsed events

### DIFF
--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -7,6 +7,7 @@ public final class com/jakewharton/mosaic/terminal/StdinReader : java/lang/AutoC
 
 public final class com/jakewharton/mosaic/terminal/TerminalParser {
 	public fun <init> (Lcom/jakewharton/mosaic/terminal/StdinReader;)V
+	public final fun debugNext ()Lkotlin/Pair;
 	public final fun getKittyDisambiguateEscapeCodes ()Z
 	public final fun getXtermExtendedUtf8Mouse ()Z
 	public final fun next ()Lcom/jakewharton/mosaic/terminal/event/Event;

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -293,6 +293,7 @@ final class com.jakewharton.mosaic.terminal/TerminalParser { // com.jakewharton.
         final fun <get-xtermExtendedUtf8Mouse>(): kotlin/Boolean // com.jakewharton.mosaic.terminal/TerminalParser.xtermExtendedUtf8Mouse.<get-xtermExtendedUtf8Mouse>|<get-xtermExtendedUtf8Mouse>(){}[0]
         final fun <set-xtermExtendedUtf8Mouse>(kotlin/Boolean) // com.jakewharton.mosaic.terminal/TerminalParser.xtermExtendedUtf8Mouse.<set-xtermExtendedUtf8Mouse>|<set-xtermExtendedUtf8Mouse>(kotlin.Boolean){}[0]
 
+    final fun debugNext(): kotlin/Pair<com.jakewharton.mosaic.terminal.event/Event, kotlin/ByteArray> // com.jakewharton.mosaic.terminal/TerminalParser.debugNext|debugNext(){}[0]
     final fun next(): com.jakewharton.mosaic.terminal.event/Event // com.jakewharton.mosaic.terminal/TerminalParser.next|next(){}[0]
 }
 

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalParser.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalParser.kt
@@ -54,6 +54,23 @@ public class TerminalParser(
 	 */
 	public var xtermExtendedUtf8Mouse: Boolean = false
 
+	/**
+	 * A version of [next] which also returns the bytes that produced the event.
+	 *
+	 * **WARNING** This function is expensive, and should only be used for debugging.
+	 */
+	public fun debugNext(): Pair<Event, ByteArray> {
+		// Move any existing data to index 0 of the buffer. This will ensure we can capture all the
+		// bytes consumed (even across multiple reads) since the original offset will always be 0.
+		buffer.copyInto(buffer, 0, startIndex = offset, endIndex = limit)
+		limit = limit - offset
+		offset = 0
+
+		val event = next()
+		val bytes = buffer.copyOfRange(0, offset)
+		return event to bytes
+	}
+
 	public fun next(): Event {
 		val buffer = buffer
 		var offset = offset


### PR DESCRIPTION
```
❯ gw -q :tools:r-m-e:installDist && tools/raw-mode-echo/build/install/raw-mode-echo/bin/raw-mode-echo --mode=event --all
PrimaryDeviceAttributesEvent(data=62;22)
  1b5b3f36323b323263

OperatingStatusResponseEvent(ok=true)
  1b5b306e

TerminalVersionEvent(data=ghostty 0.1.0-main+711f9477)
  1b503e7c67686f7374747920302e312e302d6d61696e2b37313166393437371b5c

DecModeReportEvent(mode=1004, setting=Reset)
  1b5b3f313030343b322479

FocusEvent(focused=true)
  1b5b49

KittyKeyboardQueryEvent(flags=0)
  1b5b3f3075

DecModeReportEvent(mode=2048, setting=Reset)
  1b5b3f323034383b322479

ResizeEvent(rows=40, columns=214, height=720, width=1712)
  1b5b34383b34303b3231343b3732303b3137313274

TerminalColorEvent(color=Foreground, value=rgb:ffff/ffff/ffff)
  1b5d31303b7267623a666666662f666666662f666666661b5c

TerminalColorEvent(color=Background, value=rgb:2828/2c2c/3434)
  1b5d31313b7267623a323832382f326332632f333433341b5c

TerminalColorEvent(color=Cursor, value=rgb:ffff/ffff/ffff)
  1b5d31323b7267623a666666662f666666662f666666661b5c

PaletteColorEvent(color=0, value=rgb:1d1d/1f1f/2121)
  1b5d343b303b7267623a316431642f316631662f323132311b5c
```
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
