### PR TITLE
Build with Zig 0.14.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.14.0
 
       - name: Generate JNI header
         run: ./gradlew :mosaic-tty:compileJvmMainJava

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.14.0
       - run: zig build -p src/jvmMain/resources/jni
         working-directory: mosaic-tty
 

--- a/mosaic-tty/README.md
+++ b/mosaic-tty/README.md
@@ -5,7 +5,7 @@ Low-level TTY manipulation library.
 
 ## Prerequisites
 
-The JVM target requires native libraries which are built outside Gradle using Zig 0.13.0.
+The JVM target requires native libraries which are built outside Gradle using Zig 0.14.0.
 
 First, generate the JNI headers:
 ```

--- a/mosaic-tty/build.zig
+++ b/mosaic-tty/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) !void {
 	// The Windows builds create a .lib file in the lib/ directory which we don't need.
-	const deleteLib = b.addRemoveDirTree(b.getInstallPath(.prefix, "lib"));
+	const deleteLib = b.addRemoveDirTree(b.path(b.getInstallPath(.prefix, "lib")));
 	b.getInstallStep().dependOn(&deleteLib.step);
 
 	setupMosaicTarget(b, &deleteLib.step, .linux, .aarch64, "aarch64");


### PR DESCRIPTION
BEFORE:

    ❯ ls -lR mosaic-tty/src/jvmMain/resources/jni/
    total 0
    drwxr-xr-x@ 5 jw  admin  160 Mar 10 12:07 aarch64/
    drwxr-xr-x@ 4 jw  admin  128 Mar 10 12:07 amd64/
    drwxr-xr-x@ 3 jw  admin   96 Mar 10 12:07 x86_64/

    mosaic-tty/src/jvmMain/resources/jni//aarch64:
    total 184
    -rwxr-xr-x@ 1 jw  admin  53712 Mar 10 12:07 libmosaic.dylib*
    -rwxr-xr-x@ 1 jw  admin  15056 Mar 10 12:07 libmosaic.so*
    -rwxr-xr-x@ 1 jw  admin  20480 Mar 10 12:07 mosaic.dll*

    mosaic-tty/src/jvmMain/resources/jni//amd64:
    total 80
    -rwxr-xr-x@ 1 jw  admin  14568 Mar 10 12:07 libmosaic.so*
    -rwxr-xr-x@ 1 jw  admin  22016 Mar 10 12:07 mosaic.dll*

    mosaic-tty/src/jvmMain/resources/jni//x86_64:
    total 56
    -rwxr-xr-x@ 1 jw  admin  24785 Mar 10 12:07 libmosaic.dylib*

AFTER:

    ❯ ls -lR mosaic-tty/src/jvmMain/resources/jni/
    total 0
    drwxr-xr-x@ 5 jw  admin  160 Mar 13 22:19 aarch64/
    drwxr-xr-x@ 4 jw  admin  128 Mar 13 22:19 amd64/
    drwxr-xr-x@ 3 jw  admin   96 Mar 13 22:19 x86_64/

    mosaic-tty/src/jvmMain/resources/jni//aarch64:
    total 184
    -rwxr-xr-x@ 1 jw  admin  54400 Mar 13 22:19 libmosaic.dylib*
    -rwxr-xr-x@ 1 jw  admin  15184 Mar 13 22:19 libmosaic.so*
    -rwxr-xr-x@ 1 jw  admin  19968 Mar 13 22:19 mosaic.dll*

    mosaic-tty/src/jvmMain/resources/jni//amd64:
    total 80
    -rwxr-xr-x@ 1 jw  admin  15120 Mar 13 22:19 libmosaic.so*
    -rwxr-xr-x@ 1 jw  admin  23040 Mar 13 22:19 mosaic.dll*

    mosaic-tty/src/jvmMain/resources/jni//x86_64:
    total 56
    -rwxr-xr-x@ 1 jw  admin  24954 Mar 13 22:19 libmosaic.dylib*

Closes #783 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
