### PR TITLE
Do not reference event from platform input type

### DIFF
--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/PlatformInput.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/PlatformInput.kt
@@ -1,7 +1,5 @@
 package com.jakewharton.mosaic.terminal
 
-import com.jakewharton.mosaic.terminal.event.ResizeEvent
-
 internal expect class PlatformInput : AutoCloseable {
 	/**
 	 * Read up to [count] bytes into [buffer] at [offset]. The number of bytes read will be returned.
@@ -31,7 +29,8 @@ internal expect class PlatformInput : AutoCloseable {
 
 	fun enableWindowResizeEvents()
 
-	fun currentSize(): ResizeEvent
+	/** @return Array of `[columns, rows, width, height]` */
+	fun currentSize(): IntArray
 
 	/**
 	 * Free the resources associated with this reader.

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalReader.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalReader.kt
@@ -121,7 +121,13 @@ public class TerminalReader internal constructor(
 
 	/** Synchronously query for the current terminal size. */
 	public fun currentSize(): ResizeEvent {
-		return platformInput.currentSize()
+		val (columns, rows, width, height) = platformInput.currentSize()
+		return ResizeEvent(
+			columns = columns,
+			rows = rows,
+			width = width,
+			height = height,
+		)
 	}
 
 	/**

--- a/mosaic-terminal/src/jvmMain/kotlin/com/jakewharton/mosaic/terminal/PlatformInput.kt
+++ b/mosaic-terminal/src/jvmMain/kotlin/com/jakewharton/mosaic/terminal/PlatformInput.kt
@@ -1,7 +1,5 @@
 package com.jakewharton.mosaic.terminal
 
-import com.jakewharton.mosaic.terminal.event.ResizeEvent
-
 // TODO @JvmSynthetic https://youtrack.jetbrains.com/issue/KT-24981
 internal actual class PlatformInput(
 	private var inputPtr: Long,
@@ -27,14 +25,8 @@ internal actual class PlatformInput(
 		Jni.platformInputEnableWindowResizeEvents(inputPtr)
 	}
 
-	actual fun currentSize(): ResizeEvent {
-		val (columns, rows, width, height) = Jni.platformInputCurrentSize(inputPtr)
-		return ResizeEvent(
-			columns = columns,
-			rows = rows,
-			width = width,
-			height = height,
-		)
+	actual fun currentSize(): IntArray {
+		return Jni.platformInputCurrentSize(inputPtr)
 	}
 
 	actual override fun close() {

--- a/mosaic-terminal/src/nativeMain/kotlin/com/jakewharton/mosaic/terminal/PlatformInput.kt
+++ b/mosaic-terminal/src/nativeMain/kotlin/com/jakewharton/mosaic/terminal/PlatformInput.kt
@@ -1,6 +1,5 @@
 package com.jakewharton.mosaic.terminal
 
-import com.jakewharton.mosaic.terminal.event.ResizeEvent
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.NativePlacement
@@ -57,15 +56,10 @@ internal actual class PlatformInput internal constructor(
 		Tty.throwError(error)
 	}
 
-	actual fun currentSize(): ResizeEvent {
+	actual fun currentSize(): IntArray {
 		platformInput_currentTerminalSize(ptr).useContents {
 			if (error == 0U) {
-				return ResizeEvent(
-					columns = columns,
-					rows = rows,
-					width = width,
-					height = height,
-				)
+				return intArrayOf(columns, rows, width, height)
 			}
 			Tty.throwError(error)
 		}


### PR DESCRIPTION
Only the reader should know about events.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
