### PR TITLE
Expose underlying `Tty` instance from `TerminalReader`

### DIFF
--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -5,6 +5,7 @@ public final class com/jakewharton/mosaic/terminal/TerminalReader : java/lang/Au
 	public final fun enableWindowResizeEvents ()V
 	public final fun getEvents ()Lkotlinx/coroutines/channels/ReceiveChannel;
 	public final fun getKittyDisambiguateEscapeCodes ()Z
+	public final fun getTty ()Lcom/jakewharton/mosaic/tty/Tty;
 	public final fun getXtermExtendedUtf8Mouse ()Z
 	public final fun interrupt ()V
 	public final fun runParseLoop ()V

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -370,6 +370,8 @@ final class com.jakewharton.mosaic.terminal.event/XtermPixelSizeEvent : com.jake
 final class com.jakewharton.mosaic.terminal/TerminalReader : kotlin/AutoCloseable { // com.jakewharton.mosaic.terminal/TerminalReader|null[0]
     final val events // com.jakewharton.mosaic.terminal/TerminalReader.events|{}events[0]
         final fun <get-events>(): kotlinx.coroutines.channels/ReceiveChannel<com.jakewharton.mosaic.terminal.event/Event> // com.jakewharton.mosaic.terminal/TerminalReader.events.<get-events>|<get-events>(){}[0]
+    final val tty // com.jakewharton.mosaic.terminal/TerminalReader.tty|{}tty[0]
+        final fun <get-tty>(): com.jakewharton.mosaic.tty/Tty // com.jakewharton.mosaic.terminal/TerminalReader.tty.<get-tty>|<get-tty>(){}[0]
 
     final var kittyDisambiguateEscapeCodes // com.jakewharton.mosaic.terminal/TerminalReader.kittyDisambiguateEscapeCodes|{}kittyDisambiguateEscapeCodes[0]
         final fun <get-kittyDisambiguateEscapeCodes>(): kotlin/Boolean // com.jakewharton.mosaic.terminal/TerminalReader.kittyDisambiguateEscapeCodes.<get-kittyDisambiguateEscapeCodes>|<get-kittyDisambiguateEscapeCodes>(){}[0]

--- a/mosaic-terminal/build.gradle
+++ b/mosaic-terminal/build.gradle
@@ -23,7 +23,7 @@ kotlin {
 		commonMain {
 			dependencies {
 				api libs.kotlinx.coroutines.core
-				implementation projects.mosaicTty
+				api projects.mosaicTty
 			}
 		}
 		commonTest {

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalReader.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalReader.kt
@@ -47,7 +47,7 @@ public fun TerminalReader(emitDebugEvents: Boolean = false): TerminalReader {
 }
 
 public class TerminalReader internal constructor(
-	private val tty: Tty,
+	public val tty: Tty,
 	events: Channel<Event>,
 	private val emitDebugEvents: Boolean,
 ) : AutoCloseable {


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
