### PR TITLE
Parse terminal ID(?) from primary device attributes

### DIFF
--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -153,9 +153,10 @@ public final class com/jakewharton/mosaic/terminal/event/PaletteColorEvent : com
 }
 
 public final class com/jakewharton/mosaic/terminal/event/PrimaryDeviceAttributesEvent : com/jakewharton/mosaic/terminal/event/Event {
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (ILjava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Ljava/lang/String;
+	public final fun getId ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -202,10 +202,12 @@ final class com.jakewharton.mosaic.terminal.event/PaletteColorEvent : com.jakewh
 }
 
 final class com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent : com.jakewharton.mosaic.terminal.event/Event { // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent|null[0]
-    constructor <init>(kotlin/String) // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent.<init>|<init>(kotlin.String){}[0]
+    constructor <init>(kotlin/Int, kotlin/String) // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent.<init>|<init>(kotlin.Int;kotlin.String){}[0]
 
     final val data // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent.data|{}data[0]
         final fun <get-data>(): kotlin/String // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent.data.<get-data>|<get-data>(){}[0]
+    final val id // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent.id|{}id[0]
+        final fun <get-id>(): kotlin/Int // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent.id.<get-id>|<get-id>(){}[0]
 
     final fun equals(kotlin/Any?): kotlin/Boolean // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.jakewharton.mosaic.terminal.event/PrimaryDeviceAttributesEvent.hashCode|hashCode(){}[0]

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalReader.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalReader.kt
@@ -428,9 +428,15 @@ public class TerminalReader internal constructor(
 
 				'c'.code -> {
 					if (buffer[b3Index].toInt() == '?'.code) {
-						val data = buffer.decodeToString(start + 3, finalIndex)
-						// TODO Parse parameters from data
-						return PrimaryDeviceAttributesEvent(data)
+						val b4Index = start + 3
+						val delimiter = buffer.indexOfOrDefault(';'.code.toByte(), b4Index, finalIndex, finalIndex)
+						val id = buffer.parseIntDigits(b4Index, delimiter, orElse = { break@error })
+						val data = if (delimiter < finalIndex) {
+							buffer.decodeToString(delimiter + 1, finalIndex)
+						} else {
+							""
+						}
+						return PrimaryDeviceAttributesEvent(id, data)
 					}
 				}
 

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/event/Event.kt
@@ -103,6 +103,7 @@ public class BracketedPasteEvent(
 
 @Poko
 public class PrimaryDeviceAttributesEvent(
+	public val id: Int,
 	public val data: String,
 ) : Event
 

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiPrimaryDeviceAttributesEventTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TerminalParserCsiPrimaryDeviceAttributesEventTest.kt
@@ -15,13 +15,25 @@ class TerminalParserCsiPrimaryDeviceAttributesEventTest : BaseTerminalParserTest
 		)
 	}
 
-	@Test fun emptyData() = runTest {
+	@Test fun emptyDataFails() = runTest {
 		writer.writeHex("1b5b3f63")
-		assertThat(reader.next()).isEqualTo(PrimaryDeviceAttributesEvent(data = ""))
+		assertThat(reader.next()).isEqualTo(
+			UnknownEvent("1b5b3f63".hexToByteArray()),
+		)
 	}
 
-	@Test fun data() = runTest {
+	@Test fun idNoData() = runTest {
+		writer.writeHex("1b5b3f3263")
+		assertThat(reader.next()).isEqualTo(PrimaryDeviceAttributesEvent(id = 2, data = ""))
+	}
+
+	@Test fun idWithSemicolonNoData() = runTest {
+		writer.writeHex("1b5b3f323b63")
+		assertThat(reader.next()).isEqualTo(PrimaryDeviceAttributesEvent(id = 2, data = ""))
+	}
+
+	@Test fun idAndData() = runTest {
 		writer.writeHex("1b5b3f323b3263")
-		assertThat(reader.next()).isEqualTo(PrimaryDeviceAttributesEvent(data = "2;2"))
+		assertThat(reader.next()).isEqualTo(PrimaryDeviceAttributesEvent(id = 2, data = "2"))
 	}
 }


### PR DESCRIPTION
I have no idea if this is called an "ID", but the docs omit a name. This is needed to determine during capability querying whether we can issue more complex queries or at the dumbest of dumb terminals (read: Terminal.app on macOS).

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
