### PR TITLE
Test for concurrent `TestTty` usage

### DIFF
--- a/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TestTtyTest.kt
+++ b/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TestTtyTest.kt
@@ -1,0 +1,20 @@
+package com.jakewharton.mosaic.tty
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class TestTtyTest {
+	@Test fun canCreateMultiple() {
+		if (isWindows()) return // TODO Not currently supported.
+
+		TestTty.create().use { one ->
+			TestTty.create().use { two ->
+				one.writeInput("hey")
+				two.writeInput("bye")
+				assertThat(two.tty.readInput(3)).isEqualTo("bye")
+				assertThat(one.tty.readInput(3)).isEqualTo("hey")
+			}
+		}
+	}
+}

--- a/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TtyTest.kt
+++ b/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TtyTest.kt
@@ -41,12 +41,12 @@ class TtyTest {
 	@Test fun readWhatWasWritten() {
 		val buffer = ByteArray(10) { 'x'.code.toByte() }
 
-		testTty.writeInput("hello".encodeToByteArray())
+		testTty.writeInput("hello")
 		val readA = tty.readInput(buffer, 0, 10)
 		assertThat(readA, "readA").isEqualTo(5)
 		assertThat(buffer.decodeToString()).isEqualTo("helloxxxxx")
 
-		testTty.writeInput("world".encodeToByteArray())
+		testTty.writeInput("world")
 		val readB = tty.readInput(buffer, 0, 10)
 		assertThat(readB, "readB").isEqualTo(5)
 		assertThat(buffer.decodeToString()).isEqualTo("worldxxxxx")
@@ -55,7 +55,7 @@ class TtyTest {
 	@Test fun readOnlyUpToCount() {
 		val buffer = ByteArray(10) { 'x'.code.toByte() }
 
-		testTty.writeInput("hello".encodeToByteArray())
+		testTty.writeInput("hello")
 		val read = tty.readInput(buffer, 0, 4)
 		assertThat(read).isEqualTo(4)
 		assertThat(buffer.decodeToString()).isEqualTo("hellxxxxxx")
@@ -64,7 +64,7 @@ class TtyTest {
 	@Test fun readUnderflow() {
 		val buffer = ByteArray(10) { 'x'.code.toByte() }
 
-		testTty.writeInput("hello".encodeToByteArray())
+		testTty.writeInput("hello")
 		val read = tty.readInput(buffer, 0, 10)
 		assertThat(read).isEqualTo(5)
 		assertThat(buffer.decodeToString()).isEqualTo("helloxxxxx")
@@ -73,7 +73,7 @@ class TtyTest {
 	@Test fun readAtOffset() {
 		val buffer = ByteArray(10) { 'x'.code.toByte() }
 
-		testTty.writeInput("hello".encodeToByteArray())
+		testTty.writeInput("hello")
 		val read = tty.readInput(buffer, 5, 5)
 		assertThat(read).isEqualTo(5)
 		assertThat(buffer.decodeToString()).isEqualTo("xxxxxhello")
@@ -267,18 +267,9 @@ class TtyTest {
 	 * write-read round-trip to ensure all events were processed.
 	 */
 	private fun doWriteReadRoundtrip() {
-		val outgoing = "roundtrip".encodeToByteArray()
-		testTty.writeInput(outgoing)
-		var offset = 0
-		val incoming = ByteArray(1024)
-		while (offset < outgoing.size) {
-			val read = tty.readInput(incoming, offset, outgoing.size)
-			if (read == -1) {
-				throw RuntimeException("eof")
-			}
-			offset += read
-		}
-		assertThat(incoming.decodeToString(endIndex = offset)).isEqualTo("roundtrip")
+		val data = "roundtrip"
+		testTty.writeInput(data)
+		assertThat(tty.readInput(data.length)).isEqualTo(data)
 	}
 
 	inner class MyCallback(
@@ -296,11 +287,5 @@ class TtyTest {
 		override fun onResize(columns: Int, rows: Int, width: Int, height: Int) {
 			events += "$prefix onResize $columns $rows $width $height"
 		}
-	}
-
-	private fun TestTty.writeInput(buffer: ByteArray) {
-		// TODO Figure out public API to fully write a ByteArray.
-		val written = writeInput(buffer, 0, buffer.size)
-		assertThat(written).isEqualTo(buffer.size)
 	}
 }

--- a/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/util.kt
+++ b/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/util.kt
@@ -1,0 +1,23 @@
+package com.jakewharton.mosaic.tty
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+
+fun TestTty.writeInput(data: String) {
+	val bytes = data.encodeToByteArray()
+	val written = writeInput(bytes, 0, bytes.size)
+	assertThat(written).isEqualTo(bytes.size)
+}
+
+fun Tty.readInput(count: Int): String {
+	var offset = 0
+	val incoming = ByteArray(1024)
+	while (offset < count) {
+		val read = readInput(incoming, offset, count)
+		if (read == -1) {
+			throw RuntimeException("eof")
+		}
+		offset += read
+	}
+	return incoming.decodeToString(endIndex = count)
+}


### PR DESCRIPTION
This should not have the same restriction as `Tty`, although currently Windows isn't fully supported for concurrent usage.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
