### PR TITLE
Only do size fallback if input is a TTY

### DIFF
--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminal.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminal.kt
@@ -289,7 +289,7 @@ public suspend fun Tty.useAsTerminal(
 				print("\r\n")
 			}
 
-			if (!toggleInBandResize) {
+			if (!toggleInBandResize && isInputTty()) {
 				currentSize().let { (columns, rows) ->
 					size.value = Terminal.Size(columns, rows)
 				}


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
