### PR TITLE
Create `Terminal.Theme`, and use `Terminal.Size` more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changed:
 - Switched to our own terminal integration library. Report any issues with keyboard input, incorrect size reporting, or garbled output.
 - Only disable the cursor and emit synchronized rendering markers if the terminal reports support for those features.
 - `Static` function is now called `StaticEffect` to better indicate that it only renders its content once.
-- The runtime's `Terminal` was renamed to `TerminalState` to avoid conflict with new, lower-level `Terminal` type.
+- The runtime's `Terminal` was renamed to `TerminalState` to avoid conflict with new, lower-level `Terminal` type. Additionally, `TerminalState` now uses `Terminal.Theme` and `Terminal.Size` for exposing the theme and size, respectively.
 - `runMosaic` and `runMosaicBlocking` now accept a `NonInteractivePolicy` argument which dictates the behavior when Mosaic cannot connect directly to the TTY.
 
 Fixed:

--- a/mosaic-runtime/api/mosaic-runtime.api
+++ b/mosaic-runtime/api/mosaic-runtime.api
@@ -45,11 +45,11 @@ public final class com/jakewharton/mosaic/TerminalKt {
 
 public final class com/jakewharton/mosaic/TerminalState {
 	public static final field $stable I
-	public synthetic fun <init> (ZZJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLcom/jakewharton/mosaic/terminal/Terminal$Theme;Lcom/jakewharton/mosaic/terminal/Terminal$Size;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getDarkTheme ()Z
 	public final fun getFocused ()Z
-	public final fun getSize-Usd9Mdw ()J
+	public final fun getSize ()Lcom/jakewharton/mosaic/terminal/Terminal$Size;
+	public final fun getTheme ()Lcom/jakewharton/mosaic/terminal/Terminal$Theme;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/mosaic-runtime/api/mosaic-runtime.klib.api
+++ b/mosaic-runtime/api/mosaic-runtime.klib.api
@@ -401,14 +401,14 @@ final class com.jakewharton.mosaic/StaticLogger { // com.jakewharton.mosaic/Stat
 }
 
 final class com.jakewharton.mosaic/TerminalState { // com.jakewharton.mosaic/TerminalState|null[0]
-    constructor <init>(kotlin/Boolean, kotlin/Boolean, com.jakewharton.mosaic.ui.unit/IntSize) // com.jakewharton.mosaic/TerminalState.<init>|<init>(kotlin.Boolean;kotlin.Boolean;com.jakewharton.mosaic.ui.unit.IntSize){}[0]
+    constructor <init>(kotlin/Boolean, com.jakewharton.mosaic.terminal/Terminal.Theme, com.jakewharton.mosaic.terminal/Terminal.Size) // com.jakewharton.mosaic/TerminalState.<init>|<init>(kotlin.Boolean;com.jakewharton.mosaic.terminal.Terminal.Theme;com.jakewharton.mosaic.terminal.Terminal.Size){}[0]
 
-    final val darkTheme // com.jakewharton.mosaic/TerminalState.darkTheme|{}darkTheme[0]
-        final fun <get-darkTheme>(): kotlin/Boolean // com.jakewharton.mosaic/TerminalState.darkTheme.<get-darkTheme>|<get-darkTheme>(){}[0]
     final val focused // com.jakewharton.mosaic/TerminalState.focused|{}focused[0]
         final fun <get-focused>(): kotlin/Boolean // com.jakewharton.mosaic/TerminalState.focused.<get-focused>|<get-focused>(){}[0]
     final val size // com.jakewharton.mosaic/TerminalState.size|{}size[0]
-        final fun <get-size>(): com.jakewharton.mosaic.ui.unit/IntSize // com.jakewharton.mosaic/TerminalState.size.<get-size>|<get-size>(){}[0]
+        final fun <get-size>(): com.jakewharton.mosaic.terminal/Terminal.Size // com.jakewharton.mosaic/TerminalState.size.<get-size>|<get-size>(){}[0]
+    final val theme // com.jakewharton.mosaic/TerminalState.theme|{}theme[0]
+        final fun <get-theme>(): com.jakewharton.mosaic.terminal/Terminal.Theme // com.jakewharton.mosaic/TerminalState.theme.<get-theme>|<get-theme>(){}[0]
 
     final fun equals(kotlin/Any?): kotlin/Boolean // com.jakewharton.mosaic/TerminalState.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.jakewharton.mosaic/TerminalState.hashCode|hashCode(){}[0]

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -26,7 +26,6 @@ import com.jakewharton.mosaic.terminal.Terminal
 import com.jakewharton.mosaic.tty.Tty
 import com.jakewharton.mosaic.tty.terminal.asTerminalIn
 import com.jakewharton.mosaic.ui.BoxMeasurePolicy
-import com.jakewharton.mosaic.ui.unit.IntSize
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
@@ -170,8 +169,8 @@ internal class MosaicComposition(
 	private var terminalState = mutableStateOf(
 		TerminalState(
 			terminal.state.focused.value,
-			terminal.state.systemTheme.value,
-			terminal.state.size.value.let { IntSize(it.columns, it.rows) },
+			terminal.state.theme.value,
+			terminal.state.size.value,
 		),
 	).also { state ->
 		scope.launch(Unconfined, start = UNDISPATCHED) {
@@ -184,13 +183,13 @@ internal class MosaicComposition(
 			}
 		}
 		scope.launch(Unconfined, start = UNDISPATCHED) {
-			terminal.state.systemTheme.collect { systemTheme ->
-				state.value = state.value.copy(darkTheme = systemTheme)
+			terminal.state.theme.collect { theme ->
+				state.value = state.value.copy(theme = theme)
 			}
 		}
 		scope.launch(Unconfined, start = UNDISPATCHED) {
 			terminal.state.size.collect { size ->
-				state.value = state.value.copy(size = IntSize(size.columns, size.rows))
+				state.value = state.value.copy(size = size)
 			}
 		}
 	}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nonInteractive.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/nonInteractive.kt
@@ -29,7 +29,7 @@ internal object NonInteractiveTerminal : Terminal, Terminal.State, Terminal.Capa
 	override val events: ReceiveChannel<Event> = Channel<Event>().apply { close() }
 
 	override val focused: StateFlow<Boolean> = MutableStateFlow(true)
-	override val systemTheme: StateFlow<Boolean> = MutableStateFlow(false)
+	override val theme: StateFlow<Terminal.Theme> = MutableStateFlow(Terminal.Theme.Unknown)
 	override val size: StateFlow<Terminal.Size> = MutableStateFlow(Terminal.Size.Default)
 
 	override val interactive: Boolean get() = false

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/terminal.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/terminal.kt
@@ -3,7 +3,7 @@ package com.jakewharton.mosaic
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
-import com.jakewharton.mosaic.ui.unit.IntSize
+import com.jakewharton.mosaic.terminal.Terminal
 import dev.drewhamilton.poko.Poko
 
 public val LocalTerminalState: ProvidableCompositionLocal<TerminalState> = compositionLocalOf {
@@ -13,13 +13,13 @@ public val LocalTerminalState: ProvidableCompositionLocal<TerminalState> = compo
 @[Immutable Poko]
 public class TerminalState(
 	public val focused: Boolean,
-	public val darkTheme: Boolean,
-	public val size: IntSize,
+	public val theme: Terminal.Theme,
+	public val size: Terminal.Size,
 )
 
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun TerminalState.copy(
 	focused: Boolean = this.focused,
-	darkTheme: Boolean = this.darkTheme,
-	size: IntSize = this.size,
-) = TerminalState(focused, darkTheme, size)
+	theme: Terminal.Theme = this.theme,
+	size: Terminal.Size = this.size,
+) = TerminalState(focused, theme, size)

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/CounterTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/CounterTest.kt
@@ -88,7 +88,7 @@ class CounterTest {
 			var count by remember { mutableIntStateOf(0) }
 
 			Box(
-				modifier = Modifier.width(LocalTerminalState.current.size.width),
+				modifier = Modifier.width(LocalTerminalState.current.size.columns),
 				contentAlignment = Alignment.Center,
 			) {
 				Text("The count is: $count")

--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -298,7 +298,16 @@ public final class com/jakewharton/mosaic/terminal/Terminal$Size$Companion {
 public abstract interface class com/jakewharton/mosaic/terminal/Terminal$State {
 	public abstract fun getFocused ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getSize ()Lkotlinx/coroutines/flow/StateFlow;
-	public abstract fun getSystemTheme ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getTheme ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class com/jakewharton/mosaic/terminal/Terminal$Theme : java/lang/Enum {
+	public static final field Dark Lcom/jakewharton/mosaic/terminal/Terminal$Theme;
+	public static final field Light Lcom/jakewharton/mosaic/terminal/Terminal$Theme;
+	public static final field Unknown Lcom/jakewharton/mosaic/terminal/Terminal$Theme;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/jakewharton/mosaic/terminal/Terminal$Theme;
+	public static fun values ()[Lcom/jakewharton/mosaic/terminal/Terminal$Theme;
 }
 
 public final class com/jakewharton/mosaic/terminal/TerminalColorEvent : com/jakewharton/mosaic/terminal/Event {

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -27,6 +27,18 @@ abstract interface com.jakewharton.mosaic.terminal/Terminal : kotlin/AutoCloseab
     abstract val state // com.jakewharton.mosaic.terminal/Terminal.state|{}state[0]
         abstract fun <get-state>(): com.jakewharton.mosaic.terminal/Terminal.State // com.jakewharton.mosaic.terminal/Terminal.state.<get-state>|<get-state>(){}[0]
 
+    final enum class Theme : kotlin/Enum<com.jakewharton.mosaic.terminal/Terminal.Theme> { // com.jakewharton.mosaic.terminal/Terminal.Theme|null[0]
+        enum entry Dark // com.jakewharton.mosaic.terminal/Terminal.Theme.Dark|null[0]
+        enum entry Light // com.jakewharton.mosaic.terminal/Terminal.Theme.Light|null[0]
+        enum entry Unknown // com.jakewharton.mosaic.terminal/Terminal.Theme.Unknown|null[0]
+
+        final val entries // com.jakewharton.mosaic.terminal/Terminal.Theme.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<com.jakewharton.mosaic.terminal/Terminal.Theme> // com.jakewharton.mosaic.terminal/Terminal.Theme.entries.<get-entries>|<get-entries>#static(){}[0]
+
+        final fun valueOf(kotlin/String): com.jakewharton.mosaic.terminal/Terminal.Theme // com.jakewharton.mosaic.terminal/Terminal.Theme.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<com.jakewharton.mosaic.terminal/Terminal.Theme> // com.jakewharton.mosaic.terminal/Terminal.Theme.values|values#static(){}[0]
+    }
+
     abstract interface Capabilities { // com.jakewharton.mosaic.terminal/Terminal.Capabilities|null[0]
         abstract val ansiLevel // com.jakewharton.mosaic.terminal/Terminal.Capabilities.ansiLevel|{}ansiLevel[0]
             abstract fun <get-ansiLevel>(): com.jakewharton.mosaic.terminal/AnsiLevel // com.jakewharton.mosaic.terminal/Terminal.Capabilities.ansiLevel.<get-ansiLevel>|<get-ansiLevel>(){}[0]
@@ -51,8 +63,8 @@ abstract interface com.jakewharton.mosaic.terminal/Terminal : kotlin/AutoCloseab
             abstract fun <get-focused>(): kotlinx.coroutines.flow/StateFlow<kotlin/Boolean> // com.jakewharton.mosaic.terminal/Terminal.State.focused.<get-focused>|<get-focused>(){}[0]
         abstract val size // com.jakewharton.mosaic.terminal/Terminal.State.size|{}size[0]
             abstract fun <get-size>(): kotlinx.coroutines.flow/StateFlow<com.jakewharton.mosaic.terminal/Terminal.Size> // com.jakewharton.mosaic.terminal/Terminal.State.size.<get-size>|<get-size>(){}[0]
-        abstract val systemTheme // com.jakewharton.mosaic.terminal/Terminal.State.systemTheme|{}systemTheme[0]
-            abstract fun <get-systemTheme>(): kotlinx.coroutines.flow/StateFlow<kotlin/Boolean> // com.jakewharton.mosaic.terminal/Terminal.State.systemTheme.<get-systemTheme>|<get-systemTheme>(){}[0]
+        abstract val theme // com.jakewharton.mosaic.terminal/Terminal.State.theme|{}theme[0]
+            abstract fun <get-theme>(): kotlinx.coroutines.flow/StateFlow<com.jakewharton.mosaic.terminal/Terminal.Theme> // com.jakewharton.mosaic.terminal/Terminal.State.theme.<get-theme>|<get-theme>(){}[0]
     }
 
     final class Size { // com.jakewharton.mosaic.terminal/Terminal.Size|null[0]

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/Terminal.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/Terminal.kt
@@ -11,7 +11,7 @@ public interface Terminal : AutoCloseable {
 
 	public interface State {
 		public val focused: StateFlow<Boolean>
-		public val systemTheme: StateFlow<Boolean>
+		public val theme: StateFlow<Theme>
 		public val size: StateFlow<Size>
 	}
 
@@ -36,5 +36,11 @@ public interface Terminal : AutoCloseable {
 		public companion object {
 			public val Default: Size = Size(80, 24)
 		}
+	}
+
+	public enum class Theme {
+		Unknown,
+		Light,
+		Dark,
 	}
 }

--- a/mosaic-testing/api/mosaic-testing.api
+++ b/mosaic-testing/api/mosaic-testing.api
@@ -59,7 +59,7 @@ public final class com/jakewharton/mosaic/testing/TestTerminal$State : com/jakew
 	public synthetic fun getFocused ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getSize ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public synthetic fun getSize ()Lkotlinx/coroutines/flow/StateFlow;
-	public fun getSystemTheme ()Lkotlinx/coroutines/flow/MutableStateFlow;
-	public synthetic fun getSystemTheme ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getTheme ()Lkotlinx/coroutines/flow/MutableStateFlow;
+	public synthetic fun getTheme ()Lkotlinx/coroutines/flow/StateFlow;
 }
 

--- a/mosaic-testing/api/mosaic-testing.klib.api
+++ b/mosaic-testing/api/mosaic-testing.klib.api
@@ -59,8 +59,8 @@ final class com.jakewharton.mosaic.testing/TestTerminal : com.jakewharton.mosaic
             final fun <get-focused>(): kotlinx.coroutines.flow/MutableStateFlow<kotlin/Boolean> // com.jakewharton.mosaic.testing/TestTerminal.State.focused.<get-focused>|<get-focused>(){}[0]
         final val size // com.jakewharton.mosaic.testing/TestTerminal.State.size|{}size[0]
             final fun <get-size>(): kotlinx.coroutines.flow/MutableStateFlow<com.jakewharton.mosaic.terminal/Terminal.Size> // com.jakewharton.mosaic.testing/TestTerminal.State.size.<get-size>|<get-size>(){}[0]
-        final val systemTheme // com.jakewharton.mosaic.testing/TestTerminal.State.systemTheme|{}systemTheme[0]
-            final fun <get-systemTheme>(): kotlinx.coroutines.flow/MutableStateFlow<kotlin/Boolean> // com.jakewharton.mosaic.testing/TestTerminal.State.systemTheme.<get-systemTheme>|<get-systemTheme>(){}[0]
+        final val theme // com.jakewharton.mosaic.testing/TestTerminal.State.theme|{}theme[0]
+            final fun <get-theme>(): kotlinx.coroutines.flow/MutableStateFlow<com.jakewharton.mosaic.terminal/Terminal.Theme> // com.jakewharton.mosaic.testing/TestTerminal.State.theme.<get-theme>|<get-theme>(){}[0]
     }
 }
 

--- a/mosaic-testing/src/commonMain/kotlin/com/jakewharton/mosaic/testing/TestTerminal.kt
+++ b/mosaic-testing/src/commonMain/kotlin/com/jakewharton/mosaic/testing/TestTerminal.kt
@@ -19,7 +19,7 @@ public class TestTerminal(
 
 	public class State : Terminal.State {
 		override val focused: MutableStateFlow<Boolean> = MutableStateFlow(true)
-		override val systemTheme: MutableStateFlow<Boolean> = MutableStateFlow(false)
+		override val theme: MutableStateFlow<Terminal.Theme> = MutableStateFlow(Terminal.Theme.Unknown)
 		override val size: MutableStateFlow<Terminal.Size> = MutableStateFlow(Terminal.Size.Default)
 	}
 

--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminal.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminal.kt
@@ -44,7 +44,7 @@ private class TtyTerminal(
 
 	class State(
 		override val focused: StateFlow<Boolean>,
-		override val systemTheme: StateFlow<Boolean>,
+		override val theme: StateFlow<Terminal.Theme>,
 		override val size: StateFlow<Terminal.Size>,
 	) : Terminal.State
 
@@ -80,7 +80,7 @@ public suspend fun Tty.asTerminalIn(
 	}
 
 	val focused = MutableStateFlow(true)
-	val systemTheme = MutableStateFlow(false)
+	val theme = MutableStateFlow(Terminal.Theme.Unknown)
 	val size = MutableStateFlow(Terminal.Size.Default)
 
 	val events = Channel<Event>(64, onBufferOverflow = DROP_OLDEST)
@@ -265,7 +265,11 @@ public suspend fun Tty.asTerminalIn(
 				}
 
 				is SystemThemeEvent -> {
-					systemTheme.value = event.isDark
+					theme.value = if (event.isDark) {
+						Terminal.Theme.Dark
+					} else {
+						Terminal.Theme.Light
+					}
 				}
 
 				else -> {}
@@ -300,7 +304,7 @@ public suspend fun Tty.asTerminalIn(
 	return TtyTerminal(
 		state = TtyTerminal.State(
 			focused = focused,
-			systemTheme = systemTheme,
+			theme = theme,
 			size = size,
 		),
 		capabilities = TtyTerminal.Capabilities(

--- a/samples/demo/src/commonMain/kotlin/example/demo.kt
+++ b/samples/demo/src/commonMain/kotlin/example/demo.kt
@@ -60,8 +60,8 @@ private fun TerminalInfo() {
 	val widthAndHeightTitleColorAnimatable = remember { Animatable(Color.White) }
 
 	val screenSize = LocalTerminalState.current.size
-	val screenWidth = screenSize.width
-	val screenHeight = screenSize.height
+	val screenWidth = screenSize.columns
+	val screenHeight = screenSize.rows
 
 	val screenWidthState = rememberUpdatedIntState(screenWidth)
 	val screenHeightState = rememberUpdatedIntState(screenHeight)
@@ -188,7 +188,7 @@ private fun ColumnScope.GradientsBlock() {
 		textColorProvider = { percent -> Color(1.0f - percent, 0.0f, 1.0f - percent) },
 		backgroundColorProvider = { percent -> Color(percent, 0.0f, percent) },
 	)
-	val screenHalfWidth = LocalTerminalState.current.size.width / 2
+	val screenHalfWidth = LocalTerminalState.current.size.columns / 2
 	LaunchedEffect(screenHalfWidth) {
 		gradientWidthAnimatable.animateTo(screenHalfWidth)
 	}


### PR DESCRIPTION
The ternary theme more accurately models our knowledge, and the size propagates both cell and pixel values.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
