### PR TITLE
Use `javac`-generated JNI header

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,9 +18,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version-file: .github/workflows/.java-version
+
       - uses: mlugg/setup-zig@v1
         with:
           version: 0.13.0
+
+      - name: Generate JNI header
+        run: ./gradlew :mosaic-tty:compileJvmMainJava
 
       - run: zig build -p src/jvmMain/resources/jni
         working-directory: mosaic-tty

--- a/mosaic-tty/README.md
+++ b/mosaic-tty/README.md
@@ -7,8 +7,12 @@ Low-level TTY manipulation library.
 
 The JVM target requires native libraries which are built outside Gradle using Zig 0.13.0.
 
-After downloading or installing Zig, in the `mosaic-tty/` directory run:
+First, generate the JNI headers:
+```
+./gradlew compileJvmMainJava
+```
+
+Then, after downloading or installing Zig, in the `mosaic-tty/` directory run:
 ```
 zig build -p src/jvmMain/resources/jni
 ```
-to create them.

--- a/mosaic-tty/build.zig
+++ b/mosaic-tty/build.zig
@@ -29,6 +29,7 @@ fn setupMosaicTarget(b: *std.Build, step: *std.Build.Step, tag: std.Target.Os.Ta
 	lib.linkLibC();
 
 	lib.addIncludePath(b.path("src/commonMain/c"));
+	lib.addIncludePath(b.path("build/generated/sources/headers/java/jvmMain"));
 	lib.addIncludePath(b.path("src/jvmMain/include/share"));
 	lib.addIncludePath(
 		switch (tag) {
@@ -44,7 +45,7 @@ fn setupMosaicTarget(b: *std.Build, step: *std.Build.Step, tag: std.Target.Os.Ta
 			"src/commonMain/c/mosaic-tty-windows.c",
 			"src/commonMain/c/mosaic-test-tty-posix.c",
 			"src/commonMain/c/mosaic-test-tty-windows.c",
-			"src/jvmMain/c/mosaic-jni.c",
+			"src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c",
 		},
 		.flags = &.{
 			"-std=gnu11",

--- a/mosaic-tty/src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c
+++ b/mosaic-tty/src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c
@@ -1,3 +1,5 @@
+#include "com_jakewharton_mosaic_tty_Jni.h"
+
 #include "cutils.h"
 #include "jni.h"
 #include "mosaic.h"
@@ -412,7 +414,7 @@ Java_com_jakewharton_mosaic_tty_Jni_testTtyFocusEvent(
 	JNIEnv *env UNUSED,
 	jclass type UNUSED,
 	jlong testTtyOpaque,
-	bool focused
+	jboolean focused
 ) {
 	MosaicTestTty *testTty = (MosaicTestTty *) testTtyOpaque;
 	testTty_focusEvent(testTty, focused);

--- a/mosaic-tty/src/jvmMain/java/com/jakewharton/mosaic/tty/Jni.java
+++ b/mosaic-tty/src/jvmMain/java/com/jakewharton/mosaic/tty/Jni.java
@@ -62,7 +62,7 @@ final class Jni {
 
 	static native long ttyInit();
 
-	static native long ttySetCallback(long ttyPtr, long callbackPtr);
+	static native void ttySetCallback(long ttyPtr, long callbackPtr);
 
 	static native int ttyReadInput(
 		long ttyPtr,


### PR DESCRIPTION
This ensures the Java and C signatures do not differ.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
