### PR TITLE
Inject keys and terminal state into Mosaic

### DIFF
--- a/mosaic-runtime/api/mosaic-runtime.api
+++ b/mosaic-runtime/api/mosaic-runtime.api
@@ -2,16 +2,14 @@ public abstract interface class com/jakewharton/mosaic/Mosaic {
 	public abstract fun awaitComplete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun cancel ()V
 	public abstract fun dump ()Ljava/lang/String;
-	public abstract fun getTerminalState ()Landroidx/compose/runtime/MutableState;
 	public abstract fun paint ()Lcom/jakewharton/mosaic/TextCanvas;
 	public fun paintStatics ()Ljava/util/List;
 	public abstract fun paintStaticsTo (Landroidx/collection/MutableObjectList;)V
-	public abstract fun sendKeyEvent (Lcom/jakewharton/mosaic/layout/KeyEvent;)V
 	public abstract fun setContent (Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class com/jakewharton/mosaic/MosaicKt {
-	public static final fun Mosaic (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lcom/jakewharton/mosaic/Mosaic;
+	public static final fun Mosaic (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;Lkotlinx/coroutines/channels/Channel;Landroidx/compose/runtime/State;)Lcom/jakewharton/mosaic/Mosaic;
 	public static final fun renderMosaic (Lkotlin/jvm/functions/Function2;)Ljava/lang/String;
 	public static final fun runMosaic (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun runMosaicBlocking (Lkotlin/jvm/functions/Function2;)V
@@ -19,11 +17,16 @@ public final class com/jakewharton/mosaic/MosaicKt {
 
 public final class com/jakewharton/mosaic/Terminal {
 	public static final field $stable I
+	public static final field Companion Lcom/jakewharton/mosaic/Terminal$Companion;
 	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getSize-Usd9Mdw ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/jakewharton/mosaic/Terminal$Companion {
+	public final fun getDefault ()Lcom/jakewharton/mosaic/Terminal;
 }
 
 public final class com/jakewharton/mosaic/TerminalKt {

--- a/mosaic-runtime/api/mosaic-runtime.klib.api
+++ b/mosaic-runtime/api/mosaic-runtime.klib.api
@@ -197,14 +197,10 @@ abstract interface com.jakewharton.mosaic.ui/RowScope { // com.jakewharton.mosai
 }
 
 abstract interface com.jakewharton.mosaic/Mosaic { // com.jakewharton.mosaic/Mosaic|null[0]
-    abstract val terminalState // com.jakewharton.mosaic/Mosaic.terminalState|{}terminalState[0]
-        abstract fun <get-terminalState>(): androidx.compose.runtime/MutableState<com.jakewharton.mosaic/Terminal> // com.jakewharton.mosaic/Mosaic.terminalState.<get-terminalState>|<get-terminalState>(){}[0]
-
     abstract fun cancel() // com.jakewharton.mosaic/Mosaic.cancel|cancel(){}[0]
     abstract fun dump(): kotlin/String // com.jakewharton.mosaic/Mosaic.dump|dump(){}[0]
     abstract fun paint(): com.jakewharton.mosaic/TextCanvas // com.jakewharton.mosaic/Mosaic.paint|paint(){}[0]
     abstract fun paintStaticsTo(androidx.collection/MutableObjectList<com.jakewharton.mosaic/TextCanvas>) // com.jakewharton.mosaic/Mosaic.paintStaticsTo|paintStaticsTo(androidx.collection.MutableObjectList<com.jakewharton.mosaic.TextCanvas>){}[0]
-    abstract fun sendKeyEvent(com.jakewharton.mosaic.layout/KeyEvent) // com.jakewharton.mosaic/Mosaic.sendKeyEvent|sendKeyEvent(com.jakewharton.mosaic.layout.KeyEvent){}[0]
     abstract fun setContent(kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>) // com.jakewharton.mosaic/Mosaic.setContent|setContent(kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>){}[0]
     abstract suspend fun awaitComplete() // com.jakewharton.mosaic/Mosaic.awaitComplete|awaitComplete(){}[0]
     open fun paintStatics(): kotlin.collections/List<com.jakewharton.mosaic/TextCanvas> // com.jakewharton.mosaic/Mosaic.paintStatics|paintStatics(){}[0]
@@ -403,6 +399,11 @@ final class com.jakewharton.mosaic/Terminal { // com.jakewharton.mosaic/Terminal
     final fun equals(kotlin/Any?): kotlin/Boolean // com.jakewharton.mosaic/Terminal.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.jakewharton.mosaic/Terminal.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.jakewharton.mosaic/Terminal.toString|toString(){}[0]
+
+    final object Companion { // com.jakewharton.mosaic/Terminal.Companion|null[0]
+        final val Default // com.jakewharton.mosaic/Terminal.Companion.Default|{}Default[0]
+            final fun <get-Default>(): com.jakewharton.mosaic/Terminal // com.jakewharton.mosaic/Terminal.Companion.Default.<get-Default>|<get-Default>(){}[0]
+    }
 }
 
 final value class com.jakewharton.mosaic.ui.unit/Constraints { // com.jakewharton.mosaic.ui.unit/Constraints|null[0]
@@ -803,7 +804,7 @@ final fun com.jakewharton.mosaic.ui/com_jakewharton_mosaic_ui_RowColumnParentDat
 final fun com.jakewharton.mosaic.ui/com_jakewharton_mosaic_ui_RowScopeInstance$stableprop_getter(): kotlin/Int // com.jakewharton.mosaic.ui/com_jakewharton_mosaic_ui_RowScopeInstance$stableprop_getter|com_jakewharton_mosaic_ui_RowScopeInstance$stableprop_getter(){}[0]
 final fun com.jakewharton.mosaic.ui/com_jakewharton_mosaic_ui_StaticState$stableprop_getter(): kotlin/Int // com.jakewharton.mosaic.ui/com_jakewharton_mosaic_ui_StaticState$stableprop_getter|com_jakewharton_mosaic_ui_StaticState$stableprop_getter(){}[0]
 final fun com.jakewharton.mosaic.ui/com_jakewharton_mosaic_ui_VerticalAlignModifier$stableprop_getter(): kotlin/Int // com.jakewharton.mosaic.ui/com_jakewharton_mosaic_ui_VerticalAlignModifier$stableprop_getter|com_jakewharton_mosaic_ui_VerticalAlignModifier$stableprop_getter(){}[0]
-final fun com.jakewharton.mosaic/Mosaic(kotlin.coroutines/CoroutineContext, kotlin/Function1<com.jakewharton.mosaic/Mosaic, kotlin/Unit>): com.jakewharton.mosaic/Mosaic // com.jakewharton.mosaic/Mosaic|Mosaic(kotlin.coroutines.CoroutineContext;kotlin.Function1<com.jakewharton.mosaic.Mosaic,kotlin.Unit>){}[0]
+final fun com.jakewharton.mosaic/Mosaic(kotlin.coroutines/CoroutineContext, kotlin/Function1<com.jakewharton.mosaic/Mosaic, kotlin/Unit>, kotlinx.coroutines.channels/Channel<com.jakewharton.mosaic.layout/KeyEvent>, androidx.compose.runtime/State<com.jakewharton.mosaic/Terminal>): com.jakewharton.mosaic/Mosaic // com.jakewharton.mosaic/Mosaic|Mosaic(kotlin.coroutines.CoroutineContext;kotlin.Function1<com.jakewharton.mosaic.Mosaic,kotlin.Unit>;kotlinx.coroutines.channels.Channel<com.jakewharton.mosaic.layout.KeyEvent>;androidx.compose.runtime.State<com.jakewharton.mosaic.Terminal>){}[0]
 final fun com.jakewharton.mosaic/com_jakewharton_mosaic_AnsiRendering$stableprop_getter(): kotlin/Int // com.jakewharton.mosaic/com_jakewharton_mosaic_AnsiRendering$stableprop_getter|com_jakewharton_mosaic_AnsiRendering$stableprop_getter(){}[0]
 final fun com.jakewharton.mosaic/com_jakewharton_mosaic_DebugRendering$stableprop_getter(): kotlin/Int // com.jakewharton.mosaic/com_jakewharton_mosaic_DebugRendering$stableprop_getter|com_jakewharton_mosaic_DebugRendering$stableprop_getter(){}[0]
 final fun com.jakewharton.mosaic/com_jakewharton_mosaic_GlobalSnapshotManager$stableprop_getter(): kotlin/Int // com.jakewharton.mosaic/com_jakewharton_mosaic_GlobalSnapshotManager$stableprop_getter|com_jakewharton_mosaic_GlobalSnapshotManager$stableprop_getter(){}[0]

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/terminal.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/terminal.kt
@@ -13,4 +13,11 @@ public val LocalTerminal: ProvidableCompositionLocal<Terminal> = compositionLoca
 @[Immutable Poko]
 public class Terminal(
 	public val size: IntSize,
-)
+) {
+	public companion object {
+		public val Default: Terminal = Terminal(
+			// https://en.wikipedia.org/wiki/VT52
+			size = IntSize(width = 80, height = 24),
+		)
+	}
+}

--- a/mosaic-testing/api/mosaic-testing.api
+++ b/mosaic-testing/api/mosaic-testing.api
@@ -12,6 +12,8 @@ public abstract interface class com/jakewharton/mosaic/testing/SnapshotStrategy 
 public abstract interface class com/jakewharton/mosaic/testing/TestMosaic : com/jakewharton/mosaic/Mosaic {
 	public abstract fun awaitSnapshot-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun awaitSnapshot-VtjQ1oo$default (Lcom/jakewharton/mosaic/testing/TestMosaic;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getTerminalState ()Landroidx/compose/runtime/MutableState;
+	public abstract fun sendKeyEvent (Lcom/jakewharton/mosaic/layout/KeyEvent;)V
 	public abstract fun setContentAndSnapshot (Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 }
 

--- a/mosaic-testing/api/mosaic-testing.klib.api
+++ b/mosaic-testing/api/mosaic-testing.klib.api
@@ -11,6 +11,10 @@ abstract fun interface <#A: kotlin/Any?> com.jakewharton.mosaic.testing/Snapshot
 }
 
 abstract interface <#A: kotlin/Any?> com.jakewharton.mosaic.testing/TestMosaic : com.jakewharton.mosaic/Mosaic { // com.jakewharton.mosaic.testing/TestMosaic|null[0]
+    abstract val terminalState // com.jakewharton.mosaic.testing/TestMosaic.terminalState|{}terminalState[0]
+        abstract fun <get-terminalState>(): androidx.compose.runtime/MutableState<com.jakewharton.mosaic/Terminal> // com.jakewharton.mosaic.testing/TestMosaic.terminalState.<get-terminalState>|<get-terminalState>(){}[0]
+
+    abstract fun sendKeyEvent(com.jakewharton.mosaic.layout/KeyEvent) // com.jakewharton.mosaic.testing/TestMosaic.sendKeyEvent|sendKeyEvent(com.jakewharton.mosaic.layout.KeyEvent){}[0]
     abstract fun setContentAndSnapshot(kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>): #A // com.jakewharton.mosaic.testing/TestMosaic.setContentAndSnapshot|setContentAndSnapshot(kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>){}[0]
     abstract suspend fun awaitSnapshot(kotlin.time/Duration = ...): #A // com.jakewharton.mosaic.testing/TestMosaic.awaitSnapshot|awaitSnapshot(kotlin.time.Duration){}[0]
 }


### PR DESCRIPTION
This makes #579 easier. It was also weird that a "production" `Mosaic` could have keys sent or terminal state mutated. Now it's properly encapsulated and only mutable in the test harness.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
