### PR TITLE
Get rid of last `Platform`-prefixed type

### DIFF
--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/EventChannelTtyCallback.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/EventChannelTtyCallback.kt
@@ -7,7 +7,7 @@ import com.jakewharton.mosaic.terminal.event.ResizeEvent
 import com.jakewharton.mosaic.tty.Tty
 import kotlinx.coroutines.channels.SendChannel
 
-internal class PlatformEventHandler(
+internal class EventChannelTtyCallback(
 	private val events: SendChannel<Event>,
 	private val emitDebugEvents: Boolean,
 ) : Tty.Callback {

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalReader.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/TerminalReader.kt
@@ -41,7 +41,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
  */
 public fun TerminalReader(emitDebugEvents: Boolean = false): TerminalReader {
 	val events = Channel<Event>(UNLIMITED)
-	val callback = PlatformEventHandler(events, emitDebugEvents)
+	val callback = EventChannelTtyCallback(events, emitDebugEvents)
 	val tty = Tty.create(callback)
 	return TerminalReader(tty, events, emitDebugEvents)
 }

--- a/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TestTerminalReader.kt
+++ b/mosaic-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/terminal/TestTerminalReader.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 
 internal fun TestTerminalReader(): TestTerminalReader {
 	val events = Channel<Event>(UNLIMITED)
-	val platformEventHandler = PlatformEventHandler(events, emitDebugEvents = false)
-	val testTty = TestTty.create(platformEventHandler)
+	val callback = EventChannelTtyCallback(events, emitDebugEvents = false)
+	val testTty = TestTty.create(callback)
 	val reader = TerminalReader(testTty.tty, events, emitDebugEvents = false)
 	return TestTerminalReader(testTty, reader)
 }


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
