### PR TITLE
Always go raw, but add a policy to skip TTY binding

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -252,8 +252,6 @@ jobs:
         sample:
           - counter
           - jest
-    env:
-      MOSAIC_RAW_MODE: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/mosaic-runtime/api/mosaic-runtime.api
+++ b/mosaic-runtime/api/mosaic-runtime.api
@@ -17,6 +17,7 @@ public final class com/jakewharton/mosaic/MosaicKt {
 }
 
 public final class com/jakewharton/mosaic/NonInteractivePolicy : java/lang/Enum {
+	public static final field AssumeAndIgnore Lcom/jakewharton/mosaic/NonInteractivePolicy;
 	public static final field Exit Lcom/jakewharton/mosaic/NonInteractivePolicy;
 	public static final field Ignore Lcom/jakewharton/mosaic/NonInteractivePolicy;
 	public static final field Return Lcom/jakewharton/mosaic/NonInteractivePolicy;

--- a/mosaic-runtime/api/mosaic-runtime.klib.api
+++ b/mosaic-runtime/api/mosaic-runtime.klib.api
@@ -26,6 +26,7 @@ final enum class com.jakewharton.mosaic.layout/IntrinsicSize : kotlin/Enum<com.j
 }
 
 final enum class com.jakewharton.mosaic/NonInteractivePolicy : kotlin/Enum<com.jakewharton.mosaic/NonInteractivePolicy> { // com.jakewharton.mosaic/NonInteractivePolicy|null[0]
+    enum entry AssumeAndIgnore // com.jakewharton.mosaic/NonInteractivePolicy.AssumeAndIgnore|null[0]
     enum entry Exit // com.jakewharton.mosaic/NonInteractivePolicy.Exit|null[0]
     enum entry Ignore // com.jakewharton.mosaic/NonInteractivePolicy.Ignore|null[0]
     enum entry Return // com.jakewharton.mosaic/NonInteractivePolicy.Return|null[0]

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.jakewharton.mosaic.NonInteractivePolicy.AssumeAndIgnore
 import com.jakewharton.mosaic.NonInteractivePolicy.Exit
 import com.jakewharton.mosaic.NonInteractivePolicy.Ignore
 import com.jakewharton.mosaic.NonInteractivePolicy.Return
@@ -59,17 +60,22 @@ public fun runMosaicBlocking(
 }
 
 public suspend fun runMosaic(
-	nonInteractivePolicy: NonInteractivePolicy = Exit,
+	onNonInteractive: NonInteractivePolicy = Exit,
 	content: @Composable () -> Unit,
 ): Boolean = coroutineScope {
-	val terminal = Tty.tryBind()
-		?.asTerminalIn(this)
-		?: when (nonInteractivePolicy) {
-			Exit -> nonInteractiveExit()
-			Throw -> throw IllegalStateException(NonInteractiveMessage)
-			Ignore -> NonInteractiveTerminal
-			Return -> return@coroutineScope false
-		}
+	val terminal = if (onNonInteractive != AssumeAndIgnore) {
+		Tty.tryBind()
+			?.asTerminalIn(this)
+			?: when (onNonInteractive) {
+				Exit -> nonInteractiveExit()
+				Throw -> throw IllegalStateException(NonInteractiveMessage)
+				Return -> return@coroutineScope false
+				Ignore -> NonInteractiveTerminal
+				AssumeAndIgnore -> throw AssertionError()
+			}
+	} else {
+		NonInteractiveTerminal
+	}
 
 	terminal.use { terminal ->
 		val rendering = if (env("MOSAIC_DEBUG_RENDERING") == "true") {

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nonInteractive.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nonInteractive.kt
@@ -16,11 +16,14 @@ public enum class NonInteractivePolicy {
 	/** Throw an [IllegalStateException] with a non-interactive message. */
 	Throw,
 
+	/** Immediately return false. */
+	Return,
+
 	/** Continue running with a fake [Terminal] with default state, no capabilities, and no events. */
 	Ignore,
 
-	/** Immediately return false. */
-	Return,
+	/** Assume the absence of a TTY without checking, and proceed using [Ignore]. */
+	AssumeAndIgnore,
 }
 
 internal object NonInteractiveTerminal : Terminal, Terminal.State, Terminal.Capabilities {

--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminal.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminal.kt
@@ -74,10 +74,7 @@ public suspend fun Tty.asTerminalIn(
 ): Terminal {
 	// Entering raw mode can fail, so perform it before any additional control sequences which change
 	// settings. We also need to be in character mode to query capabilities with control sequences.
-	// TODO This should also be a parameter.
-	if (env("MOSAIC_RAW_MODE") != "false") {
-		enableRawMode()
-	}
+	enableRawMode()
 
 	val focused = MutableStateFlow(true)
 	val systemTheme = MutableStateFlow(false)


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
