### PR TITLE
Use our own env var lookup

### DIFF
--- a/mosaic-runtime/build.gradle
+++ b/mosaic-runtime/build.gradle
@@ -5,16 +5,7 @@ apply from: "$rootDir/publish.gradle"
 apply plugin: 'dev.drewhamilton.poko'
 
 kotlin {
-	applyDefaultHierarchyTemplate {
-		it.common {
-			it.group("native") {
-				it.group("posix") {
-					it.group("linux") {}
-					it.group("macos") {}
-				}
-			}
-		}
-	}
+	applyDefaultHierarchyTemplate()
 
 	explicitApi()
 

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.withFrameNanos
 import com.github.ajalt.mordant.input.RawModeScope
 import com.github.ajalt.mordant.input.enterRawMode
-import com.github.ajalt.mordant.platform.MultiplatformSystem
 import com.github.ajalt.mordant.terminal.Terminal as MordantTerminal
 import com.jakewharton.finalization.withFinalizationHook
 import com.jakewharton.mosaic.layout.KeyEvent
@@ -71,7 +70,7 @@ internal suspend fun runMosaic(enterRawMode: Boolean, content: @Composable () ->
 	val mordantTerminal = MordantTerminal()
 	val rendering = createRendering(mordantTerminal.terminalInfo.ansiLevel.toMosaicAnsiLevel())
 
-	val rawMode = if (enterRawMode && MultiplatformSystem.readEnvironmentVariable("MOSAIC_RAW_MODE") != "false") {
+	val rawMode = if (enterRawMode && env("MOSAIC_RAW_MODE") != "false") {
 		// In theory this call could fail, so perform it before any additional control sequences.
 		mordantTerminal.enterRawMode()
 	} else {

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/platform.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/platform.kt
@@ -1,5 +1,7 @@
 package com.jakewharton.mosaic
 
+internal expect fun env(name: String): String?
+
 internal expect fun platformDisplay(chars: CharSequence)
 
 internal expect class AtomicBoolean

--- a/mosaic-runtime/src/jvmMain/kotlin/com/jakewharton/mosaic/platform.kt
+++ b/mosaic-runtime/src/jvmMain/kotlin/com/jakewharton/mosaic/platform.kt
@@ -4,6 +4,10 @@ import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets.UTF_8
 import org.fusesource.jansi.AnsiConsole
 
+internal actual fun env(name: String): String? {
+	return System.getenv(name)
+}
+
 private val out = AnsiConsole.out()!!.also { AnsiConsole.systemInstall() }
 private val encoder = UTF_8.newEncoder()!!
 

--- a/mosaic-runtime/src/nativeMain/kotlin/com/jakewharton/mosaic/platform.kt
+++ b/mosaic-runtime/src/nativeMain/kotlin/com/jakewharton/mosaic/platform.kt
@@ -1,6 +1,12 @@
 package com.jakewharton.mosaic
 
 import kotlin.concurrent.AtomicInt
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
+
+internal actual fun env(name: String): String? {
+	return getenv(name)?.toKString()
+}
 
 internal actual fun platformDisplay(chars: CharSequence) {
 	print(chars.toString())


### PR DESCRIPTION
Reducing Mordant reliance in preparation to switch to our own raw mode mechanism.

Towards #579

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
