### PR TITLE
Parse tertiary DA for kicks

### DIFF
--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -204,6 +204,15 @@ public final class com/jakewharton/mosaic/terminal/event/TerminalVersionEvent : 
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/jakewharton/mosaic/terminal/event/TertiaryDeviceAttributesEvent : com/jakewharton/mosaic/terminal/event/Event {
+	public fun <init> (II)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getManufacturingSite ()I
+	public final fun getTerminalId ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/jakewharton/mosaic/terminal/event/UnknownEvent : com/jakewharton/mosaic/terminal/event/Event {
 	public fun <init> ([B)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -276,6 +276,19 @@ final class com.jakewharton.mosaic.terminal.event/TerminalVersionEvent : com.jak
     final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/TerminalVersionEvent.toString|toString(){}[0]
 }
 
+final class com.jakewharton.mosaic.terminal.event/TertiaryDeviceAttributesEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/TertiaryDeviceAttributesEvent|null[0]
+    constructor <init>(kotlin/Int, kotlin/Int) // com.jakewharton.mosaic.terminal.event/TertiaryDeviceAttributesEvent.<init>|<init>(kotlin.Int;kotlin.Int){}[0]
+
+    final val manufacturingSite // com.jakewharton.mosaic.terminal.event/TertiaryDeviceAttributesEvent.manufacturingSite|{}manufacturingSite[0]
+        final fun <get-manufacturingSite>(): kotlin/Int // com.jakewharton.mosaic.terminal.event/TertiaryDeviceAttributesEvent.manufacturingSite.<get-manufacturingSite>|<get-manufacturingSite>(){}[0]
+    final val terminalId // com.jakewharton.mosaic.terminal.event/TertiaryDeviceAttributesEvent.terminalId|{}terminalId[0]
+        final fun <get-terminalId>(): kotlin/Int // com.jakewharton.mosaic.terminal.event/TertiaryDeviceAttributesEvent.terminalId.<get-terminalId>|<get-terminalId>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/TertiaryDeviceAttributesEvent.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.jakewharton.mosaic.terminal.event/TertiaryDeviceAttributesEvent.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.jakewharton.mosaic.terminal.event/TertiaryDeviceAttributesEvent.toString|toString(){}[0]
+}
+
 final class com.jakewharton.mosaic.terminal.event/UnknownEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/UnknownEvent|null[0]
     constructor <init>(kotlin/ByteArray) // com.jakewharton.mosaic.terminal.event/UnknownEvent.<init>|<init>(kotlin.ByteArray){}[0]
 

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/bytes.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/bytes.kt
@@ -50,11 +50,39 @@ internal inline fun ByteArray.parseIntDigits(start: Int, end: Int, orElse: () ->
 		if (end > start) {
 			var value = 0
 			for (i in start until end) {
+				value *= 10
+
 				val digit = this[i].toInt()
 				if (digit !in '0'.code..'9'.code) break@error
+				// '0' is 0b110000, so the low 4 bits give us the digit value.
+				value += digit and 0b1111
+			}
+			return value
+		}
+	} while (false)
 
-				value *= 10
-				value += digit - '0'.code
+	return orElse()
+}
+
+internal inline fun ByteArray.parseHexDigits(start: Int, end: Int, orElse: () -> Int): Int {
+	error@ do {
+		if (end > start) {
+			var value = 0
+			for (i in start until end) {
+				value = value shl 4
+
+				val digit = this[i].toInt()
+				if (digit in '0'.code..'9'.code) {
+					// '0' is 0b110000, so the low 4 bits give us the digit value.
+					// We can do a logical OR because we know these bits are empty from the shift above.
+					value = value or (digit and 0b1111)
+				} else if (digit in 'a'.code..'f'.code) {
+					value += digit - 'a'.code + 10
+				} else if (digit in 'A'.code..'F'.code) {
+					value += digit - 'A'.code + 10
+				} else {
+					break@error
+				}
 			}
 			return value
 		}

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
@@ -107,6 +107,12 @@ public class PrimaryDeviceAttributesEvent(
 ) : Event
 
 @Poko
+public class TertiaryDeviceAttributesEvent(
+	public val manufacturingSite: Int,
+	public val terminalId: Int,
+) : Event
+
+@Poko
 public class OperatingStatusResponseEvent(
 	public val ok: Boolean,
 ) : Event

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserDcsTertiaryDeviceAttributesEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserDcsTertiaryDeviceAttributesEventTest.kt
@@ -1,0 +1,34 @@
+package com.jakewharton.mosaic.terminal
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jakewharton.mosaic.terminal.event.TertiaryDeviceAttributesEvent
+import com.jakewharton.mosaic.terminal.event.UnknownEvent
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+class TerminalParserDcsTertiaryDeviceAttributesEventTest : BaseTerminalParserTest() {
+	@Test fun zeroes() = runTest {
+		writer.writeHex("1b50217c30303030303030301b5c")
+		assertThat(reader.next()).isEqualTo(TertiaryDeviceAttributesEvent(0, 0))
+	}
+
+	@Test fun values() = runTest {
+		writer.writeHex("1b50217c37423036463835351b5c")
+		assertThat(reader.next()).isEqualTo(TertiaryDeviceAttributesEvent(123, 456789))
+	}
+
+	@Test fun tooShort() = runTest {
+		writer.writeHex("1b50217c303030303030301b5c")
+		assertThat(reader.next()).isEqualTo(
+			UnknownEvent("1b50217c303030303030301b5c".hexToByteArray()),
+		)
+	}
+
+	@Test fun tooLong() = runTest {
+		writer.writeHex("1b50217c3030303030303030301b5c")
+		assertThat(reader.next()).isEqualTo(
+			UnknownEvent("1b50217c3030303030303030301b5c".hexToByteArray()),
+		)
+	}
+}


### PR DESCRIPTION
```
Z:\>raw-mode-echo.exe

1b5b3f36313b363b373b31343b32313b32323b32333b32343b32383b33323b343263
PrimaryDeviceAttributesEvent(data=61;6;7;14;21;22;23;24;28;32;42)

1b50217c30303030303030301b5c
TertiaryDeviceAttributesEvent(manufacturingSite=0, terminalId=0)
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
