### PR TITLE
Drop Jansi, use Mordant for output

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,6 @@ ktlint-composeRules = "io.nlopez.compose.rules:ktlint:0.4.22"
 mordant-core = { module = "com.github.ajalt.mordant:mordant-core", version.ref = "mordant" }
 mordant-jvmJna = { module = "com.github.ajalt.mordant:mordant-jvm-jna", version.ref = "mordant" }
 
-jansi = "org.fusesource.jansi:jansi:2.4.1"
 clikt = "com.github.ajalt.clikt:clikt:5.0.3"
 codepoints = "de.cketti.unicode:kotlin-codepoints:0.9.0"
 finalizationHook = "com.jakewharton.finalization:finalization-hook:0.1.0"

--- a/mosaic-runtime/build.gradle
+++ b/mosaic-runtime/build.gradle
@@ -35,7 +35,6 @@ kotlin {
 
 		jvmMain {
 			dependencies {
-				implementation libs.jansi
 				implementation libs.mordant.jvmJna
 			}
 		}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -81,11 +81,11 @@ internal suspend fun runMosaic(enterRawMode: Boolean, content: @Composable () ->
 		null
 	}
 
-	platformDisplay(cursorHide)
+	mordantTerminal.rawPrint(cursorHide)
 
 	withFinalizationHook(
 		hook = {
-			platformDisplay(cursorShow)
+			mordantTerminal.rawPrint(cursorShow)
 			rawMode?.close()
 		},
 		block = {
@@ -96,7 +96,7 @@ internal suspend fun runMosaic(enterRawMode: Boolean, content: @Composable () ->
 			val mosaicComposition = MosaicComposition(
 				coroutineContext = coroutineContext + clock,
 				onDraw = { rootNode ->
-					platformDisplay(rendering.render(rootNode))
+					mordantTerminal.rawPrint(rendering.render(rootNode).toString())
 				},
 				keyEvents = keyEvents,
 				terminalState = terminalState,

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/platform.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/platform.kt
@@ -2,8 +2,6 @@ package com.jakewharton.mosaic
 
 internal expect fun env(name: String): String?
 
-internal expect fun platformDisplay(chars: CharSequence)
-
 internal expect class AtomicBoolean
 
 internal expect inline fun AtomicBoolean.set(value: Boolean)

--- a/mosaic-runtime/src/jvmMain/kotlin/com/jakewharton/mosaic/platform.kt
+++ b/mosaic-runtime/src/jvmMain/kotlin/com/jakewharton/mosaic/platform.kt
@@ -1,28 +1,7 @@
 package com.jakewharton.mosaic
 
-import java.nio.CharBuffer
-import java.nio.charset.StandardCharsets.UTF_8
-import org.fusesource.jansi.AnsiConsole
-
 internal actual fun env(name: String): String? {
 	return System.getenv(name)
-}
-
-private val out = AnsiConsole.out()!!.also { AnsiConsole.systemInstall() }
-private val encoder = UTF_8.newEncoder()!!
-
-internal actual fun platformDisplay(chars: CharSequence) {
-	// Write a single byte array to stdout to create an atomic visual change. If you instead write
-	// the string, it will be UTF-8 encoded using an intermediate buffer that appears to be
-	// periodically flushed to the underlying byte stream. This will cause fraction-of-a-second
-	// flickers of broken content. Note that this only occurs with the AnsiConsole stream, but
-	// there's no harm in doing it unconditionally.
-	val bytes = encoder.encode(CharBuffer.wrap(chars))
-	out.write(bytes.array(), 0, bytes.limit())
-
-	// Explicitly flush to ensure the trailing line clear is sent. Empirically, this appears to be
-	// buffered and not processed until the next frame, or not at all on the final frame.
-	out.flush()
 }
 
 internal actual typealias AtomicBoolean = java.util.concurrent.atomic.AtomicBoolean

--- a/mosaic-runtime/src/nativeMain/kotlin/com/jakewharton/mosaic/platform.kt
+++ b/mosaic-runtime/src/nativeMain/kotlin/com/jakewharton/mosaic/platform.kt
@@ -8,10 +8,6 @@ internal actual fun env(name: String): String? {
 	return getenv(name)?.toKString()
 }
 
-internal actual fun platformDisplay(chars: CharSequence) {
-	print(chars.toString())
-}
-
 internal actual typealias AtomicBoolean = AtomicInt
 
 @Suppress("NOTHING_TO_INLINE")


### PR DESCRIPTION
![Screenshot 2025-02-14 at 10 20 32 AM](https://github.com/user-attachments/assets/b58ca492-3ba3-47d5-8d65-9742083caf7f)

Closes #471 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
