### PR TITLE
Remove `runTest` from TTY Terminal tests

### DIFF
--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/BaseEventParserTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/BaseEventParserTest.kt
@@ -5,7 +5,6 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.tty.TestTty
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
-import kotlinx.coroutines.test.runTest
 
 abstract class BaseEventParserTest {
 	internal val testTty = TestTty.create()
@@ -16,7 +15,7 @@ abstract class BaseEventParserTest {
 		tty.enableRawMode()
 	}
 
-	@AfterTest fun after() = runTest {
+	@AfterTest fun after() {
 		testTty.close()
 		assertThat(parser.copyBuffer().toHexString()).isEqualTo("")
 	}

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiBracketedPasteEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiBracketedPasteEventTest.kt
@@ -4,15 +4,14 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.BracketedPasteEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiBracketedPasteEventTest : BaseEventParserTest() {
-	@Test fun pasteStart() = runTest {
+	@Test fun pasteStart() {
 		testTty.writeHex("1b5b3230307e")
 		assertThat(parser.next()).isEqualTo(BracketedPasteEvent(start = true))
 	}
 
-	@Test fun pasteEnd() = runTest {
+	@Test fun pasteEnd() {
 		testTty.writeHex("1b5b3230317e")
 		assertThat(parser.next()).isEqualTo(BracketedPasteEvent(start = false))
 	}

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiDecModeReportEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiDecModeReportEventTest.kt
@@ -10,10 +10,9 @@ import com.jakewharton.mosaic.terminal.DecModeReportEvent.Setting.Reset
 import com.jakewharton.mosaic.terminal.DecModeReportEvent.Setting.Set
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiDecModeReportEventTest : BaseEventParserTest() {
-	@Test fun settings() = runTest {
+	@Test fun settings() {
 		testTty.writeHex("1b5b3f313030343b302479")
 		assertThat(parser.next()).isEqualTo(
 			DecModeReportEvent(
@@ -55,7 +54,7 @@ class EventParserCsiDecModeReportEventTest : BaseEventParserTest() {
 		)
 	}
 
-	@Test fun minimal() = runTest {
+	@Test fun minimal() {
 		testTty.writeHex("1b5b3f313b302479")
 		assertThat(parser.next()).isEqualTo(
 			DecModeReportEvent(
@@ -65,56 +64,56 @@ class EventParserCsiDecModeReportEventTest : BaseEventParserTest() {
 		)
 	}
 
-	@Test fun unknownSetting() = runTest {
+	@Test fun unknownSetting() {
 		testTty.writeHex("1b5b313030343b352479")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b313030343b352479".hexToByteArray()),
 		)
 	}
 
-	@Test fun noQuestion() = runTest {
+	@Test fun noQuestion() {
 		testTty.writeHex("1b5b313030343b302479")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b313030343b302479".hexToByteArray()),
 		)
 	}
 
-	@Test fun noDollar() = runTest {
+	@Test fun noDollar() {
 		testTty.writeHex("1b5b3f313030343b3079")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f313030343b3079".hexToByteArray()),
 		)
 	}
 
-	@Test fun noMode() = runTest {
+	@Test fun noMode() {
 		testTty.writeHex("1b5b3f3b3130302479")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f3b3130302479".hexToByteArray()),
 		)
 	}
 
-	@Test fun nonDigitMode() = runTest {
+	@Test fun nonDigitMode() {
 		testTty.writeHex("1b5b3f31302d32343b302479")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f31302d32343b302479".hexToByteArray()),
 		)
 	}
 
-	@Test fun noSetting() = runTest {
+	@Test fun noSetting() {
 		testTty.writeHex("1b5b3f313030343b2479")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f313030343b2479".hexToByteArray()),
 		)
 	}
 
-	@Test fun nonDigitSetting() = runTest {
+	@Test fun nonDigitSetting() {
 		testTty.writeHex("1b5b3f313030343b312d322479")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f313030343b312d322479".hexToByteArray()),
 		)
 	}
 
-	@Test fun noSemicolon() = runTest {
+	@Test fun noSemicolon() {
 		testTty.writeHex("1b5b3f313030342479")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f313030342479".hexToByteArray()),

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiFocusEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiFocusEventTest.kt
@@ -4,15 +4,14 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.FocusEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiFocusEventTest : BaseEventParserTest() {
-	@Test fun focusedTrue() = runTest {
+	@Test fun focusedTrue() {
 		testTty.writeHex("1b5b49")
 		assertThat(parser.next()).isEqualTo(FocusEvent(focused = true))
 	}
 
-	@Test fun focusedFalse() = runTest {
+	@Test fun focusedFalse() {
 		testTty.writeHex("1b5b4f")
 		assertThat(parser.next()).isEqualTo(FocusEvent(focused = false))
 	}

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiKeyboardEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiKeyboardEventTest.kt
@@ -20,99 +20,98 @@ import com.jakewharton.mosaic.terminal.KeyboardEvent.Companion.Right
 import com.jakewharton.mosaic.terminal.KeyboardEvent.Companion.Up
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiKeyboardEventTest : BaseEventParserTest() {
-	@Test fun up() = runTest {
+	@Test fun up() {
 		testTty.writeHex("1b5b41")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Up))
 	}
 
-	@Test fun down() = runTest {
+	@Test fun down() {
 		testTty.writeHex("1b5b42")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Down))
 	}
 
-	@Test fun right() = runTest {
+	@Test fun right() {
 		testTty.writeHex("1b5b43")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Right))
 	}
 
-	@Test fun left() = runTest {
+	@Test fun left() {
 		testTty.writeHex("1b5b44")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Left))
 	}
 
-	@Test fun begin() = runTest {
+	@Test fun begin() {
 		testTty.writeHex("1b5b45")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(KpBegin))
 	}
 
-	@Test fun end() = runTest {
+	@Test fun end() {
 		testTty.writeHex("1b5b46")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(End))
 	}
 
-	@Test fun home() = runTest {
+	@Test fun home() {
 		testTty.writeHex("1b5b48")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Home))
 	}
 
-	@Test fun modifierShiftUp() = runTest {
+	@Test fun modifierShiftUp() {
 		testTty.writeHex("1b5b313b3241")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Up, modifiers = ModifierShift))
 	}
 
-	@Test fun modifierAltUp() = runTest {
+	@Test fun modifierAltUp() {
 		testTty.writeHex("1b5b313b3341")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Up, modifiers = ModifierAlt))
 	}
 
-	@Test fun modifierCtrlUp() = runTest {
+	@Test fun modifierCtrlUp() {
 		testTty.writeHex("1b5b313b3541")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Up, modifiers = ModifierCtrl))
 	}
 
-	@Test fun modifierSuperUp() = runTest {
+	@Test fun modifierSuperUp() {
 		testTty.writeHex("1b5b313b3941")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Up, modifiers = ModifierSuper))
 	}
 
-	@Test fun modifierHyperUp() = runTest {
+	@Test fun modifierHyperUp() {
 		testTty.writeHex("1b5b313b313741")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Up, modifiers = ModifierHyper))
 	}
 
-	@Test fun modifierMetaUp() = runTest {
+	@Test fun modifierMetaUp() {
 		testTty.writeHex("1b5b313b333341")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Up, modifiers = ModifierMeta))
 	}
 
-	@Test fun modifierCapsLockUp() = runTest {
+	@Test fun modifierCapsLockUp() {
 		testTty.writeHex("1b5b313b363541")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Up, modifiers = ModifierCapsLock))
 	}
 
-	@Test fun modifierNumLockUp() = runTest {
+	@Test fun modifierNumLockUp() {
 		testTty.writeHex("1b5b313b31323941")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Up, modifiers = ModifierNumLock))
 	}
 
-	@Test fun non1p0() = runTest {
+	@Test fun non1p0() {
 		testTty.writeHex("1b5b323b3248")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b323b3248".hexToByteArray()),
 		)
 	}
 
-	@Test fun emptyModifier() = runTest {
+	@Test fun emptyModifier() {
 		testTty.writeHex("1b5b313b48")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b313b48".hexToByteArray()),
 		)
 	}
 
-	@Test fun nonDigitModifier() = runTest {
+	@Test fun nonDigitModifier() {
 		testTty.writeHex("1b5b313b2f48")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b313b2f48".hexToByteArray()),

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiKittyKeyboardEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiKittyKeyboardEventTest.kt
@@ -5,38 +5,37 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.KeyboardEvent
 import com.jakewharton.mosaic.terminal.KeyboardEvent.Companion.ModifierShift
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiKittyKeyboardEventTest : BaseEventParserTest() {
-	@Test fun h() = runTest {
+	@Test fun h() {
 		testTty.writeHex("1b5b31303475")
 		assertThat(parser.next()).isEqualTo(
 			KeyboardEvent(0x68),
 		)
 	}
 
-	@Test fun shiftH() = runTest {
+	@Test fun shiftH() {
 		testTty.writeHex("1b5b3130343b3275")
 		assertThat(parser.next()).isEqualTo(
 			KeyboardEvent(0x68, modifiers = ModifierShift),
 		)
 	}
 
-	@Test fun shiftHWithAlternate() = runTest {
+	@Test fun shiftHWithAlternate() {
 		testTty.writeHex("1b5b3130343a37323b3275")
 		assertThat(parser.next()).isEqualTo(
 			KeyboardEvent(0x68, 0x48, modifiers = ModifierShift),
 		)
 	}
 
-	@Test fun shiftHWithReleaseEventType() = runTest {
+	@Test fun shiftHWithReleaseEventType() {
 		testTty.writeHex("1b5b3130343b323a3375")
 		assertThat(parser.next()).isEqualTo(
 			KeyboardEvent(0x68, modifiers = ModifierShift, eventType = 3),
 		)
 	}
 
-	@Test fun hWithAssociatedText() = runTest {
+	@Test fun hWithAssociatedText() {
 		testTty.writeHex("1b5b3130343b3b31303475")
 		assertThat(parser.next()).isEqualTo(
 			KeyboardEvent(0x68, text = "h"),

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiKittyKeyboardQueryEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiKittyKeyboardQueryEventTest.kt
@@ -5,32 +5,31 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.KittyKeyboardQueryEvent
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiKittyKeyboardQueryEventTest : BaseEventParserTest() {
-	@Test fun flagsNone() = runTest {
+	@Test fun flagsNone() {
 		testTty.writeHex("1b5b3f3075")
 		assertThat(parser.next()).isEqualTo(KittyKeyboardQueryEvent(0))
 	}
 
-	@Test fun flagsAll() = runTest {
+	@Test fun flagsAll() {
 		testTty.writeHex("1b5b3f333175")
 		assertThat(parser.next()).isEqualTo(KittyKeyboardQueryEvent(31))
 	}
 
-	@Test fun flagsUnknown() = runTest {
+	@Test fun flagsUnknown() {
 		testTty.writeHex("1b5b3f31323875")
 		assertThat(parser.next()).isEqualTo(KittyKeyboardQueryEvent(128))
 	}
 
-	@Test fun flagsMissing() = runTest {
+	@Test fun flagsMissing() {
 		testTty.writeHex("1b5b3f75")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f75".hexToByteArray()),
 		)
 	}
 
-	@Test fun flagsNonDigit() = runTest {
+	@Test fun flagsNonDigit() {
 		testTty.writeHex("1b5b3f312b2075")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f312b2075".hexToByteArray()),

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiMouseEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiMouseEventTest.kt
@@ -6,115 +6,114 @@ import com.jakewharton.mosaic.terminal.MouseEvent
 import com.jakewharton.mosaic.terminal.MouseEvent.Button
 import com.jakewharton.mosaic.terminal.MouseEvent.Type
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiMouseEventTest : BaseEventParserTest() {
-	@Test fun motion() = runTest {
+	@Test fun motion() {
 		testTty.writeHex("1b5b4d434837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Motion, Button.None),
 		)
 	}
 
-	@Test fun click() = runTest {
+	@Test fun click() {
 		testTty.writeHex("1b5b4d204837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.Left),
 		)
 	}
 
-	@Test fun drag() = runTest {
+	@Test fun drag() {
 		testTty.writeHex("1b5b4d404837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Drag, Button.Left),
 		)
 	}
 
-	@Test fun clickMouseUp() = runTest {
+	@Test fun clickMouseUp() {
 		testTty.writeHex("1b5b4d234837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.None),
 		)
 	}
 
-	@Test fun shiftClick() = runTest {
+	@Test fun shiftClick() {
 		testTty.writeHex("1b5b4d244837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.Left, shift = true),
 		)
 	}
 
-	@Test fun altClick() = runTest {
+	@Test fun altClick() {
 		testTty.writeHex("1b5b4d284837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.Left, alt = true),
 		)
 	}
 
-	@Test fun ctrlClick() = runTest {
+	@Test fun ctrlClick() {
 		testTty.writeHex("1b5b4d304837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.Left, ctrl = true),
 		)
 	}
 
-	@Test fun clickRight() = runTest {
+	@Test fun clickRight() {
 		testTty.writeHex("1b5b4d224837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.Right),
 		)
 	}
 
-	@Test fun clickMiddle() = runTest {
+	@Test fun clickMiddle() {
 		testTty.writeHex("1b5b4d214837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.Middle),
 		)
 	}
 
-	@Test fun clickWheelUp() = runTest {
+	@Test fun clickWheelUp() {
 		testTty.writeHex("1b5b4d604837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.WheelUp),
 		)
 	}
 
-	@Test fun clickWheelDown() = runTest {
+	@Test fun clickWheelDown() {
 		testTty.writeHex("1b5b4d614837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.WheelDown),
 		)
 	}
 
-	@Test fun clickButton8() = runTest {
+	@Test fun clickButton8() {
 		testTty.writeHex("1b5b4da04837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.Button8),
 		)
 	}
 
-	@Test fun clickButton9() = runTest {
+	@Test fun clickButton9() {
 		testTty.writeHex("1b5b4da14837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.Button9),
 		)
 	}
 
-	@Test fun clickButton10() = runTest {
+	@Test fun clickButton10() {
 		testTty.writeHex("1b5b4da24837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.Button10),
 		)
 	}
 
-	@Test fun clickButton11() = runTest {
+	@Test fun clickButton11() {
 		testTty.writeHex("1b5b4da34837")
 		assertThat(parser.next()).isEqualTo(
 			MouseEvent(39, 22, Type.Press, Button.Button11),
 		)
 	}
 
-	@Test fun clickUtf8() = runTest {
+	@Test fun clickUtf8() {
 		parser.xtermExtendedUtf8Mouse = true
 
 		testTty.writeHex("1b5b4d20c28037")

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiOperatingStatusResponseEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiOperatingStatusResponseEventTest.kt
@@ -5,25 +5,24 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.OperatingStatusResponseEvent
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiOperatingStatusResponseEventTest : BaseEventParserTest() {
-	@Test fun ok() = runTest {
+	@Test fun ok() {
 		testTty.writeHex("1b5b306e")
 		assertThat(parser.next()).isEqualTo(OperatingStatusResponseEvent(ok = true))
 	}
 
-	@Test fun notOk() = runTest {
+	@Test fun notOk() {
 		testTty.writeHex("1b5b336e")
 		assertThat(parser.next()).isEqualTo(OperatingStatusResponseEvent(ok = false))
 	}
 
-	@Test fun unknownP1() = runTest {
+	@Test fun unknownP1() {
 		testTty.writeHex("1b5b316e")
 		assertThat(parser.next()).isEqualTo(UnknownEvent("1b5b316e".hexToByteArray()))
 	}
 
-	@Test fun nonDigitP1() = runTest {
+	@Test fun nonDigitP1() {
 		testTty.writeHex("1b5b2b6e")
 		assertThat(parser.next()).isEqualTo(UnknownEvent("1b5b2b6e".hexToByteArray()))
 	}

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiPrimaryDeviceAttributesEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiPrimaryDeviceAttributesEventTest.kt
@@ -5,34 +5,33 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.PrimaryDeviceAttributesEvent
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiPrimaryDeviceAttributesEventTest : BaseEventParserTest() {
-	@Test fun noLeadingQuestionMarkIsUnknown() = runTest {
+	@Test fun noLeadingQuestionMarkIsUnknown() {
 		testTty.writeHex("1b5b303063")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b303063".hexToByteArray()),
 		)
 	}
 
-	@Test fun emptyDataFails() = runTest {
+	@Test fun emptyDataFails() {
 		testTty.writeHex("1b5b3f63")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f63".hexToByteArray()),
 		)
 	}
 
-	@Test fun idNoData() = runTest {
+	@Test fun idNoData() {
 		testTty.writeHex("1b5b3f3263")
 		assertThat(parser.next()).isEqualTo(PrimaryDeviceAttributesEvent(id = 2, data = ""))
 	}
 
-	@Test fun idWithSemicolonNoData() = runTest {
+	@Test fun idWithSemicolonNoData() {
 		testTty.writeHex("1b5b3f323b63")
 		assertThat(parser.next()).isEqualTo(PrimaryDeviceAttributesEvent(id = 2, data = ""))
 	}
 
-	@Test fun idAndData() = runTest {
+	@Test fun idAndData() {
 		testTty.writeHex("1b5b3f323b3263")
 		assertThat(parser.next()).isEqualTo(PrimaryDeviceAttributesEvent(id = 2, data = "2"))
 	}

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiResizeEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiResizeEventTest.kt
@@ -5,37 +5,36 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.ResizeEvent
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiResizeEventTest : BaseEventParserTest() {
-	@Test fun basic() = runTest {
+	@Test fun basic() {
 		testTty.writeHex("1b5b34383b313b323b333b3474")
 		assertThat(parser.next()).isEqualTo(ResizeEvent(2, 1, 4, 3))
 	}
 
-	@Test fun pixelSizeAsZero() = runTest {
+	@Test fun pixelSizeAsZero() {
 		testTty.writeHex("1b5b34383b313b323b303b3074")
 		assertThat(parser.next()).isEqualTo(ResizeEvent(2, 1, 0, 0))
 	}
 
-	@Test fun subparametersIgnored() = runTest {
+	@Test fun subparametersIgnored() {
 		testTty.writeHex("1b5b34383b313a39393b323a39383a39373b333a39393a3a39373b343a39393a74")
 		assertThat(parser.next()).isEqualTo(ResizeEvent(2, 1, 4, 3))
 	}
 
-	@Test fun emptySubparametersIgnored() = runTest {
+	@Test fun emptySubparametersIgnored() {
 		testTty.writeHex("1b5b34383b313a3b323a3b333a3b343a74")
 		assertThat(parser.next()).isEqualTo(ResizeEvent(2, 1, 4, 3))
 	}
 
-	@Test fun emptyModeFails() = runTest {
+	@Test fun emptyModeFails() {
 		testTty.writeHex("1b5b3b313b323b333b3474")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3b313b323b333b3474".hexToByteArray()),
 		)
 	}
 
-	@Test fun emptyParameterFails() = runTest {
+	@Test fun emptyParameterFails() {
 		testTty.writeHex("1b5b34383b3b323b333b3474")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b34383b3b323b333b3474".hexToByteArray()),
@@ -54,7 +53,7 @@ class EventParserCsiResizeEventTest : BaseEventParserTest() {
 		)
 	}
 
-	@Test fun nonDigitParameterFails() = runTest {
+	@Test fun nonDigitParameterFails() {
 		testTty.writeHex("1b5b34383b312e303b323b333b3474")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b34383b312e303b323b333b3474".hexToByteArray()),

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiSystemThemeEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiSystemThemeEventTest.kt
@@ -5,41 +5,40 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.SystemThemeEvent
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiSystemThemeEventTest : BaseEventParserTest() {
-	@Test fun dark() = runTest {
+	@Test fun dark() {
 		testTty.writeHex("1b5b3f3939373b316e")
 		assertThat(parser.next()).isEqualTo(SystemThemeEvent(isDark = true))
 	}
 
-	@Test fun light() = runTest {
+	@Test fun light() {
 		testTty.writeHex("1b5b3f3939373b326e")
 		assertThat(parser.next()).isEqualTo(SystemThemeEvent(isDark = false))
 	}
 
-	@Test fun missingP2() = runTest {
+	@Test fun missingP2() {
 		testTty.writeHex("1b5b3f3939373b6e")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f3939373b6e".hexToByteArray()),
 		)
 	}
 
-	@Test fun unknownP2() = runTest {
+	@Test fun unknownP2() {
 		testTty.writeHex("1b5b3f3939373b346e")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f3939373b346e".hexToByteArray()),
 		)
 	}
 
-	@Test fun nonDigitP2() = runTest {
+	@Test fun nonDigitP2() {
 		testTty.writeHex("1b5b3f3939373b2b6e")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f3939373b2b6e".hexToByteArray()),
 		)
 	}
 
-	@Test fun tooLongP2() = runTest {
+	@Test fun tooLongP2() {
 		testTty.writeHex("1b5b3f3939373b31316e")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b3f3939373b31316e".hexToByteArray()),

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiXtermCharacterSizeEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiXtermCharacterSizeEventTest.kt
@@ -5,15 +5,14 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import com.jakewharton.mosaic.terminal.XtermCharacterSizeEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiXtermCharacterSizeEventTest : BaseEventParserTest() {
-	@Test fun basic() = runTest {
+	@Test fun basic() {
 		testTty.writeHex("1b5b383b313b3274")
 		assertThat(parser.next()).isEqualTo(XtermCharacterSizeEvent(1, 2))
 	}
 
-	@Test fun emptyParameterFails() = runTest {
+	@Test fun emptyParameterFails() {
 		testTty.writeHex("1b5b383b3b3274")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b383b3b3274".hexToByteArray()),
@@ -24,7 +23,7 @@ class EventParserCsiXtermCharacterSizeEventTest : BaseEventParserTest() {
 		)
 	}
 
-	@Test fun nonDigitParameterFails() = runTest {
+	@Test fun nonDigitParameterFails() {
 		testTty.writeHex("1b5b383b223b3274")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b383b223b3274".hexToByteArray()),

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiXtermPixelSizeEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserCsiXtermPixelSizeEventTest.kt
@@ -5,15 +5,14 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import com.jakewharton.mosaic.terminal.XtermPixelSizeEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserCsiXtermPixelSizeEventTest : BaseEventParserTest() {
-	@Test fun basic() = runTest {
+	@Test fun basic() {
 		testTty.writeHex("1b5b343b313b3274")
 		assertThat(parser.next()).isEqualTo(XtermPixelSizeEvent(1, 2))
 	}
 
-	@Test fun emptyParameterFails() = runTest {
+	@Test fun emptyParameterFails() {
 		testTty.writeHex("1b5b343b3b3274")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b343b3b3274".hexToByteArray()),
@@ -24,7 +23,7 @@ class EventParserCsiXtermPixelSizeEventTest : BaseEventParserTest() {
 		)
 	}
 
-	@Test fun nonDigitParameterFails() = runTest {
+	@Test fun nonDigitParameterFails() {
 		testTty.writeHex("1b5b343b223b3274")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5b343b223b3274".hexToByteArray()),

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserDcsCapabilityQueryEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserDcsCapabilityQueryEventTest.kt
@@ -5,17 +5,16 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.CapabilityQueryEvent
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserDcsCapabilityQueryEventTest : BaseEventParserTest() {
-	@Test fun unknownStatus() = runTest {
+	@Test fun unknownStatus() {
 		testTty.writeHex("1b50322b721b5c")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b50322b721b5c".hexToByteArray()),
 		)
 	}
 
-	@Test fun failureEmpty() = runTest {
+	@Test fun failureEmpty() {
 		testTty.writeHex("1b50302b721b5c")
 		assertThat(parser.next()).isEqualTo(
 			CapabilityQueryEvent(
@@ -25,7 +24,7 @@ class EventParserDcsCapabilityQueryEventTest : BaseEventParserTest() {
 		)
 	}
 
-	@Test fun failureOneEntryNoValue() = runTest {
+	@Test fun failureOneEntryNoValue() {
 		testTty.writeHex("1b50302b72353337351b5c")
 		assertThat(parser.next()).isEqualTo(
 			CapabilityQueryEvent(
@@ -35,28 +34,28 @@ class EventParserDcsCapabilityQueryEventTest : BaseEventParserTest() {
 		)
 	}
 
-	@Test fun failureOneEntryNoValueWithEquals() = runTest {
+	@Test fun failureOneEntryNoValueWithEquals() {
 		testTty.writeHex("1b50302b72353337353d1b5c")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b50302b72353337353d1b5c".hexToByteArray()),
 		)
 	}
 
-	@Test fun failureOneEntryWithValue() = runTest {
+	@Test fun failureOneEntryWithValue() {
 		testTty.writeHex("1b50302b72353337353d35373635374135343635373236441b5c")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b50302b72353337353d35373635374135343635373236441b5c".hexToByteArray()),
 		)
 	}
 
-	@Test fun successRequiresData() = runTest {
+	@Test fun successRequiresData() {
 		testTty.writeHex("1b50312b721b5c")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b50312b721b5c".hexToByteArray()),
 		)
 	}
 
-	@Test fun successOneEntryNoValue() = runTest {
+	@Test fun successOneEntryNoValue() {
 		testTty.writeHex("1b50312b72353337351b5c")
 		assertThat(parser.next()).isEqualTo(
 			CapabilityQueryEvent(
@@ -66,7 +65,7 @@ class EventParserDcsCapabilityQueryEventTest : BaseEventParserTest() {
 		)
 	}
 
-	@Test fun successOneEntryNoValueWithEquals() = runTest {
+	@Test fun successOneEntryNoValueWithEquals() {
 		testTty.writeHex("1b50312b72353337353d1b5c")
 		assertThat(parser.next()).isEqualTo(
 			CapabilityQueryEvent(
@@ -76,7 +75,7 @@ class EventParserDcsCapabilityQueryEventTest : BaseEventParserTest() {
 		)
 	}
 
-	@Test fun successOneEntryWithValue() = runTest {
+	@Test fun successOneEntryWithValue() {
 		testTty.writeHex("1b50312b72353337353d35373635374135343635373236441b5c")
 		assertThat(parser.next()).isEqualTo(
 			CapabilityQueryEvent(
@@ -86,7 +85,7 @@ class EventParserDcsCapabilityQueryEventTest : BaseEventParserTest() {
 		)
 	}
 
-	@Test fun successMultipleEntries() = runTest {
+	@Test fun successMultipleEntries() {
 		testTty.writeHex("1b50312b72353337353d35373635374135343635373236443b3638363537393b3733373537303d1b5c")
 		assertThat(parser.next()).isEqualTo(
 			CapabilityQueryEvent(
@@ -96,14 +95,14 @@ class EventParserDcsCapabilityQueryEventTest : BaseEventParserTest() {
 		)
 	}
 
-	@Test fun entryKeyOddNumberOfHex() = runTest {
+	@Test fun entryKeyOddNumberOfHex() {
 		testTty.writeHex("1b50312b723533371b5c")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b50312b723533371b5c".hexToByteArray()),
 		)
 	}
 
-	@Test fun entryValueOddNumberOfHex() = runTest {
+	@Test fun entryValueOddNumberOfHex() {
 		testTty.writeHex("1b50312b72353337353d353736353741353436353732361b5c")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b50312b72353337353d353736353741353436353732361b5c".hexToByteArray()),

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserDcsEventVersionEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserDcsEventVersionEventTest.kt
@@ -4,15 +4,14 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.TerminalVersionEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserDcsEventVersionEventTest : BaseEventParserTest() {
-	@Test fun empty() = runTest {
+	@Test fun empty() {
 		testTty.writeHex("1b503e7c1b5c")
 		assertThat(parser.next()).isEqualTo(TerminalVersionEvent(""))
 	}
 
-	@Test fun text() = runTest {
+	@Test fun text() {
 		testTty.writeHex("1b503e7c68656c6c6f1b5c")
 		assertThat(parser.next()).isEqualTo(TerminalVersionEvent("hello"))
 	}

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserDcsTertiaryDeviceAttributesEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserDcsTertiaryDeviceAttributesEventTest.kt
@@ -5,34 +5,33 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.TertiaryDeviceAttributesEvent
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserDcsTertiaryDeviceAttributesEventTest : BaseEventParserTest() {
-	@Test fun zeroes() = runTest {
+	@Test fun zeroes() {
 		testTty.writeHex("1b50217c30303030303030301b5c")
 		assertThat(parser.next()).isEqualTo(TertiaryDeviceAttributesEvent(0, 0))
 	}
 
-	@Test fun values() = runTest {
+	@Test fun values() {
 		testTty.writeHex("1b50217c37423036463835351b5c")
 		assertThat(parser.next()).isEqualTo(TertiaryDeviceAttributesEvent(123, 456789))
 	}
 
-	@Test fun tooShort() = runTest {
+	@Test fun tooShort() {
 		testTty.writeHex("1b50217c303030303030301b5c")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b50217c303030303030301b5c".hexToByteArray()),
 		)
 	}
 
-	@Test fun tooLong() = runTest {
+	@Test fun tooLong() {
 		testTty.writeHex("1b50217c3030303030303030301b5c")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b50217c3030303030303030301b5c".hexToByteArray()),
 		)
 	}
 
-	@Test fun idOddHex() = runTest {
+	@Test fun idOddHex() {
 		testTty.writeHex("1b50217c374230364638351b5c")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b50217c374230364638351b5c".hexToByteArray()),

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserGroundKeyboardEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserGroundKeyboardEventTest.kt
@@ -5,10 +5,9 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.terminal.KeyboardEvent
 import com.jakewharton.mosaic.terminal.KeyboardEvent.Companion.ModifierCtrl
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserGroundKeyboardEventTest : BaseEventParserTest() {
-	@Test fun graphic() = runTest {
+	@Test fun graphic() {
 		for (codepoint in 0x20..0x7f) {
 			val hex = codepoint.toString(16)
 			testTty.writeHex(hex)
@@ -16,172 +15,172 @@ class EventParserGroundKeyboardEventTest : BaseEventParserTest() {
 		}
 	}
 
-	@Test fun ctrlShiftAt() = runTest {
+	@Test fun ctrlShiftAt() {
 		testTty.writeHex("00")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('@'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlA() = runTest {
+	@Test fun ctrlA() {
 		testTty.writeHex("01")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('a'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlB() = runTest {
+	@Test fun ctrlB() {
 		testTty.writeHex("02")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('b'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlC() = runTest {
+	@Test fun ctrlC() {
 		testTty.writeHex("03")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('c'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlD() = runTest {
+	@Test fun ctrlD() {
 		testTty.writeHex("04")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('d'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlE() = runTest {
+	@Test fun ctrlE() {
 		testTty.writeHex("05")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('e'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlF() = runTest {
+	@Test fun ctrlF() {
 		testTty.writeHex("06")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('f'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlG() = runTest {
+	@Test fun ctrlG() {
 		testTty.writeHex("07")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('g'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlH() = runTest {
+	@Test fun ctrlH() {
 		testTty.writeHex("08")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(0x7f))
 	}
 
-	@Test fun ctrlI() = runTest {
+	@Test fun ctrlI() {
 		testTty.writeHex("09")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(0x09))
 	}
 
-	@Test fun ctrlJ() = runTest {
+	@Test fun ctrlJ() {
 		testTty.writeHex("0a")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(0x0d))
 	}
 
-	@Test fun ctrlK() = runTest {
+	@Test fun ctrlK() {
 		testTty.writeHex("0b")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('k'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlL() = runTest {
+	@Test fun ctrlL() {
 		testTty.writeHex("0c")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('l'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlM() = runTest {
+	@Test fun ctrlM() {
 		testTty.writeHex("0d")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(0x0d))
 	}
 
-	@Test fun ctrlN() = runTest {
+	@Test fun ctrlN() {
 		testTty.writeHex("0e")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('n'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlO() = runTest {
+	@Test fun ctrlO() {
 		testTty.writeHex("0f")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('o'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlP() = runTest {
+	@Test fun ctrlP() {
 		testTty.writeHex("10")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('p'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlQ() = runTest {
+	@Test fun ctrlQ() {
 		testTty.writeHex("11")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('q'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlR() = runTest {
+	@Test fun ctrlR() {
 		testTty.writeHex("12")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('r'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlS() = runTest {
+	@Test fun ctrlS() {
 		testTty.writeHex("13")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('s'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlT() = runTest {
+	@Test fun ctrlT() {
 		testTty.writeHex("14")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('t'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlU() = runTest {
+	@Test fun ctrlU() {
 		testTty.writeHex("15")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('u'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlV() = runTest {
+	@Test fun ctrlV() {
 		testTty.writeHex("16")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('v'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlW() = runTest {
+	@Test fun ctrlW() {
 		testTty.writeHex("17")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('w'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlX() = runTest {
+	@Test fun ctrlX() {
 		testTty.writeHex("18")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('x'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlY() = runTest {
+	@Test fun ctrlY() {
 		testTty.writeHex("19")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('y'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun ctrlZ() = runTest {
+	@Test fun ctrlZ() {
 		testTty.writeHex("1a")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('z'.code, modifiers = ModifierCtrl))
 	}
 
-	@Test fun bareEscape() = runTest {
+	@Test fun bareEscape() {
 		testTty.writeHex("1b")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(0x1b))
 	}
 
-	@Test fun hex1c() = runTest {
+	@Test fun hex1c() {
 		testTty.writeHex("1c")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(0x1c))
 	}
 
-	@Test fun hex1d() = runTest {
+	@Test fun hex1d() {
 		testTty.writeHex("1d")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(0x1d))
 	}
 
-	@Test fun hex1e() = runTest {
+	@Test fun hex1e() {
 		testTty.writeHex("1e")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(0x1e))
 	}
 
-	@Test fun hex1f() = runTest {
+	@Test fun hex1f() {
 		testTty.writeHex("1f")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(0x1f))
 	}
 
-	@Test fun utf8TwoBytes() = runTest {
+	@Test fun utf8TwoBytes() {
 		testTty.writeHex("cea9")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('Ω'.code))
 	}
 
-	@Test fun utf8ThreeBytes() = runTest {
+	@Test fun utf8ThreeBytes() {
 		testTty.writeHex("e28988")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent('≈'.code))
 	}

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserOscKittyPointerQueryEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserOscKittyPointerQueryEventTest.kt
@@ -6,45 +6,44 @@ import com.jakewharton.mosaic.terminal.KittyPointerQueryNameEvent
 import com.jakewharton.mosaic.terminal.KittyPointerQuerySupportEvent
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserOscKittyPointerQueryEventTest : BaseEventParserTest() {
-	@Test fun emptyFails() = runTest {
+	@Test fun emptyFails() {
 		testTty.writeHex("1b5d32323b1b5c")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5d32323b1b5c".hexToByteArray()),
 		)
 	}
 
-	@Test fun valuesSingleFalse() = runTest {
+	@Test fun valuesSingleFalse() {
 		testTty.writeHex("1b5d32323b301b5c")
 		assertThat(parser.next()).isEqualTo(
 			KittyPointerQuerySupportEvent(booleanArrayOf(false)),
 		)
 	}
 
-	@Test fun valuesSingleTrue() = runTest {
+	@Test fun valuesSingleTrue() {
 		testTty.writeHex("1b5d32323b311b5c")
 		assertThat(parser.next()).isEqualTo(
 			KittyPointerQuerySupportEvent(booleanArrayOf(true)),
 		)
 	}
 
-	@Test fun valuesSingleValueTrailingCommaFails() = runTest {
+	@Test fun valuesSingleValueTrailingCommaFails() {
 		testTty.writeHex("1b5d32323b312c1b5c")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5d32323b312c1b5c".hexToByteArray()),
 		)
 	}
 
-	@Test fun valuesMultiple() = runTest {
+	@Test fun valuesMultiple() {
 		testTty.writeHex("1b5d32323b302c302c312c312c301b5c")
 		assertThat(parser.next()).isEqualTo(
 			KittyPointerQuerySupportEvent(booleanArrayOf(false, false, true, true, false)),
 		)
 	}
 
-	@Test fun valuesTons() = runTest {
+	@Test fun valuesTons() {
 		testTty.writeHex("1b5d32323b302c302c312c312c302c302c312c312c302c302c312c312c302c302c312c312c302c302c312c312c302c302c312c312c302c302c312c312c301b5c")
 		assertThat(parser.next()).isEqualTo(
 			KittyPointerQuerySupportEvent(
@@ -62,35 +61,35 @@ class EventParserOscKittyPointerQueryEventTest : BaseEventParserTest() {
 		)
 	}
 
-	@Test fun nameSingleDigit() = runTest {
+	@Test fun nameSingleDigit() {
 		testTty.writeHex("1b5d32323b321b5c")
 		assertThat(parser.next()).isEqualTo(
 			KittyPointerQueryNameEvent("2"),
 		)
 	}
 
-	@Test fun nameLeadingValueDigit() = runTest {
+	@Test fun nameLeadingValueDigit() {
 		testTty.writeHex("1b5d32323b30611b5c")
 		assertThat(parser.next()).isEqualTo(
 			KittyPointerQueryNameEvent("0a"),
 		)
 	}
 
-	@Test fun nameValidRange() = runTest {
+	@Test fun nameValidRange() {
 		testTty.writeHex("1b5d32323b6162636465666768696a6b6c6d6e6f707172737475767778797a303132333435363738392d5f1b5c")
 		assertThat(parser.next()).isEqualTo(
 			KittyPointerQueryNameEvent("abcdefghijklmnopqrstuvwxyz0123456789-_"),
 		)
 	}
 
-	@Test fun nameInvalidRange() = runTest {
+	@Test fun nameInvalidRange() {
 		testTty.writeHex("1b5d32323b6162633132334142431b5c")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b5d32323b6162633132334142431b5c".hexToByteArray()),
 		)
 	}
 
-	@Test fun brokenOldKitty() = runTest {
+	@Test fun brokenOldKitty() {
 		// Kitty 0.39.1 and older sent 'OSC 22 :' instead of 'OSC 22 ;'. We don't bother parsing it.
 		testTty.writeHex("1b5d32323a311b5c")
 		assertThat(parser.next()).isEqualTo(

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserSs3KeyboardEventTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/EventParserSs3KeyboardEventTest.kt
@@ -16,67 +16,66 @@ import com.jakewharton.mosaic.terminal.KeyboardEvent.Companion.Up
 import com.jakewharton.mosaic.terminal.OperatingStatusResponseEvent
 import com.jakewharton.mosaic.terminal.UnknownEvent
 import kotlin.test.Test
-import kotlinx.coroutines.test.runTest
 
 class EventParserSs3KeyboardEventTest : BaseEventParserTest() {
-	@Test fun up() = runTest {
+	@Test fun up() {
 		testTty.writeHex("1b4f41")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Up))
 	}
 
-	@Test fun down() = runTest {
+	@Test fun down() {
 		testTty.writeHex("1b4f42")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Down))
 	}
 
-	@Test fun right() = runTest {
+	@Test fun right() {
 		testTty.writeHex("1b4f43")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Right))
 	}
 
-	@Test fun left() = runTest {
+	@Test fun left() {
 		testTty.writeHex("1b4f44")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Left))
 	}
 
-	@Test fun end() = runTest {
+	@Test fun end() {
 		testTty.writeHex("1b4f46")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(End))
 	}
 
-	@Test fun home() = runTest {
+	@Test fun home() {
 		testTty.writeHex("1b4f48")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(Home))
 	}
 
-	@Test fun f1() = runTest {
+	@Test fun f1() {
 		testTty.writeHex("1b4f50")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(F1))
 	}
 
-	@Test fun f2() = runTest {
+	@Test fun f2() {
 		testTty.writeHex("1b4f51")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(F2))
 	}
 
-	@Test fun f3() = runTest {
+	@Test fun f3() {
 		testTty.writeHex("1b4f52")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(F3))
 	}
 
-	@Test fun f4() = runTest {
+	@Test fun f4() {
 		testTty.writeHex("1b4f53")
 		assertThat(parser.next()).isEqualTo(KeyboardEvent(F4))
 	}
 
-	@Test fun invalidKey() = runTest {
+	@Test fun invalidKey() {
 		testTty.writeHex("1b4f75")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b4f75".hexToByteArray()),
 		)
 	}
 
-	@Test fun keyIsEscapeDoesNotConsumeEscape() = runTest {
+	@Test fun keyIsEscapeDoesNotConsumeEscape() {
 		testTty.writeHex("1b4f1b5b306e")
 		assertThat(parser.next()).isEqualTo(
 			UnknownEvent("1b4f".hexToByteArray()),


### PR DESCRIPTION
Keeping coroutines test dep since we'll need it to test the actual TTY Terminal eventually.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
