### PR TITLE
Decouple test `TerminalReader` from `TestTty`

### DIFF
--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/BaseTerminalParserTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/BaseTerminalParserTest.kt
@@ -11,8 +11,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 
 abstract class BaseTerminalParserTest {
-	internal val testTty = TestTty()
-	internal val reader = testTty.terminalReader()
+	private val testTerminalReader = TestTerminalReader()
+	internal val testTty = testTerminalReader.testTty
+	internal val reader = testTerminalReader.terminalReader
 	private val runLoop = GlobalScope.launch(Dispatchers.IO) {
 		reader.runParseLoop()
 	}

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TestTerminalReader.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TestTerminalReader.kt
@@ -1,0 +1,18 @@
+package com.jakewharton.mosaic.terminal
+
+import com.jakewharton.mosaic.terminal.event.Event
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+
+internal fun TestTerminalReader(): TestTerminalReader {
+	val events = Channel<Event>(UNLIMITED)
+	val platformEventHandler = PlatformEventHandler(events, emitDebugEvents = false)
+	val testTty = TestTty.create(platformEventHandler)
+	val reader = TerminalReader(testTty.tty, events, emitDebugEvents = false)
+	return TestTerminalReader(testTty, reader)
+}
+
+internal class TestTerminalReader(
+	val testTty: TestTty,
+	val terminalReader: TerminalReader,
+)

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TestTty.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TestTty.kt
@@ -1,11 +1,11 @@
 package com.jakewharton.mosaic.terminal
 
-internal expect fun TestTty(): TestTty
-
 internal expect class TestTty : AutoCloseable {
-	val tty: Tty
+	companion object {
+		fun create(callback: Tty.Callback): TestTty
+	}
 
-	fun terminalReader(emitDebugEvents: Boolean = false): TerminalReader
+	val tty: Tty
 
 	// TODO Take ByteString once it migrates to stdlib,
 	//  or if Sink/RawSink migrates expose that as a val.

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TtyTest.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TtyTest.kt
@@ -14,7 +14,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class TtyTest {
-	private val testTty = TestTty()
+	private val testTty = TestTty.create(object : Tty.Callback {
+		override fun onFocus(focused: Boolean) {}
+		override fun onKey() {}
+		override fun onMouse() {}
+		override fun onResize(columns: Int, rows: Int, width: Int, height: Int) {}
+	})
 	private val tty = testTty.tty
 
 	@AfterTest fun after() {


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
