### PR TITLE
`Renderer`s now take `Terminal.Capabilities` directly

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -24,7 +24,6 @@ import com.jakewharton.mosaic.ui.BoxMeasurePolicy
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
-import kotlin.time.TimeSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.Dispatchers.Unconfined
@@ -56,17 +55,9 @@ public suspend fun runMosaic(
 	content: @Composable () -> Unit,
 ): Boolean = withTerminal(onNonInteractive) { terminal ->
 	val rendering = if (env("MOSAIC_DEBUG_RENDERING") == "true") {
-		DebugRendering(
-			ansiLevel = terminal.capabilities.ansiLevel,
-			supportsKittyUnderlines = terminal.capabilities.kittyUnderline,
-			systemClock = TimeSource.Monotonic,
-		)
+		DebugRendering(terminal.capabilities)
 	} else {
-		AnsiRendering(
-			ansiLevel = terminal.capabilities.ansiLevel,
-			synchronizedOutput = terminal.capabilities.synchronizedOutput,
-			supportsKittyUnderlines = terminal.capabilities.kittyUnderline,
-		)
+		AnsiRendering(terminal.capabilities)
 	}
 
 	runMosaicComposition(terminal, rendering, content)

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/rendering.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/rendering.kt
@@ -1,6 +1,6 @@
 package com.jakewharton.mosaic
 
-import com.jakewharton.mosaic.terminal.AnsiLevel
+import com.jakewharton.mosaic.terminal.Terminal
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 
@@ -15,15 +15,14 @@ internal interface Rendering {
 }
 
 internal class DebugRendering(
-	private val ansiLevel: AnsiLevel,
-	private val supportsKittyUnderlines: Boolean,
-	private val systemClock: TimeSource,
+	private val capabilities: Terminal.Capabilities,
+	private val systemClock: TimeSource = TimeSource.Monotonic,
 ) : Rendering {
 	private var lastRender: TimeMark? = null
 
 	fun StringBuilder.appendSurface(canvas: TextCanvas) {
 		for (row in 0 until canvas.height) {
-			canvas.appendRowTo(this, row, ansiLevel, supportsKittyUnderlines)
+			canvas.appendRowTo(this, row, capabilities.ansiLevel, capabilities.kittyUnderline)
 			append("\r\n")
 		}
 	}
@@ -71,9 +70,7 @@ internal class DebugRendering(
 }
 
 internal class AnsiRendering(
-	private val ansiLevel: AnsiLevel,
-	private val synchronizedOutput: Boolean,
-	private val supportsKittyUnderlines: Boolean,
+	private val capabilities: Terminal.Capabilities,
 ) : Rendering {
 	private val stringBuilder = StringBuilder(100)
 	private var lastHeight = 0
@@ -82,7 +79,7 @@ internal class AnsiRendering(
 		return stringBuilder.apply {
 			clear()
 
-			if (synchronizedOutput) {
+			if (capabilities.synchronizedOutput) {
 				append(synchronizedOutputEnable)
 			}
 
@@ -101,7 +98,7 @@ internal class AnsiRendering(
 						// do not support synchronized rendering, this may allow seeing a partial row render.
 						append(clearLine)
 					}
-					canvas.appendRowTo(this, row, ansiLevel, supportsKittyUnderlines)
+					canvas.appendRowTo(this, row, capabilities.ansiLevel, capabilities.kittyUnderline)
 					append("\r\n")
 				}
 			}
@@ -127,7 +124,7 @@ internal class AnsiRendering(
 				append(clearDisplay)
 			}
 
-			if (synchronizedOutput) {
+			if (capabilities.synchronizedOutput) {
 				append(synchronizedOutputDisable)
 			}
 

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.isEqualTo
 import com.jakewharton.mosaic.layout.background
 import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.terminal.AnsiLevel
+import com.jakewharton.mosaic.testing.TestTerminal
 import com.jakewharton.mosaic.testing.runMosaicTest
 import com.jakewharton.mosaic.ui.Color
 import com.jakewharton.mosaic.ui.Column
@@ -14,11 +15,7 @@ import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
 class AnsiRenderingTest {
-	private val rendering = AnsiRendering(
-		ansiLevel = AnsiLevel.TRUECOLOR,
-		synchronizedOutput = true,
-		supportsKittyUnderlines = false,
-	)
+	private val rendering = AnsiRendering(TestTerminal.Capabilities())
 
 	@Test fun firstRender() = runTest {
 		runMosaicTest(RenderingSnapshots(rendering)) {
@@ -268,9 +265,7 @@ class AnsiRenderingTest {
 
 	@Test fun withoutTrailingSpacesInContainerWithAnsiNone() = runTest {
 		val rendering = AnsiRendering(
-			ansiLevel = AnsiLevel.NONE,
-			synchronizedOutput = true,
-			supportsKittyUnderlines = false,
+			TestTerminal.Capabilities(ansiLevel = AnsiLevel.NONE),
 		)
 		runMosaicTest(RenderingSnapshots(rendering)) {
 			val snapshot = setContentAndSnapshot {

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/DebugRenderingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/DebugRenderingTest.kt
@@ -9,7 +9,7 @@ import assertk.assertions.isNotNull
 import assertk.assertions.message
 import com.jakewharton.mosaic.layout.drawBehind
 import com.jakewharton.mosaic.modifier.Modifier
-import com.jakewharton.mosaic.terminal.AnsiLevel
+import com.jakewharton.mosaic.testing.TestTerminal
 import com.jakewharton.mosaic.testing.runMosaicTest
 import com.jakewharton.mosaic.ui.Layout
 import com.jakewharton.mosaic.ui.Row
@@ -22,8 +22,7 @@ import kotlinx.coroutines.test.runTest
 class DebugRenderingTest {
 	private val timeSource = TestTimeSource()
 	private val rendering = DebugRendering(
-		ansiLevel = AnsiLevel.TRUECOLOR,
-		supportsKittyUnderlines = false,
+		capabilities = TestTerminal.Capabilities(),
 		systemClock = timeSource,
 	)
 

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/MosaicTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/MosaicTest.kt
@@ -18,7 +18,6 @@ import com.jakewharton.mosaic.layout.offset
 import com.jakewharton.mosaic.layout.size
 import com.jakewharton.mosaic.layout.width
 import com.jakewharton.mosaic.modifier.Modifier
-import com.jakewharton.mosaic.terminal.AnsiLevel
 import com.jakewharton.mosaic.testing.TestTerminal
 import com.jakewharton.mosaic.testing.runMosaicTest
 import com.jakewharton.mosaic.ui.Box
@@ -105,13 +104,10 @@ class MosaicTest {
 		var frameTimeA = 0L
 		var frameTimeB = 0L
 
+		val terminal = TestTerminal()
 		runMosaicComposition(
-			rendering = AnsiRendering(
-				ansiLevel = AnsiLevel.NONE,
-				synchronizedOutput = false,
-				supportsKittyUnderlines = false,
-			),
-			terminal = TestTerminal(),
+			rendering = AnsiRendering(terminal.capabilities),
+			terminal = terminal,
 		) {
 			LaunchedEffect(Unit) {
 				withFrameNanos { frameTimeNanos ->


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
