### PR TITLE
Do not run shrinker tests on trunk

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -154,6 +154,7 @@ jobs:
   # up the additional test runs for use in the above matrix-based runner. For now, run them through
   # Gradle on a single OS and single JDK just to get some coverage.
   terminal-shrinker-tests:
+    if: ${{ github.ref != 'refs/heads/trunk' }}
     needs:
       - terminal-zig
     runs-on: macos-15


### PR DESCRIPTION
They always fail, currently.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
