### PR TITLE
Render as fast as possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ New:
 - Nothing yet!
 
 Changed:
-- Nothing yet!
+- Rendering now occurs as fast as possible, although still only when necessary. Previously the maximum FPS was capped to 20 which could cause minor visual delays when processing events.
 
 Fixed:
 - Nothing yet!

--- a/mosaic-runtime/build.gradle
+++ b/mosaic-runtime/build.gradle
@@ -46,4 +46,5 @@ kotlin {
 	}
 
 	compilerOptions.freeCompilerArgs.add('-Xexpect-actual-classes')
+	compilerOptions.freeCompilerArgs.add('-Xnon-local-break-continue')
 }


### PR DESCRIPTION
Do not delay to space out frames. Instead, send frames as fast as possible and only render when something changes. This ensures we reflect changes as soon as possible rather than after an artificial delay.

Closes #507 

@EpicDima Please review if you have time!

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
