### PR TITLE
Eliminate `platformError` type

### DIFF
--- a/mosaic-terminal/src/commonMain/c/mosaic-stdin-posix.c
+++ b/mosaic-terminal/src/commonMain/c/mosaic-stdin-posix.c
@@ -124,7 +124,7 @@ stdinRead platformInput_readWithTimeout(
 	return platformInput_readInternal(input, buffer, count, &timeout);
 }
 
-platformError platformInput_interrupt(platformInput *input) {
+uint32_t platformInput_interrupt(platformInput *input) {
 	int pipeOut = input->pipe[1];
 	int result = write(pipeOut, " ", 1);
 	return unlikely(result == -1)
@@ -144,8 +144,8 @@ void sigwinchHandler(int value UNUSED) {
 	// TODO Send errno somewhere? Maybe once we get debug logs working.
 }
 
-platformError platformInput_enableRawMode(platformInput *input) {
-	platformError result = 0;
+uint32_t platformInput_enableRawMode(platformInput *input) {
+	uint32_t result = 0;
 
 	if (unlikely(!input->saved)) {
 		goto ret; // Already enabled!
@@ -192,7 +192,7 @@ platformError platformInput_enableRawMode(platformInput *input) {
 	goto ret;
 }
 
-platformError platformInput_enableWindowResizeEvents(platformInput *input) {
+uint32_t platformInput_enableWindowResizeEvents(platformInput *input) {
 	if (input->sigwinch) {
 		return 0; // Already installed.
 	}
@@ -227,7 +227,7 @@ terminalSizeResult platformInput_currentTerminalSize(platformInput *input) {
 	return result;
 }
 
-platformError platformInput_free(platformInput *input) {
+uint32_t platformInput_free(platformInput *input) {
 	int *pipe = input->pipe;
 
 	int result = 0;
@@ -285,7 +285,7 @@ platformInput *platformInputWriter_getPlatformInput(platformInputWriter *writer)
 	return writer->input;
 }
 
-platformError platformInputWriter_write(platformInputWriter *writer, char *buffer, int count) {
+uint32_t platformInputWriter_write(platformInputWriter *writer, char *buffer, int count) {
 	int pipeOut = writer->pipe[1];
 	while (count > 0) {
 		int result = write(pipeOut, buffer, count);
@@ -300,28 +300,28 @@ platformError platformInputWriter_write(platformInputWriter *writer, char *buffe
 	return errno;
 }
 
-platformError platformInputWriter_focusEvent(platformInputWriter *writer UNUSED, bool focused UNUSED) {
+uint32_t platformInputWriter_focusEvent(platformInputWriter *writer UNUSED, bool focused UNUSED) {
 	// Focus events are delivered through VT sequences.
 	return 0;
 }
 
-platformError platformInputWriter_keyEvent(platformInputWriter *writer UNUSED) {
+uint32_t platformInputWriter_keyEvent(platformInputWriter *writer UNUSED) {
 	// Key events are delivered through VT sequences.
 	return 0;
 }
 
-platformError platformInputWriter_mouseEvent(platformInputWriter *writer UNUSED) {
+uint32_t platformInputWriter_mouseEvent(platformInputWriter *writer UNUSED) {
 	// Mouse events are delivered through VT sequences.
 	return 0;
 }
 
-platformError platformInputWriter_resizeEvent(platformInputWriter *writer, int columns, int rows, int width, int height) {
+uint32_t platformInputWriter_resizeEvent(platformInputWriter *writer, int columns, int rows, int width, int height) {
 	platformEventHandler *handler = writer->input->handler;
 	handler->onResize(handler->opaque, columns, rows, width, height);
 	return 0;
 }
 
-platformError platformInputWriter_free(platformInputWriter *writer) {
+uint32_t platformInputWriter_free(platformInputWriter *writer) {
 	int *pipe = writer->pipe;
 
 	int result = 0;

--- a/mosaic-terminal/src/commonMain/c/mosaic-stdin-windows.c
+++ b/mosaic-terminal/src/commonMain/c/mosaic-stdin-windows.c
@@ -144,14 +144,14 @@ stdinRead platformInput_readWithTimeout(
 	goto ret;
 }
 
-platformError platformInput_interrupt(platformInput *input) {
+uint32_t platformInput_interrupt(platformInput *input) {
 	return likely(SetEvent(input->waitHandles[1]) != 0)
 		? 0
 		: GetLastError();
 }
 
-platformError platformInput_enableRawMode(platformInput *input) {
-	platformError result = 0;
+uint32_t platformInput_enableRawMode(platformInput *input) {
+	uint32_t result = 0;
 
 	if (input->saved_input_mode) {
 		goto ret; // Already enabled!
@@ -221,7 +221,7 @@ platformError platformInput_enableRawMode(platformInput *input) {
 	return result;
 }
 
-platformError platformInput_enableWindowResizeEvents(platformInput *input) {
+uint32_t platformInput_enableWindowResizeEvents(platformInput *input) {
 	input->windowResizeEvents = true;
 	return 0;
 }
@@ -240,8 +240,8 @@ terminalSizeResult platformInput_currentTerminalSize(platformInput *input) {
 	return result;
 }
 
-platformError platformInput_free(platformInput *input) {
-	platformError result = 0;
+uint32_t platformInput_free(platformInput *input) {
+	uint32_t result = 0;
 
 	if (unlikely(CloseHandle(input->waitHandles[1]) == 0)) {
 		result = GetLastError();
@@ -316,8 +316,8 @@ platformInput *platformInputWriter_getPlatformInput(platformInputWriter *writer)
 	return writer->input;
 }
 
-platformError platformInputWriter_write(platformInputWriter *writer UNUSED, char *buffer, int count) {
-	DWORD result = 0;
+uint32_t platformInputWriter_write(platformInputWriter *writer UNUSED, char *buffer, int count) {
+	uint32_t result = 0;
 	INPUT_RECORD *records = calloc(count, sizeof(INPUT_RECORD));
 	if (!records) {
 		result = ERROR_NOT_ENOUGH_MEMORY;
@@ -348,7 +348,7 @@ platformError platformInputWriter_write(platformInputWriter *writer UNUSED, char
 	goto ret;
 }
 
-platformError writeRecord(INPUT_RECORD *record) {
+uint32_t writeRecord(INPUT_RECORD *record) {
 	DWORD written;
 	if (likely(WriteConsoleInputW(writerConin, record, 1, &written))) {
 		if (likely(written == 1)) {
@@ -359,24 +359,24 @@ platformError writeRecord(INPUT_RECORD *record) {
 	return GetLastError();
 }
 
-platformError platformInputWriter_focusEvent(platformInputWriter *writer UNUSED, bool focused) {
+uint32_t platformInputWriter_focusEvent(platformInputWriter *writer UNUSED, bool focused) {
 	INPUT_RECORD record;
 	record.EventType = FOCUS_EVENT;
 	record.Event.FocusEvent.bSetFocus = focused;
 	return writeRecord(&record);
 }
 
-platformError platformInputWriter_keyEvent(platformInputWriter *writer UNUSED) {
+uint32_t platformInputWriter_keyEvent(platformInputWriter *writer UNUSED) {
 	// TODO
 	return 0;
 }
 
-platformError platformInputWriter_mouseEvent(platformInputWriter *writer UNUSED) {
+uint32_t platformInputWriter_mouseEvent(platformInputWriter *writer UNUSED) {
 	// TODO
 	return 0;
 }
 
-platformError platformInputWriter_resizeEvent(platformInputWriter *writer UNUSED, int columns, int rows, int width UNUSED, int height UNUSED) {
+uint32_t platformInputWriter_resizeEvent(platformInputWriter *writer UNUSED, int columns, int rows, int width UNUSED, int height UNUSED) {
 	INPUT_RECORD record;
 	record.EventType = WINDOW_BUFFER_SIZE_EVENT;
 	record.Event.WindowBufferSizeEvent.dwSize.X = columns;
@@ -384,7 +384,7 @@ platformError platformInputWriter_resizeEvent(platformInputWriter *writer UNUSED
 	return writeRecord(&record);
 }
 
-platformError platformInputWriter_free(platformInputWriter *writer) {
+uint32_t platformInputWriter_free(platformInputWriter *writer) {
 	free(writer);
 	return 0;
 }

--- a/mosaic-terminal/src/commonMain/c/mosaic.h
+++ b/mosaic-terminal/src/commonMain/c/mosaic.h
@@ -2,18 +2,7 @@
 #define MOSAIC_H
 
 #include <stdbool.h>
-
-#if defined(__APPLE__) || defined(__linux__)
-
-typedef unsigned int platformError;
-
-#elif defined(_WIN32)
-
-#include <windows.h>
-
-typedef DWORD platformError;
-
-#endif
+#include <stdint.h>
 
 typedef void PlatformEventHandlerOnFocus(void *opaque, bool focused);
 typedef void PlatformEventHandlerOnKey(void *opaque); // TODO params
@@ -34,17 +23,17 @@ typedef struct platformInputWriterImpl platformInputWriter;
 
 typedef struct platformInputResult {
 	platformInput *input;
-	platformError error;
+	uint32_t error;
 } platformInputResult;
 
 typedef struct platformInputWriterResult {
 	platformInputWriter *writer;
-	platformError error;
+	uint32_t error;
 } platformInputWriterResult;
 
 typedef struct stdinRead {
 	int count;
-	platformError error;
+	uint32_t error;
 } stdinRead;
 
 typedef struct terminalSize {
@@ -56,25 +45,25 @@ typedef struct terminalSize {
 
 typedef struct terminalSizeResult {
 	terminalSize size;
-	platformError error;
+	uint32_t error;
 } terminalSizeResult;
 
 platformInputResult platformInput_init(platformEventHandler *handler);
 stdinRead platformInput_read(platformInput *input, char *buffer, int count);
 stdinRead platformInput_readWithTimeout(platformInput *input, char *buffer, int count, int timeoutMillis);
-platformError platformInput_interrupt(platformInput *input);
-platformError platformInput_enableRawMode(platformInput *input);
-platformError platformInput_enableWindowResizeEvents(platformInput *input);
+uint32_t platformInput_interrupt(platformInput *input);
+uint32_t platformInput_enableRawMode(platformInput *input);
+uint32_t platformInput_enableWindowResizeEvents(platformInput *input);
 terminalSizeResult platformInput_currentTerminalSize(platformInput *input);
-platformError platformInput_free(platformInput *input);
+uint32_t platformInput_free(platformInput *input);
 
 platformInputWriterResult platformInputWriter_init(platformEventHandler *handler);
 platformInput *platformInputWriter_getPlatformInput(platformInputWriter *writer);
-platformError platformInputWriter_write(platformInputWriter *writer, char *buffer, int count);
-platformError platformInputWriter_focusEvent(platformInputWriter *writer, bool focused);
-platformError platformInputWriter_keyEvent(platformInputWriter *writer);
-platformError platformInputWriter_mouseEvent(platformInputWriter *writer);
-platformError platformInputWriter_resizeEvent(platformInputWriter *writer, int columns, int rows, int width, int height);
-platformError platformInputWriter_free(platformInputWriter *writer);
+uint32_t platformInputWriter_write(platformInputWriter *writer, char *buffer, int count);
+uint32_t platformInputWriter_focusEvent(platformInputWriter *writer, bool focused);
+uint32_t platformInputWriter_keyEvent(platformInputWriter *writer);
+uint32_t platformInputWriter_mouseEvent(platformInputWriter *writer);
+uint32_t platformInputWriter_resizeEvent(platformInputWriter *writer, int columns, int rows, int width, int height);
+uint32_t platformInputWriter_free(platformInputWriter *writer);
 
 #endif // MOSAIC_H

--- a/mosaic-terminal/src/jvmMain/c/mosaic-jni.c
+++ b/mosaic-terminal/src/jvmMain/c/mosaic-jni.c
@@ -234,7 +234,7 @@ Java_com_jakewharton_mosaic_terminal_Jni_platformInputInterrupt(
 	jlong inputOpaque
 ) {
 	platformInput *input = (platformInput *) inputOpaque;
-	platformError error = platformInput_interrupt(input);
+	uint32_t error = platformInput_interrupt(input);
 	if (unlikely(error)) {
 		throwIse(env, error, "Unable to interrupt");
 	}
@@ -247,7 +247,7 @@ Java_com_jakewharton_mosaic_terminal_Jni_platformInputEnableRawMode(
 	jlong inputOpaque
 ) {
 	platformInput *input = (platformInput *) inputOpaque;
-	platformError error = platformInput_enableRawMode(input);
+	uint32_t error = platformInput_enableRawMode(input);
 	if (unlikely(error)) {
 		throwIse(env, error, "Unable to enable raw mode");
 	}
@@ -260,7 +260,7 @@ Java_com_jakewharton_mosaic_terminal_Jni_platformInputEnableWindowResizeEvents(
 	jlong inputOpaque
 ) {
 	platformInput *input = (platformInput *) inputOpaque;
-	platformError error = platformInput_enableWindowResizeEvents(input);
+	uint32_t error = platformInput_enableWindowResizeEvents(input);
 	if (unlikely(error)) {
 		throwIse(env, error, "Unable to enable window resize events");
 	}
@@ -295,7 +295,7 @@ Java_com_jakewharton_mosaic_terminal_Jni_platformInputFree(
 	jlong inputOpaque
 ) {
 	platformInput *input = (platformInput *) inputOpaque;
-	platformError error = platformInput_free(input);
+	uint32_t error = platformInput_free(input);
 	if (unlikely(error)) {
 		throwIse(env, error, "Unable to free");
 	}
@@ -330,7 +330,7 @@ Java_com_jakewharton_mosaic_terminal_Jni_platformInputWriterWrite(
 	jbyte *nativeBuffer = (*env)->GetByteArrayElements(env, buffer, NULL);
 
 	platformInputWriter *writer = (platformInputWriter *) writerOpaque;
-	platformError error = platformInputWriter_write(writer, nativeBuffer, count);
+	uint32_t error = platformInputWriter_write(writer, nativeBuffer, count);
 
 	(*env)->ReleaseByteArrayElements(env, buffer, nativeBuffer, 0);
 
@@ -402,7 +402,7 @@ Java_com_jakewharton_mosaic_terminal_Jni_platformInputWriterFree(
 	jlong writerOpaque
 ) {
 	platformInputWriter *writer = (platformInputWriter *) writerOpaque;
-	platformError error = platformInputWriter_free(writer);
+	uint32_t error = platformInputWriter_free(writer);
 	if (unlikely(error)) {
 		throwIse(env, error, "Unable to free stdin writer");
 	}


### PR DESCRIPTION
Just use a `uint32_t` directly.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
