### PR TITLE
Remove unused kotlinx.io dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,8 +13,6 @@ kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
-kotlinx-io = "org.jetbrains.kotlinx:kotlinx-io-core:0.6.0"
-
 compose-collection = { module = "org.jetbrains.compose.collection-internal:collection", version.ref = "compose" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
 

--- a/mosaic-terminal/build.gradle
+++ b/mosaic-terminal/build.gradle
@@ -62,7 +62,6 @@ kotlin {
 			dependencies {
 				implementation libs.kotlin.test
 				implementation libs.kotlinx.coroutines.test
-				implementation libs.kotlinx.io
 				implementation libs.assertk
 			}
 		}


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
