### PR TITLE
Add `setContent` variant which returns initial snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 [Unreleased]: https://github.com/JakeWharton/mosaic/compare/0.15.0...HEAD
 
 New:
-- Nothing yet!
+- Add `setContentAndSnapshot` to 'mosaic-testing' which returns the initial composition snapshot. This avoids a potential problem with calling `setContent` and then `awaitSnapshot` since the latter will trigger a subsequent recomposition (if needed), preventing observation of the initial state.
 
 Changed:
 - Nothing yet!

--- a/mosaic-testing/api/mosaic-testing.api
+++ b/mosaic-testing/api/mosaic-testing.api
@@ -12,6 +12,7 @@ public abstract interface class com/jakewharton/mosaic/testing/SnapshotStrategy 
 public abstract interface class com/jakewharton/mosaic/testing/TestMosaic : com/jakewharton/mosaic/Mosaic {
 	public abstract fun awaitSnapshot-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun awaitSnapshot-VtjQ1oo$default (Lcom/jakewharton/mosaic/testing/TestMosaic;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun setContentAndSnapshot (Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 }
 
 public final class com/jakewharton/mosaic/testing/TestMosaicKt {

--- a/mosaic-testing/api/mosaic-testing.klib.api
+++ b/mosaic-testing/api/mosaic-testing.klib.api
@@ -11,6 +11,7 @@ abstract fun interface <#A: kotlin/Any?> com.jakewharton.mosaic.testing/Snapshot
 }
 
 abstract interface <#A: kotlin/Any?> com.jakewharton.mosaic.testing/TestMosaic : com.jakewharton.mosaic/Mosaic { // com.jakewharton.mosaic.testing/TestMosaic|null[0]
+    abstract fun setContentAndSnapshot(kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>): #A // com.jakewharton.mosaic.testing/TestMosaic.setContentAndSnapshot|setContentAndSnapshot(kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>){}[0]
     abstract suspend fun awaitSnapshot(kotlin.time/Duration = ...): #A // com.jakewharton.mosaic.testing/TestMosaic.awaitSnapshot|awaitSnapshot(kotlin.time.Duration){}[0]
 }
 

--- a/mosaic-testing/build.gradle
+++ b/mosaic-testing/build.gradle
@@ -15,6 +15,13 @@ kotlin {
 				implementation libs.compose.collection
 			}
 		}
+		commonTest {
+			dependencies {
+				implementation libs.kotlin.test
+				implementation libs.kotlinx.coroutines.test
+				implementation libs.assertk
+			}
+		}
 	}
 
 	compilerOptions.freeCompilerArgs.add('-Xexpect-actual-classes')

--- a/mosaic-testing/src/commonMain/kotlin/com/jakewharton/mosaic/testing/TestMosaic.kt
+++ b/mosaic-testing/src/commonMain/kotlin/com/jakewharton/mosaic/testing/TestMosaic.kt
@@ -40,6 +40,7 @@ public suspend fun <T, R> runMosaicTest(
 }
 
 public interface TestMosaic<T> : Mosaic {
+	public fun setContentAndSnapshot(content: @Composable () -> Unit): T
 	public suspend fun awaitSnapshot(duration: Duration = 1.seconds): T
 }
 
@@ -62,6 +63,13 @@ private class RealTestMosaic<T>(
 	override fun setContent(content: @Composable () -> Unit) {
 		contentSet = true
 		mosaic.setContent(content)
+	}
+
+	override fun setContentAndSnapshot(content: @Composable (() -> Unit)): T {
+		setContent(content)
+		check(hasChanges)
+		hasChanges = false
+		return snapshotStrategy.create(mosaic)
 	}
 
 	override suspend fun awaitSnapshot(duration: Duration): T {

--- a/mosaic-testing/src/commonTest/kotlin/com/jakewharton/mosaic/testing/TestMosaicTest.kt
+++ b/mosaic-testing/src/commonTest/kotlin/com/jakewharton/mosaic/testing/TestMosaicTest.kt
@@ -1,0 +1,50 @@
+package com.jakewharton.mosaic.testing
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jakewharton.mosaic.ui.Text
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+
+class TestMosaicTest {
+	@Test fun setContentAndSnapshot() = runTest {
+		runMosaicTest {
+			var number by mutableIntStateOf(0)
+			val initial = setContentAndSnapshot {
+				Text("The number is: $number")
+				LaunchedEffect(Unit) {
+					number = 1
+				}
+			}
+
+			// Defer to allow effect to run.
+			delay(10.milliseconds)
+
+			assertThat(initial).isEqualTo("The number is: 0")
+			assertThat(awaitSnapshot()).isEqualTo("The number is: 1")
+		}
+	}
+
+	@Test fun setContentThenSnapshot() = runTest {
+		runMosaicTest {
+			var number by mutableIntStateOf(0)
+			setContent {
+				Text("The number is: $number")
+				LaunchedEffect(Unit) {
+					number = 1
+				}
+			}
+
+			// Defer to allow effect to run.
+			delay(10.milliseconds)
+
+			assertThat(awaitSnapshot()).isEqualTo("The number is: 1")
+		}
+	}
+}


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
