### PR TITLE
Add terminal capability app

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ kotlinx-coroutines = "1.10.1"
 [libraries]
 kotlin-plugin-core = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-plugin-compose = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,7 @@ include ':samples:rrtop'
 include ':samples:snake'
 
 include ':tools:raw-mode-echo'
+include ':tools:terminal-capability'
 
 enableFeaturePreview('TYPESAFE_PROJECT_ACCESSORS')
 

--- a/tools/terminal-capability/build.gradle
+++ b/tools/terminal-capability/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+
+kotlin {
+	sourceSets {
+		commonMain {
+			dependencies {
+				implementation projects.mosaicTtyTerminal
+				implementation libs.clikt
+				implementation libs.finalizationHook
+				implementation libs.kotlin.reflect
+			}
+		}
+	}
+
+	jvm {
+		binaries {
+			executable {
+				mainClass = 'example.Main'
+			}
+		}
+	}
+}

--- a/tools/terminal-capability/src/commonMain/kotlin/example/main.kt
+++ b/tools/terminal-capability/src/commonMain/kotlin/example/main.kt
@@ -43,7 +43,7 @@ private class TerminalCapabilityCommand : CliktCommand("terminal-capability") {
 		}
 		print(text)
 
-		output?.let { output->
+		output?.let { output ->
 			output.createParentDirectories()
 			output.writeText(text)
 		}

--- a/tools/terminal-capability/src/commonMain/kotlin/example/main.kt
+++ b/tools/terminal-capability/src/commonMain/kotlin/example/main.kt
@@ -1,0 +1,51 @@
+@file:JvmName("Main")
+
+package example
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.main
+import com.github.ajalt.clikt.parameters.options.help
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.path
+import com.jakewharton.mosaic.terminal.Terminal
+import com.jakewharton.mosaic.tty.Tty
+import com.jakewharton.mosaic.tty.terminal.asTerminalIn
+import kotlin.io.path.createParentDirectories
+import kotlin.io.path.writeText
+import kotlin.reflect.KProperty
+import kotlinx.coroutines.runBlocking
+
+fun main(vararg args: String) {
+	TerminalCapabilityCommand().main(args)
+}
+
+private class TerminalCapabilityCommand : CliktCommand("terminal-capability") {
+	private val output by option(envvar = "MOSAIC_TERMINAL_CAPABILITY_OUTPUT")
+		.help("Path into which the output will also be written")
+		.path()
+
+	override fun run() = runBlocking<Unit> {
+		val tty = checkNotNull(Tty.tryBind()) { "No TTY" }
+
+		val text = tty.asTerminalIn(this).use { terminal ->
+			buildString {
+				appendLine(terminal.name)
+				appendLine()
+				Terminal.Capabilities::class
+					.members
+					.filterIsInstance<KProperty<*>>()
+					.sortedBy { it.name }
+					.forEach { capabilityProperty ->
+						val value = capabilityProperty.call(terminal.capabilities)
+						appendLine("${capabilityProperty.name}: $value")
+					}
+			}
+		}
+		print(text)
+
+		output?.let { output->
+			output.createParentDirectories()
+			output.writeText(text)
+		}
+	}
+}


### PR DESCRIPTION
Useful for scripting to run on a bunch of terminals to validate capability detection.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
