### PR TITLE
Do not emit ANSI reset when level is none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changed:
 
 Fixed:
 - Prevent final character from being erased when a row writes into the last column of the terminal.
+- Do not emit ANSI style reset escape sequence when colors are disabled (such as in testing).
 
 
 ## [0.16.0] - 2025-02-14

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/surface.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/surface.kt
@@ -108,9 +108,13 @@ internal class TextSurface(
 			lastPixel = pixel
 		}
 
-		if (lastPixel.background.isSpecifiedColor ||
-			lastPixel.foreground.isSpecifiedColor ||
-			lastPixel.textStyle.isNotEmptyTextStyle
+		if (
+			ansiLevel != AnsiLevel.NONE &&
+			(
+				lastPixel.background.isSpecifiedColor ||
+					lastPixel.foreground.isSpecifiedColor ||
+					lastPixel.textStyle.isNotEmptyTextStyle
+				)
 		) {
 			appendable.append(ansiReset)
 			appendable.append(ansiClosingCharacter)

--- a/mosaic-testing/src/commonTest/kotlin/com/jakewharton/mosaic/testing/TestMosaicTest.kt
+++ b/mosaic-testing/src/commonTest/kotlin/com/jakewharton/mosaic/testing/TestMosaicTest.kt
@@ -6,7 +6,12 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import com.jakewharton.mosaic.text.SpanStyle
+import com.jakewharton.mosaic.text.buildAnnotatedString
+import com.jakewharton.mosaic.text.withStyle
+import com.jakewharton.mosaic.ui.Color
 import com.jakewharton.mosaic.ui.Text
+import com.jakewharton.mosaic.ui.TextStyle.Companion.Underline
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
@@ -45,6 +50,32 @@ class TestMosaicTest {
 			delay(10.milliseconds)
 
 			assertThat(awaitSnapshot()).isEqualTo("The number is: 1")
+		}
+	}
+
+	@Test fun noAnsiEscapesByDefault() = runTest {
+		runMosaicTest {
+			val one = setContentAndSnapshot {
+				Text(
+					buildAnnotatedString {
+						withStyle(
+							SpanStyle(
+								textStyle = Underline,
+								color = Color.Red,
+								background = Color.Green,
+							),
+						) {
+							append("hello")
+						}
+					},
+				)
+			}
+			assertThat(one).isEqualTo("hello")
+
+			val two = setContentAndSnapshot {
+				Text("world")
+			}
+			assertThat(two).isEqualTo("world")
 		}
 	}
 }


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
