### PR TITLE
Add `Tty.reset` API

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -18,7 +18,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.jakewharton.mosaic.layout.KeyEvent
 import com.jakewharton.mosaic.layout.MosaicNode
 import com.jakewharton.mosaic.tty.Tty
-import com.jakewharton.mosaic.tty.terminal.asTerminal
+import com.jakewharton.mosaic.tty.terminal.useAsTerminal
 import com.jakewharton.mosaic.ui.BoxMeasurePolicy
 import com.jakewharton.mosaic.ui.unit.IntSize
 import kotlin.concurrent.Volatile
@@ -43,7 +43,7 @@ public fun runMosaicBlocking(content: @Composable () -> Unit) {
 }
 
 public suspend fun runMosaic(content: @Composable () -> Unit) {
-	Tty.bind().asTerminal { terminal ->
+	Tty.bind().useAsTerminal(resetOnly = true) { terminal ->
 		val rendering = if (env("MOSAIC_DEBUG_RENDERING") == "true") {
 			DebugRendering(
 				ansiLevel = terminal.capabilities.ansiLevel,

--- a/mosaic-tty-terminal/api/mosaic-tty-terminal.api
+++ b/mosaic-tty-terminal/api/mosaic-tty-terminal.api
@@ -1,5 +1,6 @@
 public final class com/jakewharton/mosaic/tty/terminal/TerminalKt {
-	public static final fun asTerminal (Lcom/jakewharton/mosaic/tty/Tty;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun useAsTerminal (Lcom/jakewharton/mosaic/tty/Tty;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun useAsTerminal$default (Lcom/jakewharton/mosaic/tty/Tty;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/jakewharton/mosaic/tty/terminal/TerminalParser {

--- a/mosaic-tty-terminal/api/mosaic-tty-terminal.klib.api
+++ b/mosaic-tty-terminal/api/mosaic-tty-terminal.klib.api
@@ -20,4 +20,4 @@ final class com.jakewharton.mosaic.tty.terminal/TerminalParser { // com.jakewhar
     final fun next(): com.jakewharton.mosaic.terminal.event/Event? // com.jakewharton.mosaic.tty.terminal/TerminalParser.next|next(){}[0]
 }
 
-final suspend fun (com.jakewharton.mosaic.tty/Tty).com.jakewharton.mosaic.tty.terminal/asTerminal(kotlin.coroutines/SuspendFunction1<com.jakewharton.mosaic.terminal/Terminal, kotlin/Unit>) // com.jakewharton.mosaic.tty.terminal/asTerminal|asTerminal@com.jakewharton.mosaic.tty.Tty(kotlin.coroutines.SuspendFunction1<com.jakewharton.mosaic.terminal.Terminal,kotlin.Unit>){}[0]
+final suspend fun (com.jakewharton.mosaic.tty/Tty).com.jakewharton.mosaic.tty.terminal/useAsTerminal(kotlin/Boolean = ..., kotlin.coroutines/SuspendFunction1<com.jakewharton.mosaic.terminal/Terminal, kotlin/Unit>) // com.jakewharton.mosaic.tty.terminal/useAsTerminal|useAsTerminal@com.jakewharton.mosaic.tty.Tty(kotlin.Boolean;kotlin.coroutines.SuspendFunction1<com.jakewharton.mosaic.terminal.Terminal,kotlin.Unit>){}[0]

--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/Terminal.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/Terminal.kt
@@ -60,7 +60,11 @@ private const val StageCapabilityQueries = 2
 private const val StageDefaultQueries = 1
 private const val StageNormalOperation = 0
 
-public suspend fun Tty.asTerminal(block: suspend (Terminal) -> Unit) {
+public suspend fun Tty.useAsTerminal(
+	/** When true, Call [Tty.reset] at and of [block] instead of [Tty.close]. */
+	resetOnly: Boolean = false,
+	block: suspend (Terminal) -> Unit,
+) {
 	val events = Channel<Event>(UNLIMITED)
 
 	setCallback(EventChannelTtyCallback(events, false))
@@ -86,11 +90,15 @@ public suspend fun Tty.asTerminal(block: suspend (Terminal) -> Unit) {
 			if (toggleFocus) print(focusDisable)
 			if (toggleCursor) print(cursorEnable)
 
-			close() // TODO We should have a way to reset the Tty without closing.
+			if (resetOnly) {
+				reset()
+			} else {
+				close()
+			}
 		},
 		block = {
 			launch(Dispatchers.IO) {
-				val parser = TerminalParser(this@asTerminal)
+				val parser = TerminalParser(this@useAsTerminal)
 				while (true) {
 					val event = parser.next() ?: break
 					events.trySend(event)

--- a/mosaic-tty/api/mosaic-tty.api
+++ b/mosaic-tty/api/mosaic-tty.api
@@ -25,6 +25,7 @@ public final class com/jakewharton/mosaic/tty/Tty : java/lang/AutoCloseable {
 	public final fun interruptRead ()V
 	public final fun readInput ([BII)I
 	public final fun readInputWithTimeout ([BIII)I
+	public final fun reset ()V
 	public final fun setCallback (Lcom/jakewharton/mosaic/tty/Tty$Callback;)V
 	public final fun writeError ([BII)I
 	public final fun writeOutput ([BII)I

--- a/mosaic-tty/api/mosaic-tty.klib.api
+++ b/mosaic-tty/api/mosaic-tty.klib.api
@@ -30,6 +30,7 @@ final class com.jakewharton.mosaic.tty/Tty : kotlin/AutoCloseable { // com.jakew
     final fun interruptRead() // com.jakewharton.mosaic.tty/Tty.interruptRead|interruptRead(){}[0]
     final fun readInput(kotlin/ByteArray, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/Tty.readInput|readInput(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
     final fun readInputWithTimeout(kotlin/ByteArray, kotlin/Int, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/Tty.readInputWithTimeout|readInputWithTimeout(kotlin.ByteArray;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+    final fun reset() // com.jakewharton.mosaic.tty/Tty.reset|reset(){}[0]
     final fun setCallback(com.jakewharton.mosaic.tty/Tty.Callback?) // com.jakewharton.mosaic.tty/Tty.setCallback|setCallback(com.jakewharton.mosaic.tty.Tty.Callback?){}[0]
     final fun writeError(kotlin/ByteArray, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/Tty.writeError|writeError(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
     final fun writeOutput(kotlin/ByteArray, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/Tty.writeOutput|writeOutput(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]

--- a/mosaic-tty/src/commonMain/c/mosaic-tty-posix.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-tty-posix.c
@@ -259,25 +259,40 @@ MosaicTtyTerminalSizeResult tty_currentTerminalSize(MosaicTty *tty) {
 	return result;
 }
 
+uint32_t tty_reset(MosaicTty *tty) {
+	uint32_t result = 0;
+
+	if (tty->sigwinch) {
+		if (unlikely(signal(SIGWINCH, SIG_DFL) == SIG_ERR)) {
+			result = errno;
+		}
+		tty->sigwinch = false;
+	}
+
+	if (tty->saved) {
+		if (unlikely(tcsetattr(tty->stdin_read_fd, TCSAFLUSH, tty->saved) && result == 0)) {
+			result = errno;
+		}
+		free(tty->saved);
+		tty->saved = NULL;
+	}
+
+	return result;
+}
+
 uint32_t tty_free(MosaicTty *tty) {
 	uint32_t result = 0;
 
 	if (unlikely(close(tty->interrupt_read_fd) != 0)) {
 		result = errno;
 	}
-	if (unlikely(close(tty->interrupt_write_fd) != 0 && result != 0)) {
+	if (unlikely(close(tty->interrupt_write_fd) != 0 && result == 0)) {
 		result = errno;
 	}
 
-	if (tty->sigwinch && signal(SIGWINCH, SIG_DFL) == SIG_ERR && result != 0) {
-		result = errno;
-	}
-
-	if (tty->saved) {
-		if (tcsetattr(tty->stdin_read_fd, TCSAFLUSH, tty->saved) && result != 0) {
-			result = errno;
-		}
-		free(tty->saved);
+	uint32_t resetResult = tty_reset(tty);
+	if (resetResult != 0 && result == 0) {
+		result = resetResult;
 	}
 
 	atomic_store(&globalTty, NULL);

--- a/mosaic-tty/src/commonMain/c/mosaic-tty-windows.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-tty-windows.c
@@ -271,15 +271,11 @@ MosaicTtyTerminalSizeResult tty_currentTerminalSize(MosaicTty *tty) {
 	return result;
 }
 
-uint32_t tty_free(MosaicTty *tty) {
+uint32_t tty_reset(MosaicTty *tty) {
 	uint32_t result = 0;
 
-	if (unlikely(CloseHandle(tty->interrupt_event) == 0)) {
-		result = GetLastError();
-	}
-
 	if (tty->saved_input_mode) {
-		if (unlikely(!SetConsoleMode(tty->stdin, tty->saved_input_mode) && result == 0)) {
+		if (unlikely(!SetConsoleMode(tty->stdin, tty->saved_input_mode))) {
 			result = GetLastError();
 		}
 		if (unlikely(!SetConsoleMode(tty->stdout, tty->saved_output_mode) && result == 0)) {
@@ -288,6 +284,24 @@ uint32_t tty_free(MosaicTty *tty) {
 		if (unlikely(!SetConsoleOutputCP(tty->saved_output_code_page) && result == 0)) {
 			result = GetLastError();
 		}
+		tty->saved_input_mode = 0;
+		tty->saved_output_mode = 0;
+		tty->saved_output_code_page = 0;
+	}
+
+	return result;
+}
+
+uint32_t tty_free(MosaicTty *tty) {
+	uint32_t result = 0;
+
+	if (unlikely(CloseHandle(tty->interrupt_event) == 0)) {
+		result = GetLastError();
+	}
+
+	uint32_t resetResult = tty_reset(tty);
+	if (resetResult != 0 && result == 0) {
+		result = resetResult;
 	}
 
 	atomic_store(&globalTty, NULL);

--- a/mosaic-tty/src/commonMain/c/mosaic-tty.h
+++ b/mosaic-tty/src/commonMain/c/mosaic-tty.h
@@ -48,6 +48,7 @@ MosaicTtyIoResult tty_writeError(MosaicTty *tty, uint8_t *buffer, int count);
 uint32_t tty_enableRawMode(MosaicTty *tty);
 uint32_t tty_enableWindowResizeEvents(MosaicTty *tty);
 MosaicTtyTerminalSizeResult tty_currentTerminalSize(MosaicTty *tty);
+uint32_t tty_reset(MosaicTty *tty);
 uint32_t tty_free(MosaicTty *tty);
 
 #endif // MOSAIC_TTY_H

--- a/mosaic-tty/src/commonMain/kotlin/com/jakewharton/mosaic/tty/Tty.kt
+++ b/mosaic-tty/src/commonMain/kotlin/com/jakewharton/mosaic/tty/Tty.kt
@@ -99,7 +99,10 @@ public expect class Tty : AutoCloseable {
 	/** @return Array of `[columns, rows, width, height]` */
 	public fun currentSize(): IntArray
 
-	/** Reset TTY state and free the resources associated with this reader. */
+	/** Reset TTY state. */
+	public fun reset()
+
+	/** Calls [reset] and then frees the resources associated with this instance. */
 	override fun close()
 
 	public interface Callback {

--- a/mosaic-tty/src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c
+++ b/mosaic-tty/src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c
@@ -352,6 +352,19 @@ Java_com_jakewharton_mosaic_tty_Jni_ttyCurrentSize(
 }
 
 JNIEXPORT void JNICALL
+Java_com_jakewharton_mosaic_tty_Jni_ttyReset(
+	JNIEnv *env,
+	jclass type UNUSED,
+	jlong ttyOpaque
+) {
+	MosaicTty *tty = (MosaicTty *) ttyOpaque;
+	uint32_t error = tty_reset(tty);
+	if (unlikely(error)) {
+		throwIse(env, error);
+	}
+}
+
+JNIEXPORT void JNICALL
 Java_com_jakewharton_mosaic_tty_Jni_ttyFree(
 	JNIEnv *env,
 	jclass type UNUSED,

--- a/mosaic-tty/src/jvmMain/java/com/jakewharton/mosaic/tty/Jni.java
+++ b/mosaic-tty/src/jvmMain/java/com/jakewharton/mosaic/tty/Jni.java
@@ -105,6 +105,8 @@ final class Jni {
 	 */
 	static native int[] ttyCurrentSize(long ttyPtr);
 
+	static native void ttyReset(long ttyPtr);
+
 	static native void ttyFree(long ttyPtr);
 
 	static native long testTtyInit();

--- a/mosaic-tty/src/jvmMain/kotlin/com/jakewharton/mosaic/tty/Tty.kt
+++ b/mosaic-tty/src/jvmMain/kotlin/com/jakewharton/mosaic/tty/Tty.kt
@@ -68,6 +68,10 @@ public actual class Tty internal constructor(
 		return Jni.ttyCurrentSize(ttyPtr)
 	}
 
+	public actual fun reset() {
+		Jni.ttyReset(ttyPtr)
+	}
+
 	actual override fun close() {
 		if (ttyPtr != 0L) {
 			Jni.ttyFree(ttyPtr)

--- a/mosaic-tty/src/nativeMain/kotlin/com/jakewharton/mosaic/tty/Tty.kt
+++ b/mosaic-tty/src/nativeMain/kotlin/com/jakewharton/mosaic/tty/Tty.kt
@@ -118,6 +118,10 @@ public actual class Tty internal constructor(
 		}
 	}
 
+	public actual fun reset() {
+		tty_reset(ptr)
+	}
+
 	actual override fun close() {
 		ptr?.let { ptr ->
 			this.ptr = null

--- a/tools/raw-mode-echo/src/commonMain/kotlin/example/main.kt
+++ b/tools/raw-mode-echo/src/commonMain/kotlin/example/main.kt
@@ -49,7 +49,7 @@ private class RawModeEchoCommand : CliktCommand("raw-mode-echo") {
 				print("\u001b[?2004l") // Bracketed paste disable
 				print("\u001b[?2048l") // In-band resize disable
 				print("\u001b[?25h") // Cursor enable
-				tty.close()
+				tty.reset()
 			},
 			block = {
 				print("\u001b[?25l") // Cursor disable


### PR DESCRIPTION
Allows reusing the bound `Tty` after `useAsTerminal`, or to just skip freeing resources if the process is exiting.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
