### PR TITLE
Make `copyBuffer` public API

### DIFF
--- a/mosaic-tty-terminal/api/mosaic-tty-terminal.api
+++ b/mosaic-tty-terminal/api/mosaic-tty-terminal.api
@@ -5,6 +5,7 @@ public final class com/jakewharton/mosaic/tty/terminal/TerminalKt {
 
 public final class com/jakewharton/mosaic/tty/terminal/TerminalParser {
 	public fun <init> (Lcom/jakewharton/mosaic/tty/Tty;)V
+	public final fun copyBuffer ()[B
 	public final fun debugNext ()Lkotlin/Pair;
 	public final fun getKittyDisambiguateEscapeCodes ()Z
 	public final fun getXtermExtendedUtf8Mouse ()Z

--- a/mosaic-tty-terminal/api/mosaic-tty-terminal.klib.api
+++ b/mosaic-tty-terminal/api/mosaic-tty-terminal.klib.api
@@ -16,6 +16,7 @@ final class com.jakewharton.mosaic.tty.terminal/TerminalParser { // com.jakewhar
         final fun <get-xtermExtendedUtf8Mouse>(): kotlin/Boolean // com.jakewharton.mosaic.tty.terminal/TerminalParser.xtermExtendedUtf8Mouse.<get-xtermExtendedUtf8Mouse>|<get-xtermExtendedUtf8Mouse>(){}[0]
         final fun <set-xtermExtendedUtf8Mouse>(kotlin/Boolean) // com.jakewharton.mosaic.tty.terminal/TerminalParser.xtermExtendedUtf8Mouse.<set-xtermExtendedUtf8Mouse>|<set-xtermExtendedUtf8Mouse>(kotlin.Boolean){}[0]
 
+    final fun copyBuffer(): kotlin/ByteArray // com.jakewharton.mosaic.tty.terminal/TerminalParser.copyBuffer|copyBuffer(){}[0]
     final fun debugNext(): kotlin/Pair<com.jakewharton.mosaic.terminal.event/Event, kotlin/ByteArray>? // com.jakewharton.mosaic.tty.terminal/TerminalParser.debugNext|debugNext(){}[0]
     final fun next(): com.jakewharton.mosaic.terminal.event/Event? // com.jakewharton.mosaic.tty.terminal/TerminalParser.next|next(){}[0]
 }

--- a/mosaic-tty-terminal/build.gradle
+++ b/mosaic-tty-terminal/build.gradle
@@ -13,7 +13,6 @@ kotlin {
 			}
 			if (it.name.endsWith("Test")) {
 				languageSettings {
-					optIn('com.jakewharton.mosaic.tty.terminal.TestApi')
 					optIn('kotlin.ExperimentalStdlibApi')
 				}
 			}

--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TerminalParser.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TerminalParser.kt
@@ -38,8 +38,13 @@ public class TerminalParser(
 	private var offset = 0
 	private var limit = 0
 
-	@TestApi
-	internal fun copyBuffer() = buffer.copyOfRange(offset, limit)
+	/**
+	 * Return a copy of any buffered data.
+	 *
+	 * If a call to [next] was interrupted and parsing will not continue, this can be used to
+	 * ensure any bytes which were already buffered are not lost.
+	 */
+	public fun copyBuffer(): ByteArray = buffer.copyOfRange(offset, limit)
 
 	/**
 	 * Indicate whether Kitty's

--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TestApi.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TestApi.kt
@@ -1,9 +1,0 @@
-package com.jakewharton.mosaic.tty.terminal
-
-import kotlin.annotation.AnnotationTarget.CLASS
-import kotlin.annotation.AnnotationTarget.FUNCTION
-import kotlin.annotation.AnnotationTarget.PROPERTY
-
-@RequiresOptIn
-@Target(CLASS, FUNCTION, PROPERTY)
-internal annotation class TestApi

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/TerminalParserTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/TerminalParserTest.kt
@@ -1,0 +1,17 @@
+package com.jakewharton.mosaic.tty.terminal
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jakewharton.mosaic.terminal.event.OperatingStatusResponseEvent
+import kotlin.test.Test
+
+class TerminalParserTest : BaseTerminalParserTest() {
+	@Test fun copyBuffer() {
+		assertThat(parser.copyBuffer().toHexString()).isEqualTo("")
+		testTty.writeHex("1b5b306e1b5b306e")
+		assertThat(parser.next()).isEqualTo(OperatingStatusResponseEvent(ok = true))
+		assertThat(parser.copyBuffer().toHexString()).isEqualTo("1b5b306e")
+		assertThat(parser.next()).isEqualTo(OperatingStatusResponseEvent(ok = true))
+		assertThat(parser.copyBuffer().toHexString()).isEqualTo("")
+	}
+}


### PR DESCRIPTION
It could be useful, and avoids the whole `TestApi` nonsense.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
