### PR TITLE
Support interrupting `TestTty` reads

### DIFF
--- a/mosaic-tty/api/mosaic-tty.api
+++ b/mosaic-tty/api/mosaic-tty.api
@@ -5,6 +5,7 @@ public final class com/jakewharton/mosaic/tty/TestTty : java/lang/AutoCloseable 
 	public static final fun create ()Lcom/jakewharton/mosaic/tty/TestTty;
 	public final fun focusEvent (Z)V
 	public final fun getTty ()Lcom/jakewharton/mosaic/tty/Tty;
+	public final fun interruptRead ()V
 	public final fun keyEvent ()V
 	public final fun mouseEvent ()V
 	public final fun read ([BII)I

--- a/mosaic-tty/api/mosaic-tty.klib.api
+++ b/mosaic-tty/api/mosaic-tty.klib.api
@@ -12,6 +12,7 @@ final class com.jakewharton.mosaic.tty/TestTty : kotlin/AutoCloseable { // com.j
 
     final fun close() // com.jakewharton.mosaic.tty/TestTty.close|close(){}[0]
     final fun focusEvent(kotlin/Boolean) // com.jakewharton.mosaic.tty/TestTty.focusEvent|focusEvent(kotlin.Boolean){}[0]
+    final fun interruptRead() // com.jakewharton.mosaic.tty/TestTty.interruptRead|interruptRead(){}[0]
     final fun keyEvent() // com.jakewharton.mosaic.tty/TestTty.keyEvent|keyEvent(){}[0]
     final fun mouseEvent() // com.jakewharton.mosaic.tty/TestTty.mouseEvent|mouseEvent(){}[0]
     final fun read(kotlin/ByteArray, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/TestTty.read|read(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]

--- a/mosaic-tty/src/commonMain/c/mosaic-test-tty-posix.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-test-tty-posix.c
@@ -13,6 +13,8 @@
 
 typedef struct MosaicTestTtyImpl {
 	int fd;
+	int interrupt_read_fd;
+	int interrupt_write_fd;
 	MosaicTty *tty;
 } MosaicTestTtyImpl;
 
@@ -25,29 +27,36 @@ MosaicTestTtyInitResult testTty_init() {
 		goto ret;
 	}
 
+	int interrupt_pipe[2];
+	if (unlikely(pipe(interrupt_pipe)) != 0) {
+		result.error = errno;
+		goto err_free;
+	}
+
 	// Note: the terms of art here appear to be "master" and "slave".
 	// We use "parent" and "child" instead, respectively.
 	int parentFd = posix_openpt(O_RDWR | O_NOCTTY);
 	if (unlikely(parentFd == -1 || grantpt(parentFd) || unlockpt(parentFd))) {
 		result.error = errno;
-		goto err;
+		goto err_pipes;
 	}
 
 	char *childName = ptsname(parentFd);
 	int childFd = open(childName, O_RDWR | O_NOCTTY);
-
 	if (unlikely(childFd == -1)) {
 		result.error = errno;
-		goto err;
+		goto err_parent;
 	}
 
 	MosaicTtyInitResult ttyInitResult = tty_initWithFd(childFd);
 	if (unlikely(ttyInitResult.error)) {
 		result.error = ttyInitResult.error;
-		goto err;
+		goto err_child;
 	}
 
 	testTty->fd = parentFd;
+	testTty->interrupt_read_fd = interrupt_pipe[0];
+	testTty->interrupt_write_fd = interrupt_pipe[1];
 	testTty->tty = ttyInitResult.tty;
 
 	result.testTty = testTty;
@@ -55,7 +64,17 @@ MosaicTestTtyInitResult testTty_init() {
 	ret:
 	return result;
 
-	err:
+	err_child:
+	close(childFd);
+
+	err_parent:
+	close(parentFd);
+
+	err_pipes:
+	close(interrupt_pipe[0]);
+	close(interrupt_pipe[1]);
+
+	err_free:
 	free(testTty);
 	goto ret;
 }
@@ -65,29 +84,17 @@ MosaicTty *testTty_getTty(MosaicTestTty *testTty) {
 }
 
 MosaicTtyIoResult testTty_write(MosaicTestTty *testTty, uint8_t *buffer, int count) {
-	MosaicTtyIoResult result = {};
-
-	int written = write(testTty->fd, buffer, count);
-	if (written != -1) {
-		result.count = written;
-	} else {
-		result.error = errno;
-	}
-
-	return result;
+	return tty_writeInternal(testTty->fd, buffer, count);
 }
 
 MosaicTtyIoResult testTty_read(MosaicTestTty *testTty, uint8_t *buffer, int count) {
-	MosaicTtyIoResult result = {};
+	return tty_readInternal(testTty->fd, testTty->interrupt_read_fd, buffer, count, NULL);
+}
 
-	int c = read(testTty->fd, buffer, count);
-	if (c != -1) {
-		result.count = c;
-	} else {
-		result.error = errno;
-	}
-
-	return result;
+uint32_t testTty_interruptRead(MosaicTestTty *testTty) {
+	uint8_t space = ' ';
+	MosaicTtyIoResult result = tty_writeInternal(testTty->interrupt_write_fd, &space, 1);
+	return result.error;
 }
 
 uint32_t testTty_focusEvent(MosaicTestTty *testTty UNUSED, bool focused UNUSED) {
@@ -117,6 +124,13 @@ uint32_t testTty_free(MosaicTestTty *testTty) {
 	uint32_t result = 0;
 
 	if (unlikely(close(testTty->fd) != 0)) {
+		result = errno;
+	}
+
+	if (unlikely(close(testTty->interrupt_read_fd) != 0 && result == 0)) {
+		result = errno;
+	}
+	if (unlikely(close(testTty->interrupt_write_fd) != 0 && result == 0)) {
 		result = errno;
 	}
 

--- a/mosaic-tty/src/commonMain/c/mosaic-test-tty-windows.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-test-tty-windows.c
@@ -4,16 +4,20 @@
 #include "mosaic-test-tty.h"
 
 #include "cutils.h"
+#include <stdatomic.h>
 #include <windows.h>
 
 typedef struct MosaicTestTtyImpl {
 	MosaicTty *tty;
 	HANDLE conout_read;
 	HANDLE conout_write;
+	atomic_bool interrupt;
 } MosaicTestTtyImpl;
 
 MosaicTestTtyInitResult testTty_init() {
 	MosaicTestTtyInitResult result = {};
+
+	// TODO Atomic boolean guaranteeing single instance
 
 	MosaicTestTtyImpl *testTty = calloc(1, sizeof(MosaicTestTtyImpl));
 	if (unlikely(testTty == NULL)) {
@@ -24,11 +28,11 @@ MosaicTestTtyInitResult testTty_init() {
 	HANDLE conin = CreateFile(TEXT("CONIN$"), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);
 	if (unlikely(conin == INVALID_HANDLE_VALUE)) {
 		result.error = GetLastError();
-		goto err;
+		goto err_free;
 	}
 	if (unlikely(SetConsoleMode(conin, ENABLE_WINDOW_INPUT | ENABLE_MOUSE_INPUT | ENABLE_EXTENDED_FLAGS) == 0)) {
 		result.error = GetLastError();
-		goto err;
+		goto err_conin;
 	}
 
 	// Ensure we don't start with existing records in the buffer.
@@ -38,7 +42,7 @@ MosaicTestTtyInitResult testTty_init() {
 	HANDLE conoutWrite;
 	if (unlikely(!CreatePipe(&conoutRead, &conoutWrite, NULL, 0))) {
 		result.error = GetLastError();
-		goto err;
+		goto err_conin;
 	}
 
 	MosaicTtyInitResult ttyInitResult = tty_initWithHandles(conin, conoutWrite, true);
@@ -46,8 +50,9 @@ MosaicTestTtyInitResult testTty_init() {
 		CloseHandle(conoutRead);
 		CloseHandle(conoutWrite);
 		result.error = ttyInitResult.error;
-		goto err;
+		goto err_conout;
 	}
+
 	testTty->tty = ttyInitResult.tty;
 	testTty->conout_read = conoutRead;
 	testTty->conout_write = conoutWrite;
@@ -57,7 +62,14 @@ MosaicTestTtyInitResult testTty_init() {
 	ret:
 	return result;
 
-	err:
+	err_conout:
+	CloseHandle(conoutRead);
+	CloseHandle(conoutWrite);
+
+	err_conin:
+	CloseHandle(conin);
+
+	err_free:
 	free(testTty);
 	goto ret;
 }
@@ -95,14 +107,39 @@ MosaicTtyIoResult testTty_write(MosaicTestTty *testTty, uint8_t *buffer, int cou
 MosaicTtyIoResult testTty_read(MosaicTestTty *testTty, uint8_t *buffer, int count) {
 	MosaicTtyIoResult result = {};
 
-	DWORD c;
-	if (ReadFile(testTty->conout_read, buffer, count, &c, NULL)) {
-		result.count = c;
-	} else {
-		result.error = GetLastError();
+	// Perform a spin loop to check for data or interrupt. We can't do a normal wait because pipes
+	// do not signal properly. Since this is only for testing, the busy wait isn't a huge deal.
+	for (;;) {
+		DWORD available;
+		if (!PeekNamedPipe(testTty->conout_read, NULL, 0, NULL, &available, NULL)) {
+			goto err;
+		}
+		if (available) {
+			DWORD c;
+			if (!ReadFile(testTty->conout_read, buffer, count, &c, NULL)) {
+				goto err;
+			}
+			result.count = c;
+			break;
+		}
+		if (atomic_load(&testTty->interrupt)) {
+			atomic_store(&testTty->interrupt, false);
+			// result.count will be 0
+			break;
+		}
 	}
 
+	ret:
 	return result;
+
+	err:
+	result.error = GetLastError();
+	goto ret;
+}
+
+uint32_t testTty_interruptRead(MosaicTestTty *testTty) {
+	atomic_store(&testTty->interrupt, true);
+	return 0;
 }
 
 static uint32_t writeRecord(HANDLE h, INPUT_RECORD *record) {

--- a/mosaic-tty/src/commonMain/c/mosaic-test-tty.h
+++ b/mosaic-tty/src/commonMain/c/mosaic-test-tty.h
@@ -16,6 +16,7 @@ MosaicTestTtyInitResult testTty_init();
 MosaicTty *testTty_getTty(MosaicTestTty *testTty);
 MosaicTtyIoResult testTty_write(MosaicTestTty *testTty, uint8_t *buffer, int count);
 MosaicTtyIoResult testTty_read(MosaicTestTty *testTty, uint8_t *buffer, int count);
+uint32_t testTty_interruptRead(MosaicTestTty *testTty);
 uint32_t testTty_focusEvent(MosaicTestTty *testTty, bool focused);
 uint32_t testTty_keyEvent(MosaicTestTty *testTty);
 uint32_t testTty_mouseEvent(MosaicTestTty *testTty);

--- a/mosaic-tty/src/commonMain/c/mosaic-tty-posix.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-tty-posix.c
@@ -74,26 +74,24 @@ void tty_setCallback(MosaicTty *tty, MosaicTtyCallback *callback) {
 	tty->callback = callback;
 }
 
-static MosaicTtyIoResult tty_readInternal(
-	MosaicTty *tty,
+MosaicTtyIoResult tty_readInternal(
+	int fd,
+	int interruptFd,
 	uint8_t *buffer,
 	int count,
 	struct timeval *timeout
 ) {
 	MosaicTtyIoResult result = {};
 
-	int ttyFd = tty->fd;
-	int interruptReadFd = tty->interrupt_read_fd;
-
 	fd_set fds;
 	FD_ZERO(&fds);
-	FD_SET(ttyFd, &fds);
-	FD_SET(interruptReadFd, &fds);
+	FD_SET(fd, &fds);
+	FD_SET(interruptFd, &fds);
 
-	int nfds = 1 + ((ttyFd > interruptReadFd) ? ttyFd : interruptReadFd);
+	int nfds = 1 + ((fd > interruptFd) ? fd : interruptFd);
 	if (likely(select(nfds, &fds, NULL, NULL, timeout) >= 0)) {
-		if (likely(FD_ISSET(ttyFd, &fds) != 0)) {
-			int c = read(ttyFd, buffer, count);
+		if (likely(FD_ISSET(fd, &fds) != 0)) {
+			int c = read(fd, buffer, count);
 			if (likely(c > 0)) {
 				result.count = c;
 			} else if (c == 0) {
@@ -101,10 +99,10 @@ static MosaicTtyIoResult tty_readInternal(
 			} else {
 				goto err;
 			}
-		} else if (unlikely(FD_ISSET(interruptReadFd, &fds) != 0)) {
+		} else if (unlikely(FD_ISSET(interruptFd, &fds) != 0)) {
 			// Consume the single notification byte to clear the ready state for the next call.
-			int c = read(interruptReadFd, buffer, 1);
-			if (unlikely(c < 0)) {
+			uint8_t space;
+			if (unlikely(read(interruptFd, &space, 1) < 0)) {
 				goto err;
 			}
 		}
@@ -122,7 +120,7 @@ static MosaicTtyIoResult tty_readInternal(
 }
 
 MosaicTtyIoResult tty_read(MosaicTty *tty, uint8_t *buffer, int count) {
-	return tty_readInternal(tty, buffer, count, NULL);
+	return tty_readInternal(tty->fd, tty->interrupt_read_fd, buffer, count, NULL);
 }
 
 MosaicTtyIoResult tty_readWithTimeout(
@@ -135,7 +133,7 @@ MosaicTtyIoResult tty_readWithTimeout(
 	timeout.tv_sec = 0;
 	timeout.tv_usec = timeoutMillis * 1000;
 
-	return tty_readInternal(tty, buffer, count, &timeout);
+	return tty_readInternal(tty->fd, tty->interrupt_read_fd, buffer, count, &timeout);
 }
 
 MosaicTtyIoResult tty_writeInternal(int writeFd, uint8_t *buffer, int count) {
@@ -152,8 +150,8 @@ MosaicTtyIoResult tty_writeInternal(int writeFd, uint8_t *buffer, int count) {
 }
 
 uint32_t tty_interruptRead(MosaicTty *tty) {
-	uint8_t space[1] = { ' ' };
-	MosaicTtyIoResult result = tty_writeInternal(tty->interrupt_write_fd, space, 1);
+	uint8_t space = ' ';
+	MosaicTtyIoResult result = tty_writeInternal(tty->interrupt_write_fd, &space, 1);
 	return result.error;
 }
 

--- a/mosaic-tty/src/commonMain/c/mosaic-tty-posix.h
+++ b/mosaic-tty/src/commonMain/c/mosaic-tty-posix.h
@@ -15,4 +15,14 @@ typedef struct MosaicTtyImpl {
 
 MosaicTtyInitResult tty_initWithFd(int fd);
 
+MosaicTtyIoResult tty_readInternal(
+	int fd,
+	int interruptReadFd,
+	uint8_t *buffer,
+	int count,
+	struct timeval *timeout
+);
+
+MosaicTtyIoResult tty_writeInternal(int writeFd, uint8_t *buffer, int count);
+
 #endif // MOSAIC_TTY_POSIX_H

--- a/mosaic-tty/src/commonMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
+++ b/mosaic-tty/src/commonMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
@@ -24,6 +24,9 @@ public expect class TestTty : AutoCloseable {
 	 */
 	public fun read(buffer: ByteArray, offset: Int, count: Int): Int
 
+	/** Signal blocking calls to [read] to wake up and return 0. */
+	public fun interruptRead()
+
 	/**
 	 * Send a focus event to [tty]'s callback.
 	 *

--- a/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TestTtyTest.kt
+++ b/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TestTtyTest.kt
@@ -2,9 +2,15 @@ package com.jakewharton.mosaic.tty
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isZero
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 
 class TestTtyTest {
 	private val testTty = TestTty.create()
@@ -82,6 +88,22 @@ class TestTtyTest {
 		val read = testTty.read(buffer, 5, 5)
 		assertThat(read).isEqualTo(5)
 		assertThat(buffer.decodeToString()).isEqualTo("xxxxxhello")
+	}
+
+	@Test fun readCanBeInterrupted() = runTest {
+		backgroundScope.launch(Dispatchers.Default) {
+			delay(150.milliseconds)
+			testTty.interruptRead()
+		}
+		val readA = testTty.read(ByteArray(10), 0, 10)
+		assertThat(readA).isZero()
+
+		backgroundScope.launch(Dispatchers.Default) {
+			delay(150.milliseconds)
+			testTty.interruptRead()
+		}
+		val readB = testTty.read(ByteArray(10), 0, 10)
+		assertThat(readB).isZero()
 	}
 
 	@Test fun writeOnlyUpToCount() {

--- a/mosaic-tty/src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c
+++ b/mosaic-tty/src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c
@@ -429,6 +429,19 @@ Java_com_jakewharton_mosaic_tty_Jni_testTtyRead(
 }
 
 JNIEXPORT void JNICALL
+Java_com_jakewharton_mosaic_tty_Jni_testTtyInterruptRead(
+	JNIEnv *env,
+	jclass type UNUSED,
+	jlong testTtyOpaque
+) {
+	MosaicTestTty *testTty = (MosaicTestTty *) testTtyOpaque;
+	uint32_t error = testTty_interruptRead(testTty);
+	if (unlikely(error)) {
+		throwIse(env, error);
+	}
+}
+
+JNIEXPORT void JNICALL
 Java_com_jakewharton_mosaic_tty_Jni_testTtyFocusEvent(
 	JNIEnv *env UNUSED,
 	jclass type UNUSED,

--- a/mosaic-tty/src/jvmMain/java/com/jakewharton/mosaic/tty/Jni.java
+++ b/mosaic-tty/src/jvmMain/java/com/jakewharton/mosaic/tty/Jni.java
@@ -112,6 +112,8 @@ final class Jni {
 
 	static native int testTtyRead(long testTtyPtr, byte[] buffer, int offset, int count);
 
+	static native void testTtyInterruptRead(long testTtyPtr);
+
 	static native void testTtyFocusEvent(long testTtyPtr, boolean focused);
 
 	static native void testTtyKeyEvent(long testTtyPtr);

--- a/mosaic-tty/src/jvmMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
+++ b/mosaic-tty/src/jvmMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
@@ -28,6 +28,10 @@ public actual class TestTty private constructor(
 		return Jni.testTtyRead(testTtyPtr, buffer, offset, count)
 	}
 
+	public actual fun interruptRead() {
+		Jni.testTtyInterruptRead(testTtyPtr)
+	}
+
 	public actual fun focusEvent(focused: Boolean) {
 		Jni.testTtyFocusEvent(testTtyPtr, focused)
 	}

--- a/mosaic-tty/src/nativeMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
+++ b/mosaic-tty/src/nativeMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
@@ -48,6 +48,10 @@ public actual class TestTty private constructor(
 		}
 	}
 
+	public actual fun interruptRead() {
+		testTty_interruptRead(ptr)
+	}
+
 	public actual fun focusEvent(focused: Boolean) {
 		testTty_focusEvent(ptr, focused)
 	}


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
