### PR TITLE
Do not draw trailing whitespace

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/surface.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/surface.kt
@@ -15,6 +15,7 @@ import com.jakewharton.mosaic.ui.isNotEmptyTextStyle
 import com.jakewharton.mosaic.ui.isSpecifiedColor
 import com.jakewharton.mosaic.ui.isUnspecifiedColor
 import de.cketti.codepoints.appendCodePoint
+import kotlin.math.max
 
 private val blankPixel = TextPixel(' ')
 
@@ -34,12 +35,14 @@ internal class TextSurface(
 	var translationY = 0
 
 	private val cells = Array(width * height) { TextPixel(' ') }
+	private val lastColumn = IntArray(height)
 
 	operator fun get(row: Int, column: Int): TextPixel {
 		val x = translationX + column
 		val y = row + translationY
 		check(x in 0 until width)
 		check(y in 0 until height)
+		lastColumn[y] = max(lastColumn[y], x + 1)
 		return cells[y * width + x]
 	}
 
@@ -50,7 +53,7 @@ internal class TextSurface(
 		var lastPixel = blankPixel
 
 		val rowStart = row * width
-		val rowStop = rowStart + width
+		val rowStop = rowStart + lastColumn[row]
 		for (columnIndex in rowStart until rowStop) {
 			val pixel = cells[columnIndex]
 

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
@@ -22,10 +22,9 @@ class AnsiRenderingTest {
 				}
 			}
 
-			// TODO We should not draw trailing whitespace.
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|Hello$s
+				|Hello
 				|World!
 				|
 				""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
@@ -44,7 +43,7 @@ class AnsiRenderingTest {
 
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|Hello$s
+				|Hello
 				|World!
 				|
 				""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
@@ -62,7 +61,7 @@ class AnsiRenderingTest {
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
 				|$cursorUp${cursorUp}Hel$clearLine
-				|lo $clearLine
+				|lo$clearLine
 				|Wor
 				|ld!
 				|
@@ -85,7 +84,7 @@ class AnsiRenderingTest {
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
 				|Hel
-				|lo$s
+				|lo
 				|Wor
 				|ld!
 				|
@@ -101,7 +100,7 @@ class AnsiRenderingTest {
 
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|$cursorUp$cursorUp$cursorUp${cursorUp}Hello $clearLine
+				|$cursorUp$cursorUp$cursorUp${cursorUp}Hello$clearLine
 				|World!$clearLine
 				|$clearLine
 				|$clearLine$cursorUp
@@ -220,7 +219,7 @@ class AnsiRenderingTest {
 				"""
 				|Static
 				|TopTopTop
-				|LeftLeft$s
+				|LeftLeft
 				|
 				""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
 			)

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/CounterTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/CounterTest.kt
@@ -35,7 +35,7 @@ class CounterTest {
 			terminalState.value = Terminal(size = IntSize(width = 30, height = 1))
 			setCounterInTerminalCenter()
 			for (count in 0..9) {
-				assertThat(awaitSnapshot()).isEqualTo("        The count is: $count       ")
+				assertThat(awaitSnapshot()).isEqualTo("        The count is: $count")
 			}
 
 			terminalState.value = Terminal(size = IntSize(width = 20, height = 1))
@@ -45,7 +45,7 @@ class CounterTest {
 			delay(250L)
 
 			for (count in 10..20) {
-				assertThat(awaitSnapshot()).isEqualTo("  The count is: $count  ")
+				assertThat(awaitSnapshot()).isEqualTo("  The count is: $count")
 			}
 		}
 	}
@@ -60,7 +60,7 @@ class CounterTest {
 			for (count in 0..20) {
 				assertThat(awaitSnapshot()).isEqualTo(
 					"""
-					|The count is: $count      $s
+					|The count is: $count
 					|The second count is: $count
 					""".trimMargin(),
 				)

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/LayoutTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/LayoutTest.kt
@@ -51,7 +51,7 @@ class LayoutTest {
 			}
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|  $s
+				|
 				""".trimMargin(),
 			)
 		}
@@ -99,8 +99,8 @@ class LayoutTest {
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
 				|     CCC
-				|  BB   $s
-				|A      $s
+				|  BB
+				|A
 				""".trimMargin(),
 			)
 		}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/MosaicTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/MosaicTest.kt
@@ -46,8 +46,8 @@ class MosaicTest {
 		}
 		assertThat(actual).isEqualTo(
 			"""
-			|One $s
-			|Two $s
+			|One
+			|Two
 			|Three
 			|
 			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
@@ -76,8 +76,8 @@ class MosaicTest {
 		}
 		assertThat(actual).isEqualTo(
 			"""
-			|One $s
-			|Two $s
+			|One
+			|Two
 			|Three
 			|
 			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
@@ -106,8 +106,8 @@ class MosaicTest {
 		}
 		assertThat(actual).isEqualTo(
 			"""
-			|One $s
-			|Two $s
+			|One
+			|Two
 			|Three
 			|
 			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
@@ -148,8 +148,8 @@ class MosaicTest {
 		}
 		assertThat(actual).isEqualTo(
 			"""
-			|One $s
-			|Two $s
+			|One
+			|Two
 			|Three
 			|
 			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
@@ -168,8 +168,8 @@ class MosaicTest {
 		}
 		assertThat(actual).isEqualTo(
 			"""
-			|One $s
-			|Two $s
+			|One
+			|Two
 			|Three
 			|
 			""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
@@ -192,8 +192,8 @@ class MosaicTest {
 		actuals.forEach { actual ->
 			assertThat(actual).isEqualTo(
 				"""
-				|One $s
-				|Two $s
+				|One
+				|Two
 				|Three
 				|
 				""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
@@ -216,8 +216,8 @@ class MosaicTest {
 				}
 			}
 
-			assertThat(awaitSnapshot()).isEqualTo("$TestChar         ")
-			assertThat(awaitSnapshot()).isEqualTo("     $TestChar    ")
+			assertThat(awaitSnapshot()).isEqualTo("$TestChar")
+			assertThat(awaitSnapshot()).isEqualTo("     $TestChar")
 		}
 	}
 
@@ -236,8 +236,8 @@ class MosaicTest {
 				}
 			}
 
-			assertThat(awaitSnapshot()).isEqualTo("$TestChar         ")
-			assertThat(awaitSnapshot()).isEqualTo("     $TestChar    ")
+			assertThat(awaitSnapshot()).isEqualTo("$TestChar")
+			assertThat(awaitSnapshot()).isEqualTo("     $TestChar")
 		}
 	}
 
@@ -266,8 +266,8 @@ class MosaicTest {
 				}
 			}
 
-			assertThat(awaitSnapshot()).isEqualTo("$TestChar         ")
-			assertThat(awaitSnapshot()).isEqualTo("${TestChar + 1}         ")
+			assertThat(awaitSnapshot()).isEqualTo("$TestChar")
+			assertThat(awaitSnapshot()).isEqualTo("${TestChar + 1}")
 		}
 	}
 

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/OffsetTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/OffsetTest.kt
@@ -6,7 +6,6 @@ import com.jakewharton.mosaic.TestChar
 import com.jakewharton.mosaic.TestFiller
 import com.jakewharton.mosaic.assertFailure
 import com.jakewharton.mosaic.modifier.Modifier
-import com.jakewharton.mosaic.s
 import com.jakewharton.mosaic.testing.runMosaicTest
 import com.jakewharton.mosaic.ui.Box
 import com.jakewharton.mosaic.ui.unit.IntOffset
@@ -23,12 +22,12 @@ class OffsetTest {
 			}
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|   $TestChar $s
-				|     $s
-				|     $s
-				|     $s
-				|     $s
-				|     $s
+				|   $TestChar
+				|
+				|
+				|
+				|
+				|
 				""".trimMargin(),
 			)
 		}
@@ -71,12 +70,12 @@ class OffsetTest {
 			}
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|     $s
-				|     $s
-				|     $s
-				|     $s
-				|$TestChar    $s
-				|     $s
+				|
+				|
+				|
+				|
+				|$TestChar
+				|
 				""".trimMargin(),
 			)
 		}
@@ -119,12 +118,12 @@ class OffsetTest {
 			}
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|     $s
-				|     $s
-				|     $s
-				|     $s
-				|   $TestChar $s
-				|     $s
+				|
+				|
+				|
+				|
+				|   $TestChar
+				|
 				""".trimMargin(),
 			)
 		}
@@ -172,12 +171,12 @@ class OffsetTest {
 			}
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|   $TestChar $s
-				|     $s
-				|     $s
-				|     $s
-				|     $s
-				|     $s
+				|   $TestChar
+				|
+				|
+				|
+				|
+				|
 				""".trimMargin(),
 			)
 		}
@@ -220,12 +219,12 @@ class OffsetTest {
 			}
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|     $s
-				|     $s
-				|     $s
-				|     $s
-				|$TestChar    $s
-				|     $s
+				|
+				|
+				|
+				|
+				|$TestChar
+				|
 				""".trimMargin(),
 			)
 		}
@@ -268,12 +267,12 @@ class OffsetTest {
 			}
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|     $s
-				|     $s
-				|     $s
-				|     $s
-				|   $TestChar $s
-				|     $s
+				|
+				|
+				|
+				|
+				|   $TestChar
+				|
 				""".trimMargin(),
 			)
 		}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/PaddingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/layout/PaddingTest.kt
@@ -8,7 +8,6 @@ import com.jakewharton.mosaic.TestChar
 import com.jakewharton.mosaic.TestFiller
 import com.jakewharton.mosaic.assertFailure
 import com.jakewharton.mosaic.modifier.Modifier
-import com.jakewharton.mosaic.s
 import com.jakewharton.mosaic.testIntrinsics
 import com.jakewharton.mosaic.testing.runMosaicTest
 import com.jakewharton.mosaic.ui.Layout
@@ -90,8 +89,8 @@ class PaddingTest {
 			}
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|$s
-				|$s
+				|
+				|
 				|$TestChar
 				""".trimMargin(),
 			)
@@ -129,7 +128,7 @@ class PaddingTest {
 			}
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|$TestChar $s
+				|$TestChar
 				""".trimMargin(),
 			)
 		}
@@ -167,8 +166,8 @@ class PaddingTest {
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
 				|$TestChar
-				|$s
-				|$s
+				|
+				|
 				""".trimMargin(),
 			)
 		}
@@ -206,8 +205,8 @@ class PaddingTest {
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
 				| $TestChar
-				| $s
-				| $s
+				|
+				|
 				""".trimMargin(),
 			)
 		}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/stuff.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/stuff.kt
@@ -24,8 +24,6 @@ import com.jakewharton.mosaic.ui.unit.constrainHeight
 import com.jakewharton.mosaic.ui.unit.constrainWidth
 import kotlin.math.max
 
-const val s = " "
-
 const val TestChar = 'X'
 
 fun String.replaceLineEndingsWithCRLF(): String {

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/BoxTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/BoxTest.kt
@@ -22,7 +22,6 @@ import com.jakewharton.mosaic.layout.size
 import com.jakewharton.mosaic.layout.width
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.position
-import com.jakewharton.mosaic.s
 import com.jakewharton.mosaic.size
 import com.jakewharton.mosaic.testIntrinsics
 import com.jakewharton.mosaic.testing.runMosaicTest
@@ -63,12 +62,12 @@ class BoxTest {
 
 			assertThat(rootNode.paint().render(AnsiLevel.NONE)).isEqualTo(
 				"""
-				|     $s
-				|     $s
-				|  $TestChar$TestChar $s
-				|  $TestChar$TestChar $s
-				|     $s
-				|     $s
+				|
+				|
+				|  $TestChar$TestChar
+				|  $TestChar$TestChar
+				|
+				|
 				""".trimMargin(),
 			)
 		}
@@ -145,7 +144,7 @@ class BoxTest {
 
 			assertThat(rootNode.paint().render(AnsiLevel.NONE)).isEqualTo(
 				"""
-				|     $s
+				|
 				| $TestChar$TestChar$TestChar$TestChar$TestChar
 				| $TestChar$TestChar$TestChar$TestChar$TestChar
 				| $TestChar$TestChar$TestChar$TestChar$TestChar
@@ -192,12 +191,12 @@ class BoxTest {
 
 			assertThat(rootNode.paint().render(AnsiLevel.NONE)).isEqualTo(
 				"""
-				|$TestChar$TestChar$TestChar$TestChar$TestChar$s
-				|$TestChar$TestChar$TestChar$TestChar$TestChar$s
-				|$TestChar$TestChar$TestChar$TestChar$TestChar$s
-				|$TestChar$TestChar$TestChar$TestChar$TestChar$s
-				|$TestChar$TestChar$TestChar$TestChar$TestChar$s
-				|     $s
+				|$TestChar$TestChar$TestChar$TestChar$TestChar
+				|$TestChar$TestChar$TestChar$TestChar$TestChar
+				|$TestChar$TestChar$TestChar$TestChar$TestChar
+				|$TestChar$TestChar$TestChar$TestChar$TestChar
+				|$TestChar$TestChar$TestChar$TestChar$TestChar
+				|
 				""".trimMargin(),
 			)
 		}
@@ -239,12 +238,12 @@ class BoxTest {
 
 			assertThat(rootNode.paint().render(AnsiLevel.NONE)).isEqualTo(
 				"""
-				| $TestChar$TestChar$TestChar$TestChar$s
-				| $TestChar$TestChar$TestChar$TestChar$s
-				| $TestChar$TestChar$TestChar$TestChar$s
-				| $TestChar$TestChar$TestChar$TestChar$s
-				| $TestChar$TestChar$TestChar$TestChar$s
-				| $TestChar$TestChar$TestChar$TestChar$s
+				| $TestChar$TestChar$TestChar$TestChar
+				| $TestChar$TestChar$TestChar$TestChar
+				| $TestChar$TestChar$TestChar$TestChar
+				| $TestChar$TestChar$TestChar$TestChar
+				| $TestChar$TestChar$TestChar$TestChar
+				| $TestChar$TestChar$TestChar$TestChar
 				""".trimMargin(),
 			)
 		}
@@ -286,12 +285,12 @@ class BoxTest {
 
 			assertThat(rootNode.paint().render(AnsiLevel.NONE)).isEqualTo(
 				"""
-				|     $s
+				|
 				|$TestChar$TestChar$TestChar$TestChar$TestChar$TestChar
 				|$TestChar$TestChar$TestChar$TestChar$TestChar$TestChar
 				|$TestChar$TestChar$TestChar$TestChar$TestChar$TestChar
 				|$TestChar$TestChar$TestChar$TestChar$TestChar$TestChar
-				|     $s
+				|
 				""".trimMargin(),
 			)
 		}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/FillerTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/FillerTest.kt
@@ -12,7 +12,6 @@ import com.jakewharton.mosaic.layout.padding
 import com.jakewharton.mosaic.layout.size
 import com.jakewharton.mosaic.layout.width
 import com.jakewharton.mosaic.modifier.Modifier
-import com.jakewharton.mosaic.s
 import com.jakewharton.mosaic.size
 import com.jakewharton.mosaic.testing.runMosaicTest
 import com.jakewharton.mosaic.ui.unit.Constraints
@@ -52,12 +51,12 @@ class FillerTest {
 			}
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|   $s
-				| $TestChar$TestChar$s
-				| $TestChar$TestChar$s
-				| $TestChar$TestChar$s
-				| $TestChar$TestChar$s
-				|   $s
+				|
+				| $TestChar$TestChar
+				| $TestChar$TestChar
+				| $TestChar$TestChar
+				| $TestChar$TestChar
+				|
 				""".trimMargin(),
 			)
 		}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/SpacerTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/SpacerTest.kt
@@ -9,7 +9,6 @@ import com.jakewharton.mosaic.layout.height
 import com.jakewharton.mosaic.layout.size
 import com.jakewharton.mosaic.layout.width
 import com.jakewharton.mosaic.modifier.Modifier
-import com.jakewharton.mosaic.s
 import com.jakewharton.mosaic.size
 import com.jakewharton.mosaic.testing.runMosaicTest
 import com.jakewharton.mosaic.ui.unit.Constraints
@@ -30,12 +29,12 @@ class SpacerTest {
 			}
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|   $s
-				|   $s
-				|   $s
-				|   $s
-				|   $s
-				|   $s
+				|
+				|
+				|
+				|
+				|
+				|
 				""".trimMargin(),
 			)
 		}


### PR DESCRIPTION
We assume that accessing a pixel of the surface implies it should be drawn. Not perfect, but also pretty good.

Not sure about this approach yet. Even if we go with it, the tests for other components need to change as a lot of them were somewhat relying on the fact that we painted spaces.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
