### PR TITLE
Rename `TerminalParser` to `EventParser`

### DIFF
--- a/mosaic-tty-terminal/api/mosaic-tty-terminal.api
+++ b/mosaic-tty-terminal/api/mosaic-tty-terminal.api
@@ -1,9 +1,4 @@
-public final class com/jakewharton/mosaic/tty/terminal/TerminalKt {
-	public static final fun useAsTerminal (Lcom/jakewharton/mosaic/tty/Tty;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun useAsTerminal$default (Lcom/jakewharton/mosaic/tty/Tty;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-}
-
-public final class com/jakewharton/mosaic/tty/terminal/TerminalParser {
+public final class com/jakewharton/mosaic/tty/terminal/EventParser {
 	public fun <init> (Lcom/jakewharton/mosaic/tty/Tty;)V
 	public final fun copyBuffer ()[B
 	public final fun debugNext ()Lkotlin/Pair;
@@ -12,5 +7,10 @@ public final class com/jakewharton/mosaic/tty/terminal/TerminalParser {
 	public final fun next ()Lcom/jakewharton/mosaic/terminal/Event;
 	public final fun setKittyDisambiguateEscapeCodes (Z)V
 	public final fun setXtermExtendedUtf8Mouse (Z)V
+}
+
+public final class com/jakewharton/mosaic/tty/terminal/TerminalKt {
+	public static final fun useAsTerminal (Lcom/jakewharton/mosaic/tty/Tty;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun useAsTerminal$default (Lcom/jakewharton/mosaic/tty/Tty;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 

--- a/mosaic-tty-terminal/api/mosaic-tty-terminal.klib.api
+++ b/mosaic-tty-terminal/api/mosaic-tty-terminal.klib.api
@@ -6,19 +6,19 @@
 // - Show declarations: true
 
 // Library unique name: <com.jakewharton.mosaic:mosaic-tty-terminal>
-final class com.jakewharton.mosaic.tty.terminal/TerminalParser { // com.jakewharton.mosaic.tty.terminal/TerminalParser|null[0]
-    constructor <init>(com.jakewharton.mosaic.tty/Tty) // com.jakewharton.mosaic.tty.terminal/TerminalParser.<init>|<init>(com.jakewharton.mosaic.tty.Tty){}[0]
+final class com.jakewharton.mosaic.tty.terminal/EventParser { // com.jakewharton.mosaic.tty.terminal/EventParser|null[0]
+    constructor <init>(com.jakewharton.mosaic.tty/Tty) // com.jakewharton.mosaic.tty.terminal/EventParser.<init>|<init>(com.jakewharton.mosaic.tty.Tty){}[0]
 
-    final var kittyDisambiguateEscapeCodes // com.jakewharton.mosaic.tty.terminal/TerminalParser.kittyDisambiguateEscapeCodes|{}kittyDisambiguateEscapeCodes[0]
-        final fun <get-kittyDisambiguateEscapeCodes>(): kotlin/Boolean // com.jakewharton.mosaic.tty.terminal/TerminalParser.kittyDisambiguateEscapeCodes.<get-kittyDisambiguateEscapeCodes>|<get-kittyDisambiguateEscapeCodes>(){}[0]
-        final fun <set-kittyDisambiguateEscapeCodes>(kotlin/Boolean) // com.jakewharton.mosaic.tty.terminal/TerminalParser.kittyDisambiguateEscapeCodes.<set-kittyDisambiguateEscapeCodes>|<set-kittyDisambiguateEscapeCodes>(kotlin.Boolean){}[0]
-    final var xtermExtendedUtf8Mouse // com.jakewharton.mosaic.tty.terminal/TerminalParser.xtermExtendedUtf8Mouse|{}xtermExtendedUtf8Mouse[0]
-        final fun <get-xtermExtendedUtf8Mouse>(): kotlin/Boolean // com.jakewharton.mosaic.tty.terminal/TerminalParser.xtermExtendedUtf8Mouse.<get-xtermExtendedUtf8Mouse>|<get-xtermExtendedUtf8Mouse>(){}[0]
-        final fun <set-xtermExtendedUtf8Mouse>(kotlin/Boolean) // com.jakewharton.mosaic.tty.terminal/TerminalParser.xtermExtendedUtf8Mouse.<set-xtermExtendedUtf8Mouse>|<set-xtermExtendedUtf8Mouse>(kotlin.Boolean){}[0]
+    final var kittyDisambiguateEscapeCodes // com.jakewharton.mosaic.tty.terminal/EventParser.kittyDisambiguateEscapeCodes|{}kittyDisambiguateEscapeCodes[0]
+        final fun <get-kittyDisambiguateEscapeCodes>(): kotlin/Boolean // com.jakewharton.mosaic.tty.terminal/EventParser.kittyDisambiguateEscapeCodes.<get-kittyDisambiguateEscapeCodes>|<get-kittyDisambiguateEscapeCodes>(){}[0]
+        final fun <set-kittyDisambiguateEscapeCodes>(kotlin/Boolean) // com.jakewharton.mosaic.tty.terminal/EventParser.kittyDisambiguateEscapeCodes.<set-kittyDisambiguateEscapeCodes>|<set-kittyDisambiguateEscapeCodes>(kotlin.Boolean){}[0]
+    final var xtermExtendedUtf8Mouse // com.jakewharton.mosaic.tty.terminal/EventParser.xtermExtendedUtf8Mouse|{}xtermExtendedUtf8Mouse[0]
+        final fun <get-xtermExtendedUtf8Mouse>(): kotlin/Boolean // com.jakewharton.mosaic.tty.terminal/EventParser.xtermExtendedUtf8Mouse.<get-xtermExtendedUtf8Mouse>|<get-xtermExtendedUtf8Mouse>(){}[0]
+        final fun <set-xtermExtendedUtf8Mouse>(kotlin/Boolean) // com.jakewharton.mosaic.tty.terminal/EventParser.xtermExtendedUtf8Mouse.<set-xtermExtendedUtf8Mouse>|<set-xtermExtendedUtf8Mouse>(kotlin.Boolean){}[0]
 
-    final fun copyBuffer(): kotlin/ByteArray // com.jakewharton.mosaic.tty.terminal/TerminalParser.copyBuffer|copyBuffer(){}[0]
-    final fun debugNext(): kotlin/Pair<com.jakewharton.mosaic.terminal/Event, kotlin/ByteArray>? // com.jakewharton.mosaic.tty.terminal/TerminalParser.debugNext|debugNext(){}[0]
-    final fun next(): com.jakewharton.mosaic.terminal/Event? // com.jakewharton.mosaic.tty.terminal/TerminalParser.next|next(){}[0]
+    final fun copyBuffer(): kotlin/ByteArray // com.jakewharton.mosaic.tty.terminal/EventParser.copyBuffer|copyBuffer(){}[0]
+    final fun debugNext(): kotlin/Pair<com.jakewharton.mosaic.terminal/Event, kotlin/ByteArray>? // com.jakewharton.mosaic.tty.terminal/EventParser.debugNext|debugNext(){}[0]
+    final fun next(): com.jakewharton.mosaic.terminal/Event? // com.jakewharton.mosaic.tty.terminal/EventParser.next|next(){}[0]
 }
 
 final suspend fun (com.jakewharton.mosaic.tty/Tty).com.jakewharton.mosaic.tty.terminal/useAsTerminal(kotlin/Boolean = ..., kotlin.coroutines/SuspendFunction1<com.jakewharton.mosaic.terminal/Terminal, kotlin/Unit>) // com.jakewharton.mosaic.tty.terminal/useAsTerminal|useAsTerminal@com.jakewharton.mosaic.tty.Tty(kotlin.Boolean;kotlin.coroutines.SuspendFunction1<com.jakewharton.mosaic.terminal.Terminal,kotlin.Unit>){}[0]

--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/EventParser.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/EventParser.kt
@@ -26,7 +26,7 @@ import com.jakewharton.mosaic.terminal.XtermPixelSizeEvent
 import com.jakewharton.mosaic.tty.Tty
 import kotlin.concurrent.Volatile
 
-public class TerminalParser(
+public class EventParser(
 	private val tty: Tty,
 ) {
 	private companion object {

--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/Terminal.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/Terminal.kt
@@ -98,7 +98,7 @@ public suspend fun Tty.useAsTerminal(
 		},
 		block = {
 			launch(Dispatchers.IO) {
-				val parser = TerminalParser(this@useAsTerminal)
+				val parser = EventParser(this@useAsTerminal)
 				while (true) {
 					val event = parser.next() ?: break
 					events.trySend(event)

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/BaseEventParserTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/BaseEventParserTest.kt
@@ -6,10 +6,10 @@ import com.jakewharton.mosaic.tty.TestTty
 import kotlin.test.AfterTest
 import kotlinx.coroutines.test.runTest
 
-abstract class BaseTerminalParserTest {
+abstract class BaseEventParserTest {
 	internal val testTty = TestTty.create()
 	private val tty = testTty.tty
-	internal val parser = TerminalParser(tty)
+	internal val parser = EventParser(tty)
 
 	@AfterTest fun after() = runTest {
 		testTty.close()

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiBracketedPasteEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiBracketedPasteEventTest.kt
@@ -6,7 +6,7 @@ import com.jakewharton.mosaic.terminal.BracketedPasteEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiBracketedPasteEventTest : BaseTerminalParserTest() {
+class EventParserCsiBracketedPasteEventTest : BaseEventParserTest() {
 	@Test fun pasteStart() = runTest {
 		testTty.writeHex("1b5b3230307e")
 		assertThat(parser.next()).isEqualTo(BracketedPasteEvent(start = true))

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiDecModeReportEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiDecModeReportEventTest.kt
@@ -12,7 +12,7 @@ import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiDecModeReportEventTest : BaseTerminalParserTest() {
+class EventParserCsiDecModeReportEventTest : BaseEventParserTest() {
 	@Test fun settings() = runTest {
 		testTty.writeHex("1b5b3f313030343b302479")
 		assertThat(parser.next()).isEqualTo(

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiFocusEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiFocusEventTest.kt
@@ -6,7 +6,7 @@ import com.jakewharton.mosaic.terminal.FocusEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiFocusEventTest : BaseTerminalParserTest() {
+class EventParserCsiFocusEventTest : BaseEventParserTest() {
 	@Test fun focusedTrue() = runTest {
 		testTty.writeHex("1b5b49")
 		assertThat(parser.next()).isEqualTo(FocusEvent(focused = true))

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiKeyboardEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiKeyboardEventTest.kt
@@ -22,7 +22,7 @@ import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiKeyboardEventTest : BaseTerminalParserTest() {
+class EventParserCsiKeyboardEventTest : BaseEventParserTest() {
 	@Test fun up() = runTest {
 		testTty.writeHex("1b5b41")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Up))

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiKittyKeyboardEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiKittyKeyboardEventTest.kt
@@ -7,7 +7,7 @@ import com.jakewharton.mosaic.terminal.KeyboardEvent.Companion.ModifierShift
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiKittyKeyboardEventTest : BaseTerminalParserTest() {
+class EventParserCsiKittyKeyboardEventTest : BaseEventParserTest() {
 	@Test fun h() = runTest {
 		testTty.writeHex("1b5b31303475")
 		assertThat(parser.next()).isEqualTo(

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiKittyKeyboardQueryEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiKittyKeyboardQueryEventTest.kt
@@ -7,7 +7,7 @@ import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiKittyKeyboardQueryEventTest : BaseTerminalParserTest() {
+class EventParserCsiKittyKeyboardQueryEventTest : BaseEventParserTest() {
 	@Test fun flagsNone() = runTest {
 		testTty.writeHex("1b5b3f3075")
 		assertThat(parser.next()).isEqualTo(KittyKeyboardQueryEvent(0))

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiMouseEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiMouseEventTest.kt
@@ -8,7 +8,7 @@ import com.jakewharton.mosaic.terminal.MouseEvent.Type
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiMouseEventTest : BaseTerminalParserTest() {
+class EventParserCsiMouseEventTest : BaseEventParserTest() {
 	@Test fun motion() = runTest {
 		testTty.writeHex("1b5b4d434837")
 		assertThat(parser.next()).isEqualTo(

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiOperatingStatusResponseEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiOperatingStatusResponseEventTest.kt
@@ -7,7 +7,7 @@ import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiOperatingStatusResponseEventTest : BaseTerminalParserTest() {
+class EventParserCsiOperatingStatusResponseEventTest : BaseEventParserTest() {
 	@Test fun ok() = runTest {
 		testTty.writeHex("1b5b306e")
 		assertThat(parser.next()).isEqualTo(OperatingStatusResponseEvent(ok = true))

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiPrimaryDeviceAttributesEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiPrimaryDeviceAttributesEventTest.kt
@@ -7,7 +7,7 @@ import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiPrimaryDeviceAttributesEventTest : BaseTerminalParserTest() {
+class EventParserCsiPrimaryDeviceAttributesEventTest : BaseEventParserTest() {
 	@Test fun noLeadingQuestionMarkIsUnknown() = runTest {
 		testTty.writeHex("1b5b303063")
 		assertThat(parser.next()).isEqualTo(

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiResizeEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiResizeEventTest.kt
@@ -7,7 +7,7 @@ import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiResizeEventTest : BaseTerminalParserTest() {
+class EventParserCsiResizeEventTest : BaseEventParserTest() {
 	@Test fun basic() = runTest {
 		testTty.writeHex("1b5b34383b313b323b333b3474")
 		assertThat(parser.next()).isEqualTo(ResizeEvent(2, 1, 4, 3))

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiSystemThemeEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiSystemThemeEventTest.kt
@@ -7,7 +7,7 @@ import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiSystemThemeEventTest : BaseTerminalParserTest() {
+class EventParserCsiSystemThemeEventTest : BaseEventParserTest() {
 	@Test fun dark() = runTest {
 		testTty.writeHex("1b5b3f3939373b316e")
 		assertThat(parser.next()).isEqualTo(SystemThemeEvent(isDark = true))

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiXtermCharacterSizeEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiXtermCharacterSizeEventTest.kt
@@ -7,7 +7,7 @@ import com.jakewharton.mosaic.terminal.XtermCharacterSizeEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiXtermCharacterSizeEventTest : BaseTerminalParserTest() {
+class EventParserCsiXtermCharacterSizeEventTest : BaseEventParserTest() {
 	@Test fun basic() = runTest {
 		testTty.writeHex("1b5b383b313b3274")
 		assertThat(parser.next()).isEqualTo(XtermCharacterSizeEvent(1, 2))

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiXtermPixelSizeEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiXtermPixelSizeEventTest.kt
@@ -7,7 +7,7 @@ import com.jakewharton.mosaic.terminal.XtermPixelSizeEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserCsiXtermPixelSizeEventTest : BaseTerminalParserTest() {
+class EventParserCsiXtermPixelSizeEventTest : BaseEventParserTest() {
 	@Test fun basic() = runTest {
 		testTty.writeHex("1b5b343b313b3274")
 		assertThat(parser.next()).isEqualTo(XtermPixelSizeEvent(1, 2))

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserDcsCapabilityQueryEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserDcsCapabilityQueryEventTest.kt
@@ -7,7 +7,7 @@ import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserDcsCapabilityQueryEventTest : BaseTerminalParserTest() {
+class EventParserDcsCapabilityQueryEventTest : BaseEventParserTest() {
 	@Test fun unknownStatus() = runTest {
 		testTty.writeHex("1b50322b721b5c")
 		assertThat(parser.next()).isEqualTo(

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserDcsEventVersionEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserDcsEventVersionEventTest.kt
@@ -6,7 +6,7 @@ import com.jakewharton.mosaic.terminal.TerminalVersionEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserDcsTerminalVersionEventTest : BaseTerminalParserTest() {
+class EventParserDcsEventVersionEventTest : BaseEventParserTest() {
 	@Test fun empty() = runTest {
 		testTty.writeHex("1b503e7c1b5c")
 		assertThat(parser.next()).isEqualTo(TerminalVersionEvent(""))

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserDcsTertiaryDeviceAttributesEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserDcsTertiaryDeviceAttributesEventTest.kt
@@ -7,7 +7,7 @@ import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserDcsTertiaryDeviceAttributesEventTest : BaseTerminalParserTest() {
+class EventParserDcsTertiaryDeviceAttributesEventTest : BaseEventParserTest() {
 	@Test fun zeroes() = runTest {
 		testTty.writeHex("1b50217c30303030303030301b5c")
 		assertThat(parser.next()).isEqualTo(TertiaryDeviceAttributesEvent(0, 0))

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserGroundKeyboardEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserGroundKeyboardEventTest.kt
@@ -7,7 +7,7 @@ import com.jakewharton.mosaic.terminal.KeyboardEvent.Companion.ModifierCtrl
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserGroundKeyboardEventTest : BaseTerminalParserTest() {
+class EventParserGroundKeyboardEventTest : BaseEventParserTest() {
 	@Test fun graphic() = runTest {
 		for (codepoint in 0x20..0x7f) {
 			val hex = codepoint.toString(16)

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserOscKittyPointerQueryEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserOscKittyPointerQueryEventTest.kt
@@ -8,7 +8,7 @@ import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserOscKittyPointerQueryEventTest : BaseTerminalParserTest() {
+class EventParserOscKittyPointerQueryEventTest : BaseEventParserTest() {
 	@Test fun emptyFails() = runTest {
 		testTty.writeHex("1b5d32323b1b5c")
 		assertThat(parser.next()).isEqualTo(

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserSs3KeyboardEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserSs3KeyboardEventTest.kt
@@ -18,7 +18,7 @@ import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
-class TerminalParserSs3KeyboardEventTest : BaseTerminalParserTest() {
+class EventParserSs3KeyboardEventTest : BaseEventParserTest() {
 	@Test fun up() = runTest {
 		testTty.writeHex("1b4f41")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Up))

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserTest.kt
@@ -5,7 +5,7 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.OperatingStatusResponseEvent
 import kotlin.test.Test
 
-class TerminalParserTest : BaseTerminalParserTest() {
+class EventParserTest : BaseEventParserTest() {
 	@Test fun copyBuffer() {
 		assertThat(parser.copyBuffer().toHexString()).isEqualTo("")
 		testTty.writeHex("1b5b306e1b5b306e")

--- a/tools/raw-mode-echo/src/commonMain/kotlin/example/main.kt
+++ b/tools/raw-mode-echo/src/commonMain/kotlin/example/main.kt
@@ -12,7 +12,7 @@ import com.jakewharton.finalization.withFinalizationHook
 import com.jakewharton.mosaic.terminal.KeyboardEvent
 import com.jakewharton.mosaic.terminal.KeyboardEvent.Companion.ModifierCtrl
 import com.jakewharton.mosaic.tty.Tty
-import com.jakewharton.mosaic.tty.terminal.TerminalParser
+import com.jakewharton.mosaic.tty.terminal.EventParser
 import kotlin.jvm.JvmName
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.awaitCancellation
@@ -113,7 +113,7 @@ private class RawModeEchoCommand : CliktCommand("raw-mode-echo") {
 					first = false
 				}
 
-				val parser = TerminalParser(tty)
+				val parser = EventParser(tty)
 				while (true) {
 					val (event, bytes) = parser.debugNext() ?: break
 


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
