### PR TITLE
Expose all events on `Terminal`

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.jakewharton.mosaic.layout.KeyEvent
 import com.jakewharton.mosaic.layout.MosaicNode
+import com.jakewharton.mosaic.terminal.KeyboardEvent
 import com.jakewharton.mosaic.terminal.Terminal
 import com.jakewharton.mosaic.tty.Tty
 import com.jakewharton.mosaic.tty.terminal.useAsTerminal
@@ -278,8 +279,9 @@ internal class MosaicComposition(
 				externalClock.withFrameNanos { nanos ->
 					// Drain any pending key events before triggering the frame.
 					while (true) {
-						val keyboardEvent = terminal.keyEvents.tryReceive().getOrNull() ?: break
-						val keyEvent = keyboardEvent.toKeyEventOrNull() ?: continue
+						val event = terminal.events.tryReceive().getOrNull() ?: break
+						if (event !is KeyboardEvent) continue
+						val keyEvent = event.toKeyEventOrNull() ?: continue
 						val keyHandled = rootNode.sendKeyEvent(keyEvent)
 						if (!keyHandled && keyEvent == ctrlC) {
 							job.cancel()

--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -263,7 +263,7 @@ public final class com/jakewharton/mosaic/terminal/SystemThemeEvent : com/jakewh
 
 public abstract interface class com/jakewharton/mosaic/terminal/Terminal {
 	public abstract fun getCapabilities ()Lcom/jakewharton/mosaic/terminal/Terminal$Capabilities;
-	public abstract fun getKeyEvents ()Lkotlinx/coroutines/channels/ReceiveChannel;
+	public abstract fun getEvents ()Lkotlinx/coroutines/channels/ReceiveChannel;
 	public abstract fun getState ()Lcom/jakewharton/mosaic/terminal/Terminal$State;
 }
 

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -22,8 +22,8 @@ final enum class com.jakewharton.mosaic.terminal/AnsiLevel : kotlin/Enum<com.jak
 abstract interface com.jakewharton.mosaic.terminal/Terminal { // com.jakewharton.mosaic.terminal/Terminal|null[0]
     abstract val capabilities // com.jakewharton.mosaic.terminal/Terminal.capabilities|{}capabilities[0]
         abstract fun <get-capabilities>(): com.jakewharton.mosaic.terminal/Terminal.Capabilities // com.jakewharton.mosaic.terminal/Terminal.capabilities.<get-capabilities>|<get-capabilities>(){}[0]
-    abstract val keyEvents // com.jakewharton.mosaic.terminal/Terminal.keyEvents|{}keyEvents[0]
-        abstract fun <get-keyEvents>(): kotlinx.coroutines.channels/ReceiveChannel<com.jakewharton.mosaic.terminal/KeyboardEvent> // com.jakewharton.mosaic.terminal/Terminal.keyEvents.<get-keyEvents>|<get-keyEvents>(){}[0]
+    abstract val events // com.jakewharton.mosaic.terminal/Terminal.events|{}events[0]
+        abstract fun <get-events>(): kotlinx.coroutines.channels/ReceiveChannel<com.jakewharton.mosaic.terminal/Event> // com.jakewharton.mosaic.terminal/Terminal.events.<get-events>|<get-events>(){}[0]
     abstract val state // com.jakewharton.mosaic.terminal/Terminal.state|{}state[0]
         abstract fun <get-state>(): com.jakewharton.mosaic.terminal/Terminal.State // com.jakewharton.mosaic.terminal/Terminal.state.<get-state>|<get-state>(){}[0]
 

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/Terminal.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/Terminal.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
 public interface Terminal {
 	public val state: State
 	public val capabilities: Capabilities
-	public val keyEvents: ReceiveChannel<KeyboardEvent>
+	public val events: ReceiveChannel<Event>
 
 	public interface State {
 		public val focused: StateFlow<Boolean>

--- a/mosaic-testing/api/mosaic-testing.api
+++ b/mosaic-testing/api/mosaic-testing.api
@@ -30,8 +30,8 @@ public final class com/jakewharton/mosaic/testing/TestTerminal : com/jakewharton
 	public fun <init> (Lcom/jakewharton/mosaic/terminal/Terminal$Capabilities;)V
 	public synthetic fun <init> (Lcom/jakewharton/mosaic/terminal/Terminal$Capabilities;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCapabilities ()Lcom/jakewharton/mosaic/terminal/Terminal$Capabilities;
-	public fun getKeyEvents ()Lkotlinx/coroutines/channels/Channel;
-	public synthetic fun getKeyEvents ()Lkotlinx/coroutines/channels/ReceiveChannel;
+	public fun getEvents ()Lkotlinx/coroutines/channels/Channel;
+	public synthetic fun getEvents ()Lkotlinx/coroutines/channels/ReceiveChannel;
 	public synthetic fun getState ()Lcom/jakewharton/mosaic/terminal/Terminal$State;
 	public fun getState ()Lcom/jakewharton/mosaic/testing/TestTerminal$State;
 }

--- a/mosaic-testing/api/mosaic-testing.klib.api
+++ b/mosaic-testing/api/mosaic-testing.klib.api
@@ -24,8 +24,8 @@ final class com.jakewharton.mosaic.testing/TestTerminal : com.jakewharton.mosaic
 
     final val capabilities // com.jakewharton.mosaic.testing/TestTerminal.capabilities|{}capabilities[0]
         final fun <get-capabilities>(): com.jakewharton.mosaic.terminal/Terminal.Capabilities // com.jakewharton.mosaic.testing/TestTerminal.capabilities.<get-capabilities>|<get-capabilities>(){}[0]
-    final val keyEvents // com.jakewharton.mosaic.testing/TestTerminal.keyEvents|{}keyEvents[0]
-        final fun <get-keyEvents>(): kotlinx.coroutines.channels/Channel<com.jakewharton.mosaic.terminal/KeyboardEvent> // com.jakewharton.mosaic.testing/TestTerminal.keyEvents.<get-keyEvents>|<get-keyEvents>(){}[0]
+    final val events // com.jakewharton.mosaic.testing/TestTerminal.events|{}events[0]
+        final fun <get-events>(): kotlinx.coroutines.channels/Channel<com.jakewharton.mosaic.terminal/Event> // com.jakewharton.mosaic.testing/TestTerminal.events.<get-events>|<get-events>(){}[0]
     final val state // com.jakewharton.mosaic.testing/TestTerminal.state|{}state[0]
         final fun <get-state>(): com.jakewharton.mosaic.testing/TestTerminal.State // com.jakewharton.mosaic.testing/TestTerminal.state.<get-state>|<get-state>(){}[0]
 

--- a/mosaic-testing/src/commonMain/kotlin/com/jakewharton/mosaic/testing/TestTerminal.kt
+++ b/mosaic-testing/src/commonMain/kotlin/com/jakewharton/mosaic/testing/TestTerminal.kt
@@ -1,7 +1,7 @@
 package com.jakewharton.mosaic.testing
 
 import com.jakewharton.mosaic.terminal.AnsiLevel
-import com.jakewharton.mosaic.terminal.KeyboardEvent
+import com.jakewharton.mosaic.terminal.Event
 import com.jakewharton.mosaic.terminal.Terminal
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
@@ -11,7 +11,7 @@ public class TestTerminal(
 	override val capabilities: Terminal.Capabilities = Capabilities(),
 ) : Terminal {
 	override val state: State = State()
-	override val keyEvents: Channel<KeyboardEvent> = Channel(UNLIMITED)
+	override val events: Channel<Event> = Channel(UNLIMITED)
 
 	public class State : Terminal.State {
 		override val focused: MutableStateFlow<Boolean> = MutableStateFlow(true)

--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserTtyCallback.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserTtyCallback.kt
@@ -4,14 +4,19 @@ import com.jakewharton.mosaic.terminal.DebugEvent
 import com.jakewharton.mosaic.terminal.Event
 import com.jakewharton.mosaic.terminal.FocusEvent
 import com.jakewharton.mosaic.terminal.ResizeEvent
+import com.jakewharton.mosaic.terminal.Terminal
 import com.jakewharton.mosaic.tty.Tty
 import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.MutableStateFlow
 
-internal class EventChannelTtyCallback(
+internal class EventParserTtyCallback(
+	private val focused: MutableStateFlow<Boolean>,
+	private val size: MutableStateFlow<Terminal.Size>,
 	private val events: SendChannel<Event>,
 	private val emitDebugEvents: Boolean,
 ) : Tty.Callback {
 	override fun onFocus(focused: Boolean) {
+		this.focused.value = focused
 		sendEvent(FocusEvent(focused))
 	}
 
@@ -24,6 +29,7 @@ internal class EventChannelTtyCallback(
 	}
 
 	override fun onResize(columns: Int, rows: Int, width: Int, height: Int) {
+		size.value = Terminal.Size(columns, rows, width, height)
 		sendEvent(ResizeEvent(columns, rows, width, height))
 	}
 

--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminal.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminal.kt
@@ -8,7 +8,6 @@ import com.jakewharton.mosaic.terminal.DecModeReportEvent
 import com.jakewharton.mosaic.terminal.DecModeReportEvent.Setting
 import com.jakewharton.mosaic.terminal.Event
 import com.jakewharton.mosaic.terminal.FocusEvent
-import com.jakewharton.mosaic.terminal.KeyboardEvent
 import com.jakewharton.mosaic.terminal.KittyGraphicsEvent
 import com.jakewharton.mosaic.terminal.KittyKeyboardQueryEvent
 import com.jakewharton.mosaic.terminal.KittyNotificationEvent
@@ -24,9 +23,9 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -36,7 +35,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 private class TtyTerminal(
 	override val state: Terminal.State,
 	override val capabilities: Terminal.Capabilities,
-	override val keyEvents: ReceiveChannel<KeyboardEvent>,
+	override val events: ReceiveChannel<Event>,
 ) : Terminal {
 	class State(
 		override val focused: StateFlow<Boolean>,
@@ -68,9 +67,13 @@ public suspend fun Tty.useAsTerminal(
 	emitDebugEvents: Boolean = false,
 	block: suspend (Terminal) -> Unit,
 ) {
-	val events = Channel<Event>(UNLIMITED)
+	val focused = MutableStateFlow(true)
+	val systemTheme = MutableStateFlow(false)
+	val size = MutableStateFlow(Terminal.Size.Default)
 
-	setCallback(EventChannelTtyCallback(events, emitDebugEvents))
+	val events = Channel<Event>(64, onBufferOverflow = DROP_OLDEST)
+
+	setCallback(EventParserTtyCallback(focused, size, events, emitDebugEvents))
 
 	// Each of these will become true when their respective feature is recognized by the terminal
 	// and was not already configured to our desired setting. Revert each toggled setting on exit.
@@ -100,22 +103,6 @@ public suspend fun Tty.useAsTerminal(
 			}
 		},
 		block = {
-			launch(Dispatchers.IO) {
-				val parser = EventParser(this@useAsTerminal)
-				if (!emitDebugEvents) {
-					while (true) {
-						val event = parser.next() ?: break
-						events.trySend(event)
-					}
-				} else {
-					while (true) {
-						val debugEvent = parser.nextDebug() ?: break
-						events.trySend(debugEvent.event)
-						events.trySend(debugEvent)
-					}
-				}
-			}
-
 			print("${CSI}0c")
 			var stage = StageDeviceAttributes
 
@@ -126,147 +113,146 @@ public suspend fun Tty.useAsTerminal(
 			var supportsKittyPointerShape = false
 			var supportsKittyUnderlines = false
 
-			val focused = MutableStateFlow(true)
-			val systemTheme = MutableStateFlow(false)
-			val size = MutableStateFlow(Terminal.Size.Default)
-
-			val keyEvents = Channel<KeyboardEvent>(64, onBufferOverflow = DROP_OLDEST)
-
 			val bootstrapDone = CompletableDeferred<Unit>()
-			val eventJob = launch(start = UNDISPATCHED) {
-				try {
-					for (event in events) {
-						if (DebugBootstrap) {
-							if (stage != StageNormalOperation) {
-								print("$event\r\n")
-							}
-						}
-						when (event) {
-							is PrimaryDeviceAttributesEvent -> {
-								if (stage == StageNormalOperation) continue
-
-								if (event.id == 1) {
-									// VT100 terminals can't handle most of the other queries so just bail.
-									stage = StageNormalOperation
-									bootstrapDone.complete(Unit)
-									continue
-								}
-
-								stage = StageCapabilityQueries
-								print(
-									"$CSI?${cursorMode}\$p" +
-										"$CSI?${focusMode}\$p" +
-										"$CSI?${synchronizedRenderingMode}\$p" +
-										"$CSI?${systemThemeMode}\$p" +
-										"$CSI?${inBandResizeMode}\$p" +
-										"$CSI?u" + // Kitty keyboard
-										"${APC}Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA$ST" + // Kitty graphics
-										"${OSC}99;i=1:p=?$ST" + // Kitty notifications
-										"${OSC}22;?__current__$ST" + // Kitty pointer shape
-										"$DCS+q5375$ST" + // Kitty underline ("Su")
-										"${CSI}5n", // DSR (end marker)
-								)
-							}
-							is DecModeReportEvent -> {
-								if (stage != StageCapabilityQueries) continue
-
-								when (event.mode) {
-									cursorMode -> {
-										if (event.setting == Setting.Set) {
-											toggleCursor = true
-											print(cursorDisable)
-										}
-									}
-									focusMode -> {
-										if (event.setting == Setting.Reset) {
-											toggleFocus = true
-											// Enabling focus notification _might_ trigger an initial event. There is
-											// otherwise no explicit way to request the initial value.
-											print(focusEnable)
-										}
-									}
-									synchronizedRenderingMode -> {
-										if (event.setting == Setting.Reset) {
-											supportsSynchronizedRendering = true
-										}
-									}
-									systemThemeMode -> {
-										if (event.setting == Setting.Reset) {
-											toggleSystemTheme = true
-											print(
-												systemThemeEnable +
-													"$CSI?996n", // Current system theme query.
-											)
-										}
-									}
-									inBandResizeMode -> {
-										if (event.setting == Setting.Reset) {
-											toggleInBandResize = true
-											// Enabling in-band resize will trigger an initial event.
-											print(inBandResizeEnable)
-										}
-									}
-								}
-							}
-							is OperatingStatusResponseEvent -> {
-								if (stage == StageCapabilityQueries) {
-									if (toggleFocus or toggleInBandResize or toggleSystemTheme) {
-										// By enabling these modes (or by sending an explicit default value query after
-										// enabling the mode) wait for a reply about the default with a second DSR.
-										stage = StageDefaultQueries
-										print("${CSI}5n")
-									} else {
-										stage = StageNormalOperation
-										bootstrapDone.complete(Unit)
-									}
-								} else if (stage == StageDefaultQueries) {
-									bootstrapDone.complete(Unit)
-								}
-							}
-							is KittyKeyboardQueryEvent -> {
-								if (stage == StageCapabilityQueries) {
-									supportsKittyKeyboard = true
-								}
-							}
-							is KittyGraphicsEvent -> {
-								if (stage == StageCapabilityQueries) {
-									supportsKittyGraphics = true
-								}
-							}
-							is KittyPointerQueryEvent -> {
-								if (stage == StageCapabilityQueries) {
-									supportsKittyPointerShape = true
-								}
-							}
-							is KittyNotificationEvent -> {
-								if (stage == StageCapabilityQueries) {
-									supportsKittyNotifications = true
-								}
-							}
-							is CapabilityQueryEvent -> {
-								if (stage == StageCapabilityQueries && event.success) {
-									if ("Su" in event.data) {
-										supportsKittyUnderlines = true
-									}
-								}
-							}
-
-							is FocusEvent -> {
-								focused.value = event.focused
-							}
-							is KeyboardEvent -> {
-								keyEvents.trySend(event)
-							}
-							is ResizeEvent -> {
-								size.value = Terminal.Size(event.columns, event.rows, event.width, event.height)
-							}
-							is SystemThemeEvent -> {
-								systemTheme.value = event.isDark
-							}
-
-							else -> {}
+			launch(Dispatchers.IO) {
+				val parser = EventParser(this@useAsTerminal)
+				while (true) {
+					val event = parser.next() ?: break
+					if (DebugBootstrap) {
+						if (stage != StageNormalOperation) {
+							print("$event\r\n")
 						}
 					}
+					when (event) {
+						is PrimaryDeviceAttributesEvent -> {
+							if (stage == StageNormalOperation) continue
+
+							if (event.id == 1) {
+								// VT100 terminals can't handle most of the other queries so just bail.
+								stage = StageNormalOperation
+								bootstrapDone.complete(Unit)
+								continue
+							}
+
+							stage = StageCapabilityQueries
+							print(
+								"$CSI?${cursorMode}\$p" +
+									"$CSI?${focusMode}\$p" +
+									"$CSI?${synchronizedRenderingMode}\$p" +
+									"$CSI?${systemThemeMode}\$p" +
+									"$CSI?${inBandResizeMode}\$p" +
+									"$CSI?u" + // Kitty keyboard
+									"${APC}Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA$ST" + // Kitty graphics
+									"${OSC}99;i=1:p=?$ST" + // Kitty notifications
+									"${OSC}22;?__current__$ST" + // Kitty pointer shape
+									"$DCS+q5375$ST" + // Kitty underline ("Su")
+									"${CSI}5n", // DSR (end marker)
+							)
+						}
+						is DecModeReportEvent -> {
+							if (stage != StageCapabilityQueries) continue
+
+							when (event.mode) {
+								cursorMode -> {
+									if (event.setting == Setting.Set) {
+										toggleCursor = true
+										print(cursorDisable)
+									}
+								}
+								focusMode -> {
+									if (event.setting == Setting.Reset) {
+										toggleFocus = true
+										// Enabling focus notification _might_ trigger an initial event. There is
+										// otherwise no explicit way to request the initial value.
+										print(focusEnable)
+									}
+								}
+								synchronizedRenderingMode -> {
+									if (event.setting == Setting.Reset) {
+										supportsSynchronizedRendering = true
+									}
+								}
+								systemThemeMode -> {
+									if (event.setting == Setting.Reset) {
+										toggleSystemTheme = true
+										print(
+											systemThemeEnable +
+												"$CSI?996n", // Current system theme query.
+										)
+									}
+								}
+								inBandResizeMode -> {
+									if (event.setting == Setting.Reset) {
+										toggleInBandResize = true
+										// Enabling in-band resize will trigger an initial event.
+										print(inBandResizeEnable)
+									}
+								}
+							}
+						}
+						is OperatingStatusResponseEvent -> {
+							if (stage == StageCapabilityQueries) {
+								if (toggleFocus or toggleInBandResize or toggleSystemTheme) {
+									// By enabling these modes (or by sending an explicit default value query after
+									// enabling the mode) wait for a reply about the default with a second DSR.
+									stage = StageDefaultQueries
+									print("${CSI}5n")
+								} else {
+									stage = StageNormalOperation
+									bootstrapDone.complete(Unit)
+								}
+							} else if (stage == StageDefaultQueries) {
+								bootstrapDone.complete(Unit)
+							}
+						}
+						is KittyKeyboardQueryEvent -> {
+							if (stage == StageCapabilityQueries) {
+								supportsKittyKeyboard = true
+							}
+						}
+						is KittyGraphicsEvent -> {
+							if (stage == StageCapabilityQueries) {
+								supportsKittyGraphics = true
+							}
+						}
+						is KittyPointerQueryEvent -> {
+							if (stage == StageCapabilityQueries) {
+								supportsKittyPointerShape = true
+							}
+						}
+						is KittyNotificationEvent -> {
+							if (stage == StageCapabilityQueries) {
+								supportsKittyNotifications = true
+							}
+						}
+						is CapabilityQueryEvent -> {
+							if (stage == StageCapabilityQueries && event.success) {
+								if ("Su" in event.data) {
+									supportsKittyUnderlines = true
+								}
+							}
+						}
+
+						is FocusEvent -> {
+							focused.value = event.focused
+						}
+						is ResizeEvent -> {
+							size.value = Terminal.Size(event.columns, event.rows, event.width, event.height)
+						}
+						is SystemThemeEvent -> {
+							systemTheme.value = event.isDark
+						}
+
+						else -> {}
+					}
+
+					events.trySend(event)
+				}
+			}
+
+			val interruptJob = launch(start = UNDISPATCHED) {
+				try {
+					awaitCancellation()
 				} finally {
 					// When cancelled (from signal or normally), wake up the reader parse loop so it can exit.
 					interruptRead()
@@ -310,12 +296,12 @@ public suspend fun Tty.useAsTerminal(
 					kittyPointerShape = supportsKittyPointerShape,
 					synchronizedRendering = supportsSynchronizedRendering,
 				),
-				keyEvents = keyEvents,
+				events = events,
 			)
 
 			block(terminal)
 
-			eventJob.cancel()
+			interruptJob.cancel()
 		},
 	)
 }


### PR DESCRIPTION
Do not use a channel to communicate between the parser and the state machine. Process directly, and then forward all events to the channel.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
