### PR TITLE
Remove timing on interrupt test

### DIFF
--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/StdinReaderTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/StdinReaderTest.kt
@@ -41,23 +41,15 @@ class StdinReaderTest {
 			delay(150.milliseconds)
 			reader.interrupt()
 		}
-		val readA: Int
-		val tookA = measureTime {
-			readA = reader.read(ByteArray(10), 0, 10)
-		}
+		val readA = reader.read(ByteArray(10), 0, 10)
 		assertThat(readA).isZero()
-		assertThat(tookA).isGreaterThan(100.milliseconds)
 
 		GlobalScope.launch(Dispatchers.Default) {
 			delay(150.milliseconds)
 			reader.interrupt()
 		}
-		val readB: Int
-		val tookB = measureTime {
-			readB = reader.read(ByteArray(10), 0, 10)
-		}
+		val readB = reader.read(ByteArray(10), 0, 10)
 		assertThat(readB).isZero()
-		assertThat(tookB).isGreaterThan(100.milliseconds)
 	}
 
 	@Test fun readWithTimeoutReturnsZeroOnTimeout() {


### PR DESCRIPTION
We don't really need to know how long the read took, just that it was interrupted. Testing for time ensures that it didn't just return instantly, but we'll be okay without it. The test will hang forever if it can't be interrupted.

Closes #577 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
