### PR TITLE
Add TTY functions to write stdout and stderr

### DIFF
--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalReader.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalReader.kt
@@ -192,7 +192,7 @@ public class TerminalReader internal constructor(
 			if (kittyDisambiguateEscapeCodes || limit != 1 || buffer[0] != 0x1B.toByte()) {
 				// Common case: we are using the Kitty keyboard protocol to disambiguate escape keys, or
 				// the buffer contains anything other than a bare escape. Do a normal read for more data.
-				val read = tty.read(buffer, limit, BufferSize - limit)
+				val read = tty.readInput(buffer, limit, BufferSize - limit)
 				if (read == -1) break // EOF
 				if (read == 0) return // Interrupt
 
@@ -203,7 +203,7 @@ public class TerminalReader internal constructor(
 			// Otherwise, perform a quick read to see if we have any more bytes. This will allow us to
 			// determine whether the bare escape was truly a legacy keyboard escape event, or just the
 			// start of some other escape sequence.
-			val read = tty.readWithTimeout(
+			val read = tty.readInputWithTimeout(
 				buffer,
 				1,
 				BufferSize - 1,
@@ -955,7 +955,7 @@ public class TerminalReader internal constructor(
 	}
 
 	public fun interrupt() {
-		tty.interrupt()
+		tty.interruptRead()
 	}
 
 	/**

--- a/mosaic-tty/api/mosaic-tty.api
+++ b/mosaic-tty/api/mosaic-tty.api
@@ -22,9 +22,11 @@ public final class com/jakewharton/mosaic/tty/Tty : java/lang/AutoCloseable {
 	public final fun currentSize ()[I
 	public final fun enableRawMode ()V
 	public final fun enableWindowResizeEvents ()V
-	public final fun interrupt ()V
-	public final fun read ([BII)I
-	public final fun readWithTimeout ([BIII)I
+	public final fun interruptRead ()V
+	public final fun readInput ([BII)I
+	public final fun readInputWithTimeout ([BIII)I
+	public final fun writeError ([BII)I
+	public final fun writeOutput ([BII)I
 }
 
 public abstract interface class com/jakewharton/mosaic/tty/Tty$Callback {

--- a/mosaic-tty/api/mosaic-tty.klib.api
+++ b/mosaic-tty/api/mosaic-tty.klib.api
@@ -7,8 +7,6 @@
 
 // Library unique name: <com.jakewharton.mosaic:mosaic-tty>
 final class com.jakewharton.mosaic.tty/TestTty : kotlin/AutoCloseable { // com.jakewharton.mosaic.tty/TestTty|null[0]
-    constructor <init>(kotlinx.cinterop/CPointer<cnames.structs/MosaicTestTtyImpl>?, com.jakewharton.mosaic.tty/Tty) // com.jakewharton.mosaic.tty/TestTty.<init>|<init>(kotlinx.cinterop.CPointer<cnames.structs.MosaicTestTtyImpl>?;com.jakewharton.mosaic.tty.Tty){}[0]
-
     final val tty // com.jakewharton.mosaic.tty/TestTty.tty|{}tty[0]
         final fun <get-tty>(): com.jakewharton.mosaic.tty/Tty // com.jakewharton.mosaic.tty/TestTty.tty.<get-tty>|<get-tty>(){}[0]
 
@@ -25,15 +23,15 @@ final class com.jakewharton.mosaic.tty/TestTty : kotlin/AutoCloseable { // com.j
 }
 
 final class com.jakewharton.mosaic.tty/Tty : kotlin/AutoCloseable { // com.jakewharton.mosaic.tty/Tty|null[0]
-    constructor <init>(kotlinx.cinterop/CPointer<cnames.structs/MosaicTtyImpl>, kotlinx.cinterop/CPointer<com.jakewharton.mosaic.tty/MosaicTtyCallback>, kotlinx.cinterop/StableRef<com.jakewharton.mosaic.tty/Tty.Callback>) // com.jakewharton.mosaic.tty/Tty.<init>|<init>(kotlinx.cinterop.CPointer<cnames.structs.MosaicTtyImpl>;kotlinx.cinterop.CPointer<com.jakewharton.mosaic.tty.MosaicTtyCallback>;kotlinx.cinterop.StableRef<com.jakewharton.mosaic.tty.Tty.Callback>){}[0]
-
     final fun close() // com.jakewharton.mosaic.tty/Tty.close|close(){}[0]
     final fun currentSize(): kotlin/IntArray // com.jakewharton.mosaic.tty/Tty.currentSize|currentSize(){}[0]
     final fun enableRawMode() // com.jakewharton.mosaic.tty/Tty.enableRawMode|enableRawMode(){}[0]
     final fun enableWindowResizeEvents() // com.jakewharton.mosaic.tty/Tty.enableWindowResizeEvents|enableWindowResizeEvents(){}[0]
-    final fun interrupt() // com.jakewharton.mosaic.tty/Tty.interrupt|interrupt(){}[0]
-    final fun read(kotlin/ByteArray, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/Tty.read|read(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
-    final fun readWithTimeout(kotlin/ByteArray, kotlin/Int, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/Tty.readWithTimeout|readWithTimeout(kotlin.ByteArray;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+    final fun interruptRead() // com.jakewharton.mosaic.tty/Tty.interruptRead|interruptRead(){}[0]
+    final fun readInput(kotlin/ByteArray, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/Tty.readInput|readInput(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
+    final fun readInputWithTimeout(kotlin/ByteArray, kotlin/Int, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/Tty.readInputWithTimeout|readInputWithTimeout(kotlin.ByteArray;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+    final fun writeError(kotlin/ByteArray, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/Tty.writeError|writeError(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
+    final fun writeOutput(kotlin/ByteArray, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/Tty.writeOutput|writeOutput(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
 
     abstract interface Callback { // com.jakewharton.mosaic.tty/Tty.Callback|null[0]
         abstract fun onFocus(kotlin/Boolean) // com.jakewharton.mosaic.tty/Tty.Callback.onFocus|onFocus(kotlin.Boolean){}[0]

--- a/mosaic-tty/src/commonMain/c/mosaic-test-tty-windows.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-test-tty-windows.c
@@ -42,7 +42,10 @@ MosaicTestTtyInitResult testTty_init(MosaicTtyCallback *callback) {
 	// Ensure we don't start with existing records in the buffer.
 	FlushConsoleInputBuffer(writerConin);
 
-	MosaicTtyInitResult ttyInitResult = tty_initWithHandle(writerConin, callback);
+	HANDLE stdout = GetStdHandle(STD_OUTPUT_HANDLE);
+	HANDLE stderr = GetStdHandle(STD_ERROR_HANDLE);
+
+	MosaicTtyInitResult ttyInitResult = tty_initWithHandles(writerConin, stdout, stderr, callback);
 	if (unlikely(ttyInitResult.error)) {
 		result.error = ttyInitResult.error;
 		goto err;
@@ -65,6 +68,7 @@ MosaicTty *testTty_getTty(MosaicTestTty *testTty) {
 
 uint32_t testTty_write(MosaicTestTty *testTty UNUSED, char *buffer, int count) {
 	uint32_t result = 0;
+
 	INPUT_RECORD *records = calloc(count, sizeof(INPUT_RECORD));
 	if (!records) {
 		result = ERROR_NOT_ENOUGH_MEMORY;

--- a/mosaic-tty/src/commonMain/c/mosaic-tty-posix.h
+++ b/mosaic-tty/src/commonMain/c/mosaic-tty-posix.h
@@ -5,15 +5,21 @@
 #include <sys/select.h>
 
 typedef struct MosaicTtyImpl {
-	int stdinFd;
-	int pipe[2];
-	fd_set fds;
-	int nfds;
+	int stdin_read_fd;
+	int stdout_write_fd;
+	int stderr_write_fd;
+	int interrupt_read_fd;
+	int interrupt_write_fd;
 	MosaicTtyCallback *callback;
 	bool sigwinch;
 	struct termios *saved;
 } MosaicTtyImpl;
 
-MosaicTtyInitResult tty_initWithFd(int stdinFd, MosaicTtyCallback *callback);
+MosaicTtyInitResult tty_initWithFds(
+	int stdinReadFd,
+	int stdoutWriteFd,
+	int stderrWriteFd,
+	MosaicTtyCallback *callback
+);
 
 #endif // MOSAIC_TTY_POSIX_H

--- a/mosaic-tty/src/commonMain/c/mosaic-tty-windows.h
+++ b/mosaic-tty/src/commonMain/c/mosaic-tty-windows.h
@@ -9,7 +9,8 @@ static const int recordsCount = 64;
 typedef struct MosaicTtyImpl {
 	HANDLE stdin;
 	HANDLE stdout;
-	HANDLE waitHandles[2];
+	HANDLE stderr;
+	HANDLE interrupt_event;
 	INPUT_RECORD records[recordsCount];
 	MosaicTtyCallback *callback;
 	bool windowResizeEvents;
@@ -18,8 +19,10 @@ typedef struct MosaicTtyImpl {
 	UINT saved_output_code_page;
 } MosaicTtyImpl;
 
-MosaicTtyInitResult tty_initWithHandle(
-	HANDLE stdinRead,
+MosaicTtyInitResult tty_initWithHandles(
+	HANDLE stdin,
+	HANDLE stdout,
+	HANDLE stderr,
 	MosaicTtyCallback *callback
 );
 

--- a/mosaic-tty/src/commonMain/c/mosaic-tty.h
+++ b/mosaic-tty/src/commonMain/c/mosaic-tty.h
@@ -4,6 +4,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+typedef struct MosaicTtyImpl MosaicTty;
+
 typedef void MosaicTtyCallbackOnFocus(void *opaque, bool focused);
 typedef void MosaicTtyCallbackOnKey(void *opaque); // TODO params
 typedef void MosaicTtyCallbackOnMouse(void *opaque); // TODO params
@@ -16,9 +18,6 @@ typedef struct MosaicTtyCallback {
 	MosaicTtyCallbackOnMouse *onMouse;
 	MosaicTtyCallbackOnResize *onResize;
 } MosaicTtyCallback;
-
-
-typedef struct MosaicTtyImpl MosaicTty;
 
 typedef struct MosaicTtyInitResult {
 	MosaicTty *tty;
@@ -39,9 +38,11 @@ typedef struct MosaicTtyTerminalSizeResult {
 } MosaicTtyTerminalSizeResult;
 
 MosaicTtyInitResult tty_init(MosaicTtyCallback *callback);
-MosaicTtyIoResult tty_read(MosaicTty *tty, char *buffer, int count);
-MosaicTtyIoResult tty_readWithTimeout(MosaicTty *tty, char *buffer, int count, int timeoutMillis);
-uint32_t tty_interrupt(MosaicTty *tty);
+MosaicTtyIoResult tty_readInput(MosaicTty *tty, char *buffer, int count);
+MosaicTtyIoResult tty_readInputWithTimeout(MosaicTty *tty, char *buffer, int count, int timeoutMillis);
+uint32_t tty_interruptRead(MosaicTty *tty);
+MosaicTtyIoResult tty_writeOutput(MosaicTty *tty, char *buffer, int count);
+MosaicTtyIoResult tty_writeError(MosaicTty *tty, char *buffer, int count);
 uint32_t tty_enableRawMode(MosaicTty *tty);
 uint32_t tty_enableWindowResizeEvents(MosaicTty *tty);
 MosaicTtyTerminalSizeResult tty_currentTerminalSize(MosaicTty *tty);

--- a/mosaic-tty/src/commonMain/kotlin/com/jakewharton/mosaic/tty/Tty.kt
+++ b/mosaic-tty/src/commonMain/kotlin/com/jakewharton/mosaic/tty/Tty.kt
@@ -6,28 +6,41 @@ public expect class Tty : AutoCloseable {
 	}
 
 	/**
-	 * Read up to [count] bytes into [buffer] at [offset]. The number of bytes read will be returned.
-	 * 0 will be returned if [interrupt] is called while waiting for input. -1 will be returned if
-	 * the input stream is closed.
+	 * Read up to [count] bytes into [buffer] at [offset] from the standard input stream.
+	 * The number of bytes read will be returned. 0 will be returned if [interruptRead] is called
+	 * while waiting for input. -1 will be returned if the input stream is closed.
 	 *
-	 * @see readWithTimeout
+	 * @see readInputWithTimeout
 	 */
-	public fun read(buffer: ByteArray, offset: Int, count: Int): Int
+	public fun readInput(buffer: ByteArray, offset: Int, count: Int): Int
 
 	/**
-	 * Read up to [count] bytes into [buffer] at [offset]. The number of bytes read will be returned.
-	 * 0 will be returned if [interrupt] is called while waiting for input, or if at least
-	 * [timeoutMillis] have passed without data. -1 will be returned if the input stream is closed.
+	 * Read up to [count] bytes into [buffer] at [offset] from the standard input stream.
+	 * The number of bytes read will be returned. 0 will be returned if [interruptRead] is called
+	 * while waiting for input, or if at least [timeoutMillis] have passed without data.
+	 * -1 will be returned if the input stream is closed.
 	 *
 	 * @param timeoutMillis A value of 0 will perform a non-blocking read. Otherwise, valid values
 	 * are 1 to 999 which represent a maximum time (in milliseconds) to wait for data. Note: This
 	 * value is not validated.
-	 * @see read
+	 * @see readInput
 	 */
-	public fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int
+	public fun readInputWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int
 
-	/** Signal blocking calls to [read] to wake up and return 0. */
-	public fun interrupt()
+	/** Signal blocking calls to [readInput] or [readInputWithTimeout] to wake up and return 0. */
+	public fun interruptRead()
+
+	/**
+	 * Write up to [count] bytes from [buffer] at [offset] to the standard output stream.
+	 * The number of bytes written will be returned.
+	 */
+	public fun writeOutput(buffer: ByteArray, offset: Int, count: Int): Int
+
+	/**
+	 * Write up to [count] bytes from [buffer] at [offset] to the standard error stream.
+	 * The number of bytes written will be returned.
+	 */
+	public fun writeError(buffer: ByteArray, offset: Int, count: Int): Int
 
 	public fun enableRawMode()
 

--- a/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TtyTest.kt
+++ b/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TtyTest.kt
@@ -31,12 +31,12 @@ class TtyTest {
 		val buffer = ByteArray(10) { 'x'.code.toByte() }
 
 		testTty.write("hello".encodeToByteArray())
-		val readA = tty.read(buffer, 0, 10)
+		val readA = tty.readInput(buffer, 0, 10)
 		assertThat(readA, "readA").isEqualTo(5)
 		assertThat(buffer.decodeToString()).isEqualTo("helloxxxxx")
 
 		testTty.write("world".encodeToByteArray())
-		val readB = tty.read(buffer, 0, 10)
+		val readB = tty.readInput(buffer, 0, 10)
 		assertThat(readB, "readB").isEqualTo(5)
 		assertThat(buffer.decodeToString()).isEqualTo("worldxxxxx")
 	}
@@ -45,7 +45,7 @@ class TtyTest {
 		val buffer = ByteArray(10) { 'x'.code.toByte() }
 
 		testTty.write("hello".encodeToByteArray())
-		val read = tty.read(buffer, 0, 4)
+		val read = tty.readInput(buffer, 0, 4)
 		assertThat(read).isEqualTo(4)
 		assertThat(buffer.decodeToString()).isEqualTo("hellxxxxxx")
 	}
@@ -54,7 +54,7 @@ class TtyTest {
 		val buffer = ByteArray(10) { 'x'.code.toByte() }
 
 		testTty.write("hello".encodeToByteArray())
-		val read = tty.read(buffer, 0, 10)
+		val read = tty.readInput(buffer, 0, 10)
 		assertThat(read).isEqualTo(5)
 		assertThat(buffer.decodeToString()).isEqualTo("helloxxxxx")
 	}
@@ -63,7 +63,7 @@ class TtyTest {
 		val buffer = ByteArray(10) { 'x'.code.toByte() }
 
 		testTty.write("hello".encodeToByteArray())
-		val read = tty.read(buffer, 5, 5)
+		val read = tty.readInput(buffer, 5, 5)
 		assertThat(read).isEqualTo(5)
 		assertThat(buffer.decodeToString()).isEqualTo("xxxxxhello")
 	}
@@ -71,16 +71,16 @@ class TtyTest {
 	@Test fun readCanBeInterrupted() = runTest {
 		backgroundScope.launch(Dispatchers.Default) {
 			delay(150.milliseconds)
-			tty.interrupt()
+			tty.interruptRead()
 		}
-		val readA = tty.read(ByteArray(10), 0, 10)
+		val readA = tty.readInput(ByteArray(10), 0, 10)
 		assertThat(readA).isZero()
 
 		backgroundScope.launch(Dispatchers.Default) {
 			delay(150.milliseconds)
-			tty.interrupt()
+			tty.interruptRead()
 		}
-		val readB = tty.read(ByteArray(10), 0, 10)
+		val readB = tty.readInput(ByteArray(10), 0, 10)
 		assertThat(readB).isZero()
 	}
 
@@ -90,14 +90,14 @@ class TtyTest {
 
 		val readA: Int
 		val tookA = measureTime {
-			readA = tty.readWithTimeout(ByteArray(10), 0, 10, 100)
+			readA = tty.readInputWithTimeout(ByteArray(10), 0, 10, 100)
 		}
 		assertThat(readA).isZero()
 		assertThat(tookA).isGreaterThan(50.milliseconds)
 
 		val readB: Int
 		val tookB = measureTime {
-			readB = tty.readWithTimeout(ByteArray(10), 0, 10, 100)
+			readB = tty.readInputWithTimeout(ByteArray(10), 0, 10, 100)
 		}
 		assertThat(readB).isZero()
 		assertThat(tookB).isGreaterThan(50.milliseconds)

--- a/mosaic-tty/src/jvmMain/c/mosaic-jni.c
+++ b/mosaic-tty/src/jvmMain/c/mosaic-jni.c
@@ -162,7 +162,7 @@ Java_com_jakewharton_mosaic_tty_Jni_ttyInit(
 }
 
 JNIEXPORT jint JNICALL
-Java_com_jakewharton_mosaic_tty_Jni_ttyRead(
+Java_com_jakewharton_mosaic_tty_Jni_ttyReadInput(
 	JNIEnv *env,
 	jclass type,
 	jlong ttyOpaque,
@@ -174,22 +174,22 @@ Java_com_jakewharton_mosaic_tty_Jni_ttyRead(
 	jbyte *nativeBufferAtOffset = nativeBuffer + offset;
 
 	MosaicTty *tty = (MosaicTty *) ttyOpaque;
-	MosaicTtyIoResult read = tty_read(tty, nativeBufferAtOffset, count);
+	MosaicTtyIoResult result = tty_readInput(tty, nativeBufferAtOffset, count);
 
 	(*env)->ReleaseByteArrayElements(env, buffer, nativeBuffer, 0);
 
-	if (likely(!read.error)) {
-		return read.count;
+	if (likely(!result.error)) {
+		return result.count;
 	}
 
 	// This throw can fail, but the only condition that should cause that is OOM. Return -1 (EOF)
 	// and should cause the program to try and exit cleanly. 0 is a valid return value.
-	throwIse(env, read.error, "Unable to read stdin");
+	throwIse(env, result.error, "Unable to read input");
 	return -1;
 }
 
 JNIEXPORT jint JNICALL
-Java_com_jakewharton_mosaic_tty_Jni_ttyReadWithTimeout(
+Java_com_jakewharton_mosaic_tty_Jni_ttyReadInputWithTimeout(
 	JNIEnv *env,
 	jclass type,
 	jlong ttyOpaque,
@@ -202,7 +202,7 @@ Java_com_jakewharton_mosaic_tty_Jni_ttyReadWithTimeout(
 	jbyte *nativeBufferAtOffset = nativeBuffer + offset;
 
 	MosaicTty *tty = (MosaicTty *) ttyOpaque;
-	MosaicTtyIoResult read = tty_readWithTimeout(
+	MosaicTtyIoResult result = tty_readInputWithTimeout(
 		tty,
 		nativeBufferAtOffset,
 		count,
@@ -211,27 +211,81 @@ Java_com_jakewharton_mosaic_tty_Jni_ttyReadWithTimeout(
 
 	(*env)->ReleaseByteArrayElements(env, buffer, nativeBuffer, 0);
 
-	if (likely(!read.error)) {
-		return read.count;
+	if (likely(!result.error)) {
+		return result.count;
 	}
 
 	// This throw can fail, but the only condition that should cause that is OOM. Return -1 (EOF)
 	// and should cause the program to try and exit cleanly. 0 is a valid return value.
-	throwIse(env, read.error, "Unable to read stdin");
+	throwIse(env, result.error, "Unable to read input");
 	return -1;
 }
 
 JNIEXPORT void JNICALL
-Java_com_jakewharton_mosaic_tty_Jni_ttyInterrupt(
+Java_com_jakewharton_mosaic_tty_Jni_ttyInterruptRead(
 	JNIEnv *env,
 	jclass type,
 	jlong ttyOpaque
 ) {
 	MosaicTty *tty = (MosaicTty *) ttyOpaque;
-	uint32_t error = tty_interrupt(tty);
+	uint32_t error = tty_interruptRead(tty);
 	if (unlikely(error)) {
 		throwIse(env, error, "Unable to interrupt");
 	}
+}
+
+JNIEXPORT jint JNICALL
+Java_com_jakewharton_mosaic_tty_Jni_ttyWriteOutput(
+	JNIEnv *env,
+	jclass type,
+	jlong ttyOpaque,
+	jbyteArray buffer,
+	jint offset,
+	jint count
+) {
+	jbyte *nativeBuffer = (*env)->GetByteArrayElements(env, buffer, NULL);
+	jbyte *nativeBufferAtOffset = nativeBuffer + offset;
+
+	MosaicTty *tty = (MosaicTty *) ttyOpaque;
+	MosaicTtyIoResult result = tty_writeOutput(tty, nativeBuffer, count);
+
+	(*env)->ReleaseByteArrayElements(env, buffer, nativeBuffer, 0);
+
+	if (likely(!result.error)) {
+		return result.count;
+	}
+
+	// This throw can fail, but the only condition that should cause that is OOM. Return -1 (EOF)
+	// and should cause the program to try and exit cleanly. 0 is a valid return value.
+	throwIse(env, result.error, "Unable to write output");
+	return -1;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_jakewharton_mosaic_tty_Jni_ttyWriteError(
+	JNIEnv *env,
+	jclass type,
+	jlong ttyOpaque,
+	jbyteArray buffer,
+	jint offset,
+	jint count
+) {
+	jbyte *nativeBuffer = (*env)->GetByteArrayElements(env, buffer, NULL);
+	jbyte *nativeBufferAtOffset = nativeBuffer + offset;
+
+	MosaicTty *tty = (MosaicTty *) ttyOpaque;
+	MosaicTtyIoResult result = tty_writeError(tty, nativeBuffer, count);
+
+	(*env)->ReleaseByteArrayElements(env, buffer, nativeBuffer, 0);
+
+	if (likely(!result.error)) {
+		return result.count;
+	}
+
+	// This throw can fail, but the only condition that should cause that is OOM. Return -1 (EOF)
+	// and should cause the program to try and exit cleanly. 0 is a valid return value.
+	throwIse(env, result.error, "Unable to write error");
+	return -1;
 }
 
 JNIEXPORT void JNICALL

--- a/mosaic-tty/src/jvmMain/kotlin/com/jakewharton/mosaic/tty/Jni.kt
+++ b/mosaic-tty/src/jvmMain/kotlin/com/jakewharton/mosaic/tty/Jni.kt
@@ -22,7 +22,7 @@ internal object Jni {
 	external fun ttyInit(callbackPtr: Long): Long
 
 	@JvmStatic
-	external fun ttyRead(
+	external fun ttyReadInput(
 		ttyPtr: Long,
 		buffer: ByteArray,
 		offset: Int,
@@ -30,7 +30,7 @@ internal object Jni {
 	): Int
 
 	@JvmStatic
-	external fun ttyReadWithTimeout(
+	external fun ttyReadInputWithTimeout(
 		ttyPtr: Long,
 		buffer: ByteArray,
 		offset: Int,
@@ -39,7 +39,23 @@ internal object Jni {
 	): Int
 
 	@JvmStatic
-	external fun ttyInterrupt(ttyPtr: Long)
+	external fun ttyInterruptRead(ttyPtr: Long)
+
+	@JvmStatic
+	external fun ttyWriteOutput(
+		ttyPtr: Long,
+		buffer: ByteArray,
+		offset: Int,
+		count: Int,
+	): Int
+
+	@JvmStatic
+	external fun ttyWriteError(
+		ttyPtr: Long,
+		buffer: ByteArray,
+		offset: Int,
+		count: Int,
+	): Int
 
 	@JvmStatic
 	external fun ttyEnableRawMode(ttyPtr: Long)

--- a/mosaic-tty/src/jvmMain/kotlin/com/jakewharton/mosaic/tty/Tty.kt
+++ b/mosaic-tty/src/jvmMain/kotlin/com/jakewharton/mosaic/tty/Tty.kt
@@ -19,16 +19,24 @@ public actual class Tty internal constructor(
 		}
 	}
 
-	public actual fun read(buffer: ByteArray, offset: Int, count: Int): Int {
-		return Jni.ttyRead(ttyPtr, buffer, offset, count)
+	public actual fun readInput(buffer: ByteArray, offset: Int, count: Int): Int {
+		return Jni.ttyReadInput(ttyPtr, buffer, offset, count)
 	}
 
-	public actual fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int {
-		return Jni.ttyReadWithTimeout(ttyPtr, buffer, offset, count, timeoutMillis)
+	public actual fun readInputWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int {
+		return Jni.ttyReadInputWithTimeout(ttyPtr, buffer, offset, count, timeoutMillis)
 	}
 
-	public actual fun interrupt() {
-		Jni.ttyInterrupt(ttyPtr)
+	public actual fun interruptRead() {
+		Jni.ttyInterruptRead(ttyPtr)
+	}
+
+	public actual fun writeOutput(buffer: ByteArray, offset: Int, count: Int): Int {
+		return Jni.ttyWriteOutput(ttyPtr, buffer, offset, count)
+	}
+
+	public actual fun writeError(buffer: ByteArray, offset: Int, count: Int): Int {
+		return Jni.ttyWriteError(ttyPtr, buffer, offset, count)
 	}
 
 	public actual fun enableRawMode() {

--- a/mosaic-tty/src/nativeMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
+++ b/mosaic-tty/src/nativeMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
@@ -9,7 +9,7 @@ import kotlinx.cinterop.ptr
 import kotlinx.cinterop.useContents
 import kotlinx.cinterop.usePinned
 
-public actual class TestTty(
+public actual class TestTty private constructor(
 	private var ptr: CPointer<MosaicTestTty>?,
 	public actual val tty: Tty,
 ) : AutoCloseable {
@@ -24,7 +24,9 @@ public actual class TestTty(
 				nativeHeap.free(callbackPtr)
 				callbackRef.dispose()
 
-				check(error == 0U) { "Unable to create test tty: $error" }
+				if (error != 0U) {
+					throwError(error)
+				}
 				throw OutOfMemoryError()
 			}
 


### PR DESCRIPTION
In the future these will be used to write bytes instead of chars (#484) and to intercept 'println' usage (#681).

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
