### PR TITLE
Centralize most opt-in usage

### DIFF
--- a/mosaic-runtime/build.gradle
+++ b/mosaic-runtime/build.gradle
@@ -19,6 +19,10 @@ kotlin {
 	explicitApi()
 
 	sourceSets {
+		configureEach {
+			languageSettings.optIn('kotlinx.cinterop.ExperimentalForeignApi')
+		}
+
 		commonMain {
 			dependencies {
 				api libs.compose.runtime

--- a/mosaic-runtime/src/linuxMain/kotlin/com/jakewharton/mosaic/platform.kt
+++ b/mosaic-runtime/src/linuxMain/kotlin/com/jakewharton/mosaic/platform.kt
@@ -15,7 +15,6 @@
  */
 package com.jakewharton.mosaic
 
-import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.memScoped
@@ -25,7 +24,6 @@ import platform.posix.clock_gettime
 import platform.posix.timespec
 
 @Suppress("NOTHING_TO_INLINE")
-@OptIn(ExperimentalForeignApi::class)
 internal actual inline fun nanoTime(): Long = memScoped {
 	val timespec = alloc<timespec>()
 	clock_gettime(CLOCK_MONOTONIC_RAW.convert(), timespec.ptr)

--- a/mosaic-runtime/src/mingwMain/kotlin/com/jakewharton/mosaic/platform.kt
+++ b/mosaic-runtime/src/mingwMain/kotlin/com/jakewharton/mosaic/platform.kt
@@ -15,7 +15,6 @@
  */
 package com.jakewharton.mosaic
 
-import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
@@ -24,7 +23,6 @@ import platform.posix.clock_gettime
 import platform.posix.timespec
 
 @Suppress("NOTHING_TO_INLINE")
-@OptIn(ExperimentalForeignApi::class)
 internal actual inline fun nanoTime(): Long = memScoped {
 	val timespec = alloc<timespec>()
 	clock_gettime(CLOCK_MONOTONIC, timespec.ptr)

--- a/mosaic-terminal/build.gradle
+++ b/mosaic-terminal/build.gradle
@@ -32,7 +32,16 @@ kotlin {
 
 	sourceSets {
 		configureEach {
-			languageSettings.optIn('kotlin.contracts.ExperimentalContracts')
+			languageSettings {
+				optIn('kotlin.contracts.ExperimentalContracts')
+				optIn('kotlinx.cinterop.ExperimentalForeignApi')
+			}
+			if (it.name.endsWith("Test")) {
+				languageSettings {
+					optIn('kotlin.ExperimentalStdlibApi')
+					optIn('kotlinx.coroutines.DelicateCoroutinesApi')
+				}
+			}
 		}
 
 		commonTest {

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/BaseTerminalParserTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/BaseTerminalParserTest.kt
@@ -10,7 +10,6 @@ abstract class BaseTerminalParserTest {
 		writer.close()
 	}
 
-	@OptIn(ExperimentalStdlibApi::class)
 	internal fun StdinWriter.writeHex(hex: String) {
 		write(hex.hexToByteArray())
 	}

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/StdinReaderTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/StdinReaderTest.kt
@@ -8,13 +8,11 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-@OptIn(DelicateCoroutinesApi::class)
 class StdinReaderTest {
 	private val writer = Tty.stdinWriter()
 	private val reader = writer.reader

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiDecModeReportEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiDecModeReportEventTest.kt
@@ -11,7 +11,6 @@ import com.jakewharton.mosaic.terminal.event.DecModeReportEvent.Setting.Set
 import com.jakewharton.mosaic.terminal.event.UnknownEvent
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserCsiDecModeReportEventTest : BaseTerminalParserTest() {
 	@Test fun settings() {
 		writer.writeHex("1b5b3f313030343b302479")

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiKeyboardEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiKeyboardEventTest.kt
@@ -21,7 +21,6 @@ import com.jakewharton.mosaic.terminal.event.KeyboardEvent.Companion.Up
 import com.jakewharton.mosaic.terminal.event.UnknownEvent
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserCsiKeyboardEventTest : BaseTerminalParserTest() {
 	@Test fun up() {
 		writer.writeHex("1b5b41")

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiKittyKeyboardEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiKittyKeyboardEventTest.kt
@@ -6,7 +6,6 @@ import com.jakewharton.mosaic.terminal.event.KeyboardEvent
 import com.jakewharton.mosaic.terminal.event.KeyboardEvent.Companion.ModifierShift
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserCsiKittyKeyboardEventTest : BaseTerminalParserTest() {
 	@Test fun h() {
 		writer.writeHex("1b5b31303475")

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiKittyKeyboardQueryEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiKittyKeyboardQueryEventTest.kt
@@ -6,7 +6,6 @@ import com.jakewharton.mosaic.terminal.event.KittyKeyboardQueryEvent
 import com.jakewharton.mosaic.terminal.event.UnknownEvent
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserCsiKittyKeyboardQueryEventTest : BaseTerminalParserTest() {
 	@Test fun flagsNone() {
 		writer.writeHex("1b5b3f3075")

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiMouseEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiMouseEventTest.kt
@@ -8,7 +8,6 @@ import com.jakewharton.mosaic.terminal.event.MouseEvent.Type
 import com.jakewharton.mosaic.terminal.event.UnknownEvent
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserCsiMouseEventTest : BaseTerminalParserTest() {
 	@Test fun motion() {
 		writer.writeHex("1b5b4d434837")

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiOperatingStatusResponseEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiOperatingStatusResponseEventTest.kt
@@ -6,7 +6,6 @@ import com.jakewharton.mosaic.terminal.event.OperatingStatusResponseEvent
 import com.jakewharton.mosaic.terminal.event.UnknownEvent
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserCsiOperatingStatusResponseEventTest : BaseTerminalParserTest() {
 	@Test fun ok() {
 		writer.writeHex("1b5b306e")

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiPrimaryDeviceAttributesEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiPrimaryDeviceAttributesEventTest.kt
@@ -6,7 +6,6 @@ import com.jakewharton.mosaic.terminal.event.PrimaryDeviceAttributesEvent
 import com.jakewharton.mosaic.terminal.event.UnknownEvent
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserCsiPrimaryDeviceAttributesEventTest : BaseTerminalParserTest() {
 	@Test fun noLeadingQuestionMarkIsUnknown() {
 		writer.writeHex("1b5b303063")

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiResizeEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiResizeEventTest.kt
@@ -6,7 +6,6 @@ import com.jakewharton.mosaic.terminal.event.ResizeEvent
 import com.jakewharton.mosaic.terminal.event.UnknownEvent
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserCsiResizeEventTest : BaseTerminalParserTest() {
 	@Test fun basic() {
 		writer.writeHex("1b5b34383b313b323b333b3474")

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiSystemThemeEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiSystemThemeEventTest.kt
@@ -6,7 +6,6 @@ import com.jakewharton.mosaic.terminal.event.SystemThemeEvent
 import com.jakewharton.mosaic.terminal.event.UnknownEvent
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserCsiSystemThemeEventTest : BaseTerminalParserTest() {
 	@Test fun dark() {
 		writer.writeHex("1b5b3f3939373b316e")

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiXtermCharacterSizeEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiXtermCharacterSizeEventTest.kt
@@ -6,7 +6,6 @@ import com.jakewharton.mosaic.terminal.event.UnknownEvent
 import com.jakewharton.mosaic.terminal.event.XtermCharacterSizeEvent
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserCsiXtermCharacterSizeEventTest : BaseTerminalParserTest() {
 	@Test fun basic() {
 		writer.writeHex("1b5b383b313b3274")

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiXtermPixelSizeEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiXtermPixelSizeEventTest.kt
@@ -6,7 +6,6 @@ import com.jakewharton.mosaic.terminal.event.UnknownEvent
 import com.jakewharton.mosaic.terminal.event.XtermPixelSizeEvent
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserCsiXtermPixelSizeEventTest : BaseTerminalParserTest() {
 	@Test fun basic() {
 		writer.writeHex("1b5b343b313b3274")

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserOscKittyPointerQueryEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserOscKittyPointerQueryEventTest.kt
@@ -7,7 +7,6 @@ import com.jakewharton.mosaic.terminal.event.KittyPointerQuerySupportEvent
 import com.jakewharton.mosaic.terminal.event.UnknownEvent
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserOscKittyPointerQueryEventTest : BaseTerminalParserTest() {
 	@Test fun emptyFails() {
 		writer.writeHex("1b5d32323b1b5c")

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserSs3KeyboardEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserSs3KeyboardEventTest.kt
@@ -17,7 +17,6 @@ import com.jakewharton.mosaic.terminal.event.OperatingStatusResponseEvent
 import com.jakewharton.mosaic.terminal.event.UnknownEvent
 import kotlin.test.Test
 
-@OptIn(ExperimentalStdlibApi::class)
 class TerminalParserSs3KeyboardEventTest : BaseTerminalParserTest() {
 	@Test fun up() {
 		writer.writeHex("1b4f41")

--- a/mosaic-terminal/src/nativeMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
+++ b/mosaic-terminal/src/nativeMain/kotlin/com/jakewharton/mosaic/terminal/Tty.kt
@@ -1,12 +1,10 @@
 package com.jakewharton.mosaic.terminal
 
 import kotlinx.cinterop.CPointer
-import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.useContents
 import kotlinx.cinterop.usePinned
 
-@OptIn(ExperimentalForeignApi::class)
 public actual object Tty {
 	public actual fun enableRawMode(): AutoCloseable {
 		val savedConfig = enterRawMode().useContents {
@@ -48,7 +46,6 @@ public actual object Tty {
 	}
 }
 
-@OptIn(ExperimentalForeignApi::class)
 public actual class StdinReader internal constructor(
 	private var ref: CPointer<stdinReader>?,
 ) : AutoCloseable {
@@ -87,7 +84,6 @@ public actual class StdinReader internal constructor(
 	}
 }
 
-@OptIn(ExperimentalForeignApi::class)
 internal actual class StdinWriter internal constructor(
 	private var ref: CPointer<stdinWriter>?,
 	readerRef: CPointer<stdinReader>,


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
