### PR TITLE
Do not trigger recomposition when static renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changed:
 - Nothing yet!
 
 Fixed:
-- Nothing yet!
+- Rendering `Static` data no longer causes one additional subsequent recomposition due to internal state updates.
 
 
 ## [0.15.0] - 2025-01-07

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Static.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ui/Static.kt
@@ -3,10 +3,6 @@
 package com.jakewharton.mosaic.ui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.jakewharton.mosaic.modifier.Modifier
 import kotlin.jvm.JvmName
@@ -20,8 +16,10 @@ public fun <T> Static(
 	items: SnapshotStateList<T>,
 	content: @Composable (T) -> Unit,
 ) {
-	var lastDrawn by remember { mutableIntStateOf(0) }
-	var lastRendered by remember { mutableIntStateOf(0) }
+	// These are not state because we don't want updates to them to trigger recomposition. Changes to
+	// the list are the only thing which should trigger recomposition.
+	var lastDrawn = 0
+	var lastRendered = 0
 
 	Node(
 		measurePolicy = { measurables, constraints ->

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/StaticTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/ui/StaticTest.kt
@@ -1,0 +1,26 @@
+package com.jakewharton.mosaic.ui
+
+import androidx.compose.runtime.mutableStateListOf
+import assertk.assertThat
+import assertk.assertions.hasSize
+import com.jakewharton.mosaic.testing.MosaicSnapshots
+import com.jakewharton.mosaic.testing.runMosaicTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.test.runTest
+
+class StaticTest {
+	@Test fun renderingDoesNotCauseAnotherFrame() = runTest {
+		val statics = mutableStateListOf("static")
+		runMosaicTest(MosaicSnapshots) {
+			setContent {
+				Static(statics) { Text(it) }
+				Text("content")
+			}
+
+			assertThat(awaitSnapshot().paintStatics()).hasSize(1)
+			assertFailsWith<TimeoutCancellationException> { awaitSnapshot() }
+		}
+	}
+}


### PR DESCRIPTION
Closes #663

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
