### PR TITLE
Do not use `Rendering` for test harness

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/canvas.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/canvas.kt
@@ -156,11 +156,13 @@ internal class TextSurface(
 	}
 
 	fun render(): String = buildString {
-		for (rowIndex in 0 until height) {
-			if (rowIndex > 0) {
-				append("\r\n")
+		if (height > 0) {
+			for (rowIndex in 0 until height) {
+				appendRowTo(this, rowIndex)
+				append("\n")
 			}
-			appendRowTo(this, rowIndex)
+			// Remove trailing newline.
+			setLength(length - 1)
 		}
 	}
 }

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/CounterTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/CounterTest.kt
@@ -30,26 +30,6 @@ class CounterTest {
 		}
 	}
 
-	@Test fun counterWithAnsi() = runTest {
-		runMosaicTest(withAnsi = true) {
-			setCounter()
-			assertThat(awaitRenderSnapshot()).isEqualTo(
-				"""
-				|${ansiBeginSynchronizedUpdate}The count is: 0
-				|$ansiEndSynchronizedUpdate
-				""".trimMargin().replaceLineEndingsWithCRLF(),
-			)
-			for (i in 1..20) {
-				assertThat(awaitRenderSnapshot()).isEqualTo(
-					"""
-					|${ansiBeginSynchronizedUpdate}${cursorUp}The count is: ${i}$clearLine
-					|$ansiEndSynchronizedUpdate
-					""".trimMargin().replaceLineEndingsWithCRLF(),
-				)
-			}
-		}
-	}
-
 	@Test fun counterInTerminalCenter() = runTest {
 		runMosaicTest(initialTerminalSize = IntSize(width = 30, height = 1)) {
 			setCounterInTerminalCenter()

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/TestMosaicComposition.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/TestMosaicComposition.kt
@@ -67,10 +67,6 @@ private class RealTestMosaicComposition(
 	/** Channel with the most recent snapshot, if any. */
 	private val snapshots = Channel<NodeRenderSnapshot>(CONFLATED)
 
-	private val rendering: Rendering = AnsiRendering(
-		ansiLevel = if (withAnsi) AnsiLevel.TRUECOLOR else AnsiLevel.NONE,
-	)
-
 	private val terminalState: MutableState<Terminal> = mutableStateOf(
 		Terminal(size = initialTerminalSize),
 	)
@@ -83,16 +79,8 @@ private class RealTestMosaicComposition(
 		terminalState = terminalState,
 		keyEvents = keyEvents,
 		onDraw = { rootNode ->
-			val stringRender = if (withAnsi) {
-				rendering.render(rootNode).toString()
-			} else {
-				rendering.render(rootNode).toString()
-					.removeSurrounding(ansiBeginSynchronizedUpdate, ansiEndSynchronizedUpdate)
-					.removeSuffix("\r\n") // without last line break for simplicity
-					.replace(clearLine, "")
-					.replace(cursorUp, "")
-					.replace("\r\n", "\n") // CRLF to LF for simplicity
-			}
+			val ansiLevel = if (withAnsi) AnsiLevel.TRUECOLOR else AnsiLevel.NONE
+			val stringRender = rootNode.paint(ansiLevel).render()
 			snapshots.trySend(NodeRenderSnapshot(rootNode, stringRender))
 			hasChanges = true
 		},


### PR DESCRIPTION
`Rendering` is for sending multiple frames to a VT-aware display, and its use only complicates the test harness. Our internal tests are the only ones which should ever need to test VT sequences.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
