### PR TITLE
Add shrinker rules to keep native names

### DIFF
--- a/mosaic-terminal/src/jvmMain/resources/META-INF/proguard/com.jakewharton.mosaic-terminal.pro
+++ b/mosaic-terminal/src/jvmMain/resources/META-INF/proguard/com.jakewharton.mosaic-terminal.pro
@@ -1,0 +1,5 @@
+# Keep native method names which are used by the consumer. Our JNI code only creates JDK types and
+# only uses Java built-in types across the boundary.
+-keepclasseswithmembernames class com.jakewharton.mosaic.terminal.** {
+  native <methods>;
+}


### PR DESCRIPTION
Class and method names of native methods must be kept. We don't need to include the descriptor types, becuase we only use Java's build-in types.

Refs #536 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
