### PR TITLE
Clear line before rendering to avoid deleting final character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changed:
 - Only disable the cursor and emit synchronized rendering markers if the terminal reports support for those features.
 
 Fixed:
-- Nothing yet!
+- Prevent final character from being erased when a row writes into the last column of the terminal.
 
 
 ## [0.16.0] - 2025-02-14

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ansi.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/ansi.kt
@@ -33,7 +33,7 @@ internal const val inBandResizeDisable = "$CSI?${inBandResizeMode}l"
 
 internal const val ansiReset = "${CSI}0"
 internal const val clearLine = "${CSI}K"
-internal const val cursorUp = "${CSI}F"
+internal const val clearDisplay = "${CSI}J"
 
 internal const val ansiSeparator = ";"
 internal const val ansiClosingCharacter = "m"

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
@@ -103,7 +103,7 @@ class AnsiRenderingTest {
 				"""
 				|${cursorUp(4)}${clearLine}Hello$s
 				|${clearLine}World!
-				|${clearDisplay}
+				|$clearDisplay
 				""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
 			)
 		}

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
@@ -61,8 +61,8 @@ class AnsiRenderingTest {
 
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|$cursorUp${cursorUp}Hel$clearLine
-				|lo $clearLine
+				|${cursorUp(2)}${clearLine}Hel
+				|${clearLine}lo$s
 				|Wor
 				|ld!
 				|
@@ -101,10 +101,9 @@ class AnsiRenderingTest {
 
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|$cursorUp$cursorUp$cursorUp${cursorUp}Hello $clearLine
-				|World!$clearLine
-				|$clearLine
-				|$clearLine$cursorUp
+				|${cursorUp(4)}${clearLine}Hello$s
+				|${clearLine}World!
+				|${clearDisplay}
 				""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
 			)
 		}
@@ -155,7 +154,7 @@ class AnsiRenderingTest {
 
 			assertThat(awaitSnapshot()).isEqualTo(
 				"""
-				|${cursorUp}Three$clearLine
+				|${cursorUp(1)}${clearLine}Three
 				|Four
 				|
 				""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/stuff.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/stuff.kt
@@ -36,6 +36,8 @@ fun String.wrapWithAnsiSynchronizedUpdate(): String {
 	return "$synchronizedRenderingEnable$this$synchronizedRenderingDisable"
 }
 
+fun cursorUp(lines: Int): String = "${CSI}${lines}F"
+
 internal val MosaicNode.size: IntSize
 	get() = IntSize(width, height)
 


### PR DESCRIPTION
When a row writes into the last column, the cursor stays in that position. Clearing the remaining line from that position has the potential to delete the final character. Instead, clear the line before rendering it. This may cause partial row flickering for terminals which do not support synchronized rendering, but that's an okay trade-off.

Additionally, use more efficient ANSI to move the cursor up and to clear the remaining lines.

Closes #705 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
