### PR TITLE
Drop `TextCanvas` interface

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawScope.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawScope.kt
@@ -18,8 +18,8 @@
 
 package com.jakewharton.mosaic.layout
 
-import com.jakewharton.mosaic.TextCanvas
 import com.jakewharton.mosaic.TextPixel
+import com.jakewharton.mosaic.TextSurface
 import com.jakewharton.mosaic.UnspecifiedCodePoint
 import com.jakewharton.mosaic.isSpecifiedCodePoint
 import com.jakewharton.mosaic.isUnspecifiedCodePoint
@@ -115,7 +115,7 @@ public interface DrawScope {
 }
 
 internal open class TextCanvasDrawScope(
-	private val canvas: TextCanvas,
+	private val canvas: TextSurface,
 	override val width: Int,
 	override val height: Int,
 ) : DrawScope {

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Node.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/Node.kt
@@ -1,7 +1,6 @@
 package com.jakewharton.mosaic.layout
 
 import androidx.collection.MutableObjectList
-import com.jakewharton.mosaic.TextCanvas
 import com.jakewharton.mosaic.TextSurface
 import com.jakewharton.mosaic.layout.Placeable.PlacementScope
 import com.jakewharton.mosaic.modifier.Modifier
@@ -58,7 +57,7 @@ internal abstract class MosaicNodeLayer(
 		measureResult.placeChildren()
 	}
 
-	open fun drawTo(canvas: TextCanvas) {
+	open fun drawTo(canvas: TextSurface) {
 		next?.drawTo(canvas)
 	}
 
@@ -193,7 +192,7 @@ private class BottomLayer(
 		return node.measurePolicy.run { measure(node.children, constraints) }
 	}
 
-	override fun drawTo(canvas: TextCanvas) {
+	override fun drawTo(canvas: TextSurface) {
 		for (child in node.children) {
 			if (child.width != 0 && child.height != 0) {
 				child.topLayer.drawTo(canvas)
@@ -256,7 +255,7 @@ private class DrawLayer(
 	private val element: DrawModifier,
 	override val next: MosaicNodeLayer,
 ) : MosaicNodeLayer(false) {
-	override fun drawTo(canvas: TextCanvas) {
+	override fun drawTo(canvas: TextSurface) {
 		val oldX = canvas.translationX
 		val oldY = canvas.translationY
 		canvas.translationX = x

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/surface.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/surface.kt
@@ -16,27 +16,18 @@ import com.jakewharton.mosaic.ui.isSpecifiedColor
 import com.jakewharton.mosaic.ui.isUnspecifiedColor
 import de.cketti.codepoints.appendCodePoint
 
-internal interface TextCanvas {
-	val width: Int
-	val height: Int
-	var translationX: Int
-	var translationY: Int
-
-	operator fun get(row: Int, column: Int): TextPixel
-}
-
 private val blankPixel = TextPixel(' ')
 
 internal class TextSurface(
-	override val width: Int,
-	override val height: Int,
-) : TextCanvas {
-	override var translationX = 0
-	override var translationY = 0
+	val width: Int,
+	val height: Int,
+) {
+	var translationX = 0
+	var translationY = 0
 
 	private val cells = Array(width * height) { TextPixel(' ') }
 
-	override operator fun get(row: Int, column: Int): TextPixel {
+	operator fun get(row: Int, column: Int): TextPixel {
 		val x = translationX + column
 		val y = row + translationY
 		check(x in 0 until width)


### PR DESCRIPTION
We don't need it right now.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
