### PR TITLE
Test for permanent responses for capabilities

### DIFF
--- a/mosaic-terminal/api/mosaic-terminal.api
+++ b/mosaic-terminal/api/mosaic-terminal.api
@@ -59,7 +59,6 @@ public final class com/jakewharton/mosaic/terminal/DecModeReportEvent$Setting : 
 	public static final field Reset Lcom/jakewharton/mosaic/terminal/DecModeReportEvent$Setting;
 	public static final field Set Lcom/jakewharton/mosaic/terminal/DecModeReportEvent$Setting;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public final fun isSupported ()Z
 	public static fun valueOf (Ljava/lang/String;)Lcom/jakewharton/mosaic/terminal/DecModeReportEvent$Setting;
 	public static fun values ()[Lcom/jakewharton/mosaic/terminal/DecModeReportEvent$Setting;
 }

--- a/mosaic-terminal/api/mosaic-terminal.klib.api
+++ b/mosaic-terminal/api/mosaic-terminal.klib.api
@@ -179,8 +179,6 @@ final class com.jakewharton.mosaic.terminal/DecModeReportEvent : com.jakewharton
 
         final val entries // com.jakewharton.mosaic.terminal/DecModeReportEvent.Setting.entries|#static{}entries[0]
             final fun <get-entries>(): kotlin.enums/EnumEntries<com.jakewharton.mosaic.terminal/DecModeReportEvent.Setting> // com.jakewharton.mosaic.terminal/DecModeReportEvent.Setting.entries.<get-entries>|<get-entries>#static(){}[0]
-        final val isSupported // com.jakewharton.mosaic.terminal/DecModeReportEvent.Setting.isSupported|{}isSupported[0]
-            final fun <get-isSupported>(): kotlin/Boolean // com.jakewharton.mosaic.terminal/DecModeReportEvent.Setting.isSupported.<get-isSupported>|<get-isSupported>(){}[0]
 
         final fun valueOf(kotlin/String): com.jakewharton.mosaic.terminal/DecModeReportEvent.Setting // com.jakewharton.mosaic.terminal/DecModeReportEvent.Setting.valueOf|valueOf#static(kotlin.String){}[0]
         final fun values(): kotlin/Array<com.jakewharton.mosaic.terminal/DecModeReportEvent.Setting> // com.jakewharton.mosaic.terminal/DecModeReportEvent.Setting.values|values#static(){}[0]

--- a/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/Event.kt
+++ b/mosaic-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/terminal/Event.kt
@@ -220,15 +220,12 @@ public class DecModeReportEvent(
 	public val mode: Int,
 	public val setting: Setting,
 ) : Event {
-	public enum class Setting(
-		/** False if not recognized or permanently reset. */
-		public val isSupported: Boolean,
-	) {
-		NotRecognized(false),
-		Set(true),
-		Reset(true),
-		PermanentlySet(true),
-		PermanentlyReset(false),
+	public enum class Setting {
+		NotRecognized,
+		Set,
+		Reset,
+		PermanentlySet,
+		PermanentlyReset,
 	}
 }
 

--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminal.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminal.kt
@@ -183,7 +183,7 @@ public suspend fun Tty.asTerminalIn(
 
 					when (event.mode) {
 						cursorMode -> {
-							cursorVisibility = event.setting.isSupported
+							cursorVisibility = event.setting.canBeChanged
 							if (event.setting == Setting.Set) {
 								toggleCursor = true
 								write(cursorDisable)
@@ -201,7 +201,7 @@ public suspend fun Tty.asTerminalIn(
 						}
 
 						synchronizedOutputMode -> {
-							synchronizedOutput = event.setting.isSupported
+							synchronizedOutput = event.setting.canBeChanged
 						}
 
 						systemThemeMode -> {
@@ -387,4 +387,20 @@ internal fun detectAnsiLevel(): AnsiLevel {
 		return AnsiLevel.ANSI16
 	}
 	return AnsiLevel.NONE
+}
+
+private val Setting.isSupported get() = when (this) {
+	Setting.NotRecognized -> false
+	Setting.Set -> true
+	Setting.Reset -> true
+	Setting.PermanentlySet -> true
+	Setting.PermanentlyReset -> false
+}
+
+private val Setting.canBeChanged get() = when (this) {
+	Setting.NotRecognized -> false
+	Setting.Set -> true
+	Setting.Reset -> true
+	Setting.PermanentlySet -> false
+	Setting.PermanentlyReset -> false
 }

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminalCursorTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminalCursorTest.kt
@@ -13,11 +13,11 @@ class TtyTerminalCursorTest {
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.cursorVisibility).isFalse()
 
-			// Cursor is not hidden.
+			// No attempt to hide cursor.
 			assertThat(setup).doesNotContain("$CSI?25l")
 		}
 
-		// Cursor is left hidden.
+		// No attempt to show cursor.
 		assertThat(teardown).doesNotContain("$CSI?25h")
 	}
 
@@ -52,6 +52,40 @@ class TtyTerminalCursorTest {
 		}
 
 		// Cursor is left hidden.
+		assertThat(teardown).doesNotContain("$CSI?25h")
+	}
+
+	@Test fun replyPermanentlySet() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		// Cursor is permanently set (i.e, always visible).
+		expect("$CSI?25\$p", reply = "$CSI?25;3\$y")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			assertThat(capabilities.cursorVisibility).isFalse()
+
+			// No attempt to hide cursor.
+			assertThat(setup).doesNotContain("$CSI?25l")
+		}
+
+		// No attempt to show cursor.
+		assertThat(teardown).doesNotContain("$CSI?25h")
+	}
+
+	@Test fun replyPermanentlyReset() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		// Cursor is permanently reset (i.e, always hidden).
+		expect("$CSI?25\$p", reply = "$CSI?25;4\$y")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			assertThat(capabilities.cursorVisibility).isFalse()
+
+			// No attempt to hide cursor.
+			assertThat(setup).doesNotContain("$CSI?25l")
+		}
+
+		// No attempt to show cursor.
 		assertThat(teardown).doesNotContain("$CSI?25h")
 	}
 }

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminalFocusTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminalFocusTest.kt
@@ -13,11 +13,11 @@ class TtyTerminalFocusTest {
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.focusEvents).isFalse()
 
-			// Do not try to enable focus events.
+			// No attempt to enable focus events.
 			assertThat(setup).doesNotContain("$CSI?1004h")
 		}
 
-		// Do not try to disable focus events.
+		// No attempt to disable focus events.
 		assertThat(teardown).doesNotContain("$CSI?1004l")
 	}
 
@@ -30,11 +30,11 @@ class TtyTerminalFocusTest {
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.focusEvents).isTrue()
 
-			// Do not try to enable focus events.
+			// Focus events are not re-enabled.
 			assertThat(setup).doesNotContain("$CSI?1004h")
 		}
 
-		// Do not try to disable focus events.
+		// Focus events are left enabled.
 		assertThat(teardown).doesNotContain("$CSI?1004l")
 	}
 
@@ -53,5 +53,39 @@ class TtyTerminalFocusTest {
 
 		// Disable focus events.
 		assertThat(teardown).contains("$CSI?1004l")
+	}
+
+	@Test fun replyPermanentlySet() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		// Focus events are permanently set (i.e, always enabled).
+		expect("$CSI?1004\$p", reply = "$CSI?1004;3\$y")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			assertThat(capabilities.focusEvents).isTrue()
+
+			// No attempt to enable focus events.
+			assertThat(setup).doesNotContain("$CSI?1004h")
+		}
+
+		// No attempt to disable focus events.
+		assertThat(teardown).doesNotContain("$CSI?1004l")
+	}
+
+	@Test fun replyPermanentlyReset() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		// Focus events are permanently reset (i.e, not supported).
+		expect("$CSI?1004\$p", reply = "$CSI?1004;4\$y")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			assertThat(capabilities.focusEvents).isFalse()
+
+			// No attempt to enable focus events.
+			assertThat(setup).doesNotContain("$CSI?1004h")
+		}
+
+		// No attempt to disable focus events.
+		assertThat(teardown).doesNotContain("$CSI?1004l")
 	}
 }

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminalSynchronizedOutputTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminalSynchronizedOutputTest.kt
@@ -13,11 +13,11 @@ class TtyTerminalSynchronizedOutputTest {
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.synchronizedOutput).isFalse()
 
-			// Do not try to enable synchronized output.
+			// We make no use of synchronized output directly.
 			assertThat(setup).doesNotContain("$CSI?2026h")
 		}
 
-		// Do not try to disable synchronized output.
+		// We make no use of synchronized output directly.
 		assertThat(teardown).doesNotContain("$CSI?2026l")
 	}
 
@@ -30,11 +30,11 @@ class TtyTerminalSynchronizedOutputTest {
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.synchronizedOutput).isTrue()
 
-			// Do not try to enable synchronized output.
+			// We make no use of synchronized output directly.
 			assertThat(setup).doesNotContain("$CSI?2026h")
 		}
 
-		// Do not try to disable synchronized output.
+		// We make no use of synchronized output directly.
 		assertThat(teardown).doesNotContain("$CSI?2026l")
 	}
 
@@ -47,11 +47,46 @@ class TtyTerminalSynchronizedOutputTest {
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.synchronizedOutput).isTrue()
 
-			// Do not try to enable synchronized output. Even though supported, it's used per frame.
+			// We make no use of synchronized output directly.
 			assertThat(setup).doesNotContain("$CSI?2026h")
 		}
 
-		// Do not try to disable synchronized output.
+		// We make no use of synchronized output directly.
+		assertThat(teardown).doesNotContain("$CSI?2026l")
+	}
+
+	@Test fun replyPermanentlySet() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		// Theme events are permanently set (i.e, always enabled).
+		expect("$CSI?2026\$p", reply = "$CSI?2026;3\$y")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			// Getting this response is nonsensical, so we treat it like permanently reset.
+			assertThat(capabilities.synchronizedOutput).isFalse()
+
+			// We make no use of synchronized output directly.
+			assertThat(setup).doesNotContain("$CSI?2026h")
+		}
+
+		// We make no use of synchronized output directly.
+		assertThat(teardown).doesNotContain("$CSI?2026l")
+	}
+
+	@Test fun replyPermanentlyReset() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		// Theme events are permanently reset (i.e, not supported).
+		expect("$CSI?2026\$p", reply = "$CSI?2026;4\$y")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			assertThat(capabilities.synchronizedOutput).isFalse()
+
+			// We make no use of synchronized output directly.
+			assertThat(setup).doesNotContain("$CSI?2026h")
+		}
+
+		// We make no use of synchronized output directly.
 		assertThat(teardown).doesNotContain("$CSI?2026l")
 	}
 }

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminalThemeTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminalThemeTest.kt
@@ -13,11 +13,11 @@ class TtyTerminalThemeTest {
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.themeEvents).isFalse()
 
-			// Do not try to enable theme events.
+			// No attempt to enable theme events.
 			assertThat(setup).doesNotContain("$CSI?2031h")
 		}
 
-		// Do not try to disable theme events.
+		// No attempt to disable theme events.
 		assertThat(teardown).doesNotContain("$CSI?2031l")
 	}
 
@@ -30,11 +30,11 @@ class TtyTerminalThemeTest {
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.themeEvents).isTrue()
 
-			// Do not try to enable theme events.
+			// Theme events are not re-enabled.
 			assertThat(setup).doesNotContain("$CSI?2031h")
 		}
 
-		// Do not try to disable theme events.
+		// Theme events are left enabled.
 		assertThat(teardown).doesNotContain("$CSI?2031l")
 	}
 
@@ -53,5 +53,39 @@ class TtyTerminalThemeTest {
 
 		// Disable theme events.
 		assertThat(teardown).contains("$CSI?2031l")
+	}
+
+	@Test fun replyPermanentlySet() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		// Theme events are permanently set (i.e, always enabled).
+		expect("$CSI?2031\$p", reply = "$CSI?2031;3\$y")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			assertThat(capabilities.themeEvents).isTrue()
+
+			// No attempt to enable theme events.
+			assertThat(setup).doesNotContain("$CSI?2031h")
+		}
+
+		// No attempt to disable theme events.
+		assertThat(teardown).doesNotContain("$CSI?2031l")
+	}
+
+	@Test fun replyPermanentlyReset() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		// Theme events are permanently reset (i.e, not supported).
+		expect("$CSI?2031\$p", reply = "$CSI?2031;4\$y")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			assertThat(capabilities.themeEvents).isFalse()
+
+			// No attempt to enable theme events.
+			assertThat(setup).doesNotContain("$CSI?2031h")
+		}
+
+		// No attempt to disable theme events.
+		assertThat(teardown).doesNotContain("$CSI?2031l")
 	}
 }


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
