### PR TITLE
Query theme separately from theme update mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 [Unreleased]: https://github.com/JakeWharton/mosaic/compare/0.16.0...HEAD
 
 Changed:
-- Unsolicited focus events are now ignored unless the terminal has reported that it supports focus.
-  This should have no real impact on anything, except that now the `Terminal.capabilities.focus` value can now be trusted to indicate whether `Terminal.state.focus` will ever change.
+- Unsolicited focus and theme events are now ignored unless the terminal has reported that it supports focus and theme, respectively.
+  This should have no real impact on anything, except that now the `Terminal.capabilities` value can now be trusted to indicate whether `Terminal.state` will ever change.
+- Terminal theme is now always queried for an initial value regardless of whether the terminal supports sending theme changes.
 
 
 ## [0.17.0] - 2025-04-11

--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminal.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminal.kt
@@ -167,6 +167,7 @@ public suspend fun Tty.asTerminalIn(
 							"$CSI?$synchronizedOutputMode\$p" +
 							"$CSI?$systemThemeMode\$p" +
 							"$CSI?$inBandResizeMode\$p" +
+							"$CSI?996n" + // Theme query
 							"${APC}Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA$ST" + // Kitty graphics
 							"$CSI?u" + // Kitty keyboard
 							"${OSC}99;i=1:p=?$ST" + // Kitty notifications
@@ -208,10 +209,7 @@ public suspend fun Tty.asTerminalIn(
 							themeEvents = event.setting.isSupported
 							if (event.setting == Setting.Reset) {
 								toggleSystemTheme = true
-								write(
-									systemThemeEnable +
-										"$CSI?996n", // Current system theme query.
-								)
+								write(systemThemeEnable)
 							}
 						}
 
@@ -228,7 +226,7 @@ public suspend fun Tty.asTerminalIn(
 
 				is OperatingStatusResponseEvent -> {
 					if (stage == StageCapabilityQueries) {
-						if (focusEvents or toggleInBandResize or toggleSystemTheme) {
+						if (focusEvents or toggleInBandResize) {
 							// By enabling these modes (or by sending an explicit default value query after
 							// enabling the mode) wait for a reply about the default with a second DSR.
 							stage = StageDefaultQueries
@@ -303,10 +301,14 @@ public suspend fun Tty.asTerminalIn(
 				}
 
 				is SystemThemeEvent -> {
-					theme.value = if (event.isDark) {
-						Terminal.Theme.Dark
+					if (themeEvents || stage == StageCapabilityQueries) {
+						theme.value = if (event.isDark) {
+							Terminal.Theme.Dark
+						} else {
+							Terminal.Theme.Light
+						}
 					} else {
-						Terminal.Theme.Light
+						// TODO Report unsolicited theme events... somewhere.
 					}
 				}
 

--- a/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminalThemeTest.kt
+++ b/mosaic-tty-terminal/src/commonTest/kotlin/com/jakewharton/mosaic/tty/terminal/TtyTerminalThemeTest.kt
@@ -1,27 +1,60 @@
 package com.jakewharton.mosaic.tty.terminal
 
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
+import com.jakewharton.mosaic.terminal.SystemThemeEvent
+import com.jakewharton.mosaic.terminal.Terminal.Theme.Dark
+import com.jakewharton.mosaic.terminal.Terminal.Theme.Light
+import com.jakewharton.mosaic.terminal.Terminal.Theme.Unknown
 import kotlin.test.Test
 
 class TtyTerminalThemeTest {
-	@Test fun noReply() = terminalTest {
+	@Test fun noModeOrThemeReply() = terminalTest {
 		expect("${CSI}0c", reply = "$CSI?62;22c")
 		expect("${CSI}5n", reply = "${CSI}0n")
 
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.themeEvents).isFalse()
+			assertThat(state.theme.value).isEqualTo(Unknown)
 
 			// No attempt to enable theme events.
 			assertThat(setup).doesNotContain("$CSI?2031h")
+
+			// Write an unsolicited theme=dark event which should be ignored.
+			ptyWrite("$CSI?997;1n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = true))
+			assertThat(state.theme.value).isEqualTo(Unknown)
 		}
 
 		// No attempt to disable theme events.
 		assertThat(teardown).doesNotContain("$CSI?2031l")
 	}
 
-	@Test fun replySet() = terminalTest {
+	@Test fun noModeReplyWithThemeReply() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		expect("$CSI?996n", reply = "$CSI?997;2n")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			assertThat(capabilities.themeEvents).isFalse()
+			assertThat(state.theme.value).isEqualTo(Light)
+
+			// No attempt to enable theme events.
+			assertThat(setup).doesNotContain("$CSI?2031h")
+
+			// Write an unsolicited theme=dark event which should be ignored.
+			ptyWrite("$CSI?997;1n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = true))
+			assertThat(state.theme.value).isEqualTo(Light)
+		}
+
+		// No attempt to disable theme events.
+		assertThat(teardown).doesNotContain("$CSI?2031l")
+	}
+
+	@Test fun replyModeSetWithoutThemeReply() = terminalTest {
 		expect("${CSI}0c", reply = "$CSI?62;22c")
 		// Theme events are set (i.e, enabled).
 		expect("$CSI?2031\$p", reply = "$CSI?2031;1\$y")
@@ -29,16 +62,52 @@ class TtyTerminalThemeTest {
 
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.themeEvents).isTrue()
+			assertThat(state.theme.value).isEqualTo(Unknown)
 
 			// Theme events are not re-enabled.
 			assertThat(setup).doesNotContain("$CSI?2031h")
+
+			// Write theme events which should be honored.
+			ptyWrite("$CSI?997;1n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = true))
+			assertThat(state.theme.value).isEqualTo(Dark)
+			ptyWrite("$CSI?997;2n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = false))
+			assertThat(state.theme.value).isEqualTo(Light)
 		}
 
 		// Theme events are left enabled.
 		assertThat(teardown).doesNotContain("$CSI?2031l")
 	}
 
-	@Test fun replyReset() = terminalTest {
+	@Test fun replyModeSetWithThemeReply() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		// Theme events are set (i.e, enabled).
+		expect("$CSI?2031\$p", reply = "$CSI?2031;1\$y")
+		expect("$CSI?996n", reply = "$CSI?997;2n")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			assertThat(capabilities.themeEvents).isTrue()
+			assertThat(state.theme.value).isEqualTo(Light)
+
+			// Theme events are not re-enabled.
+			assertThat(setup).doesNotContain("$CSI?2031h")
+
+			// Write theme events which should be honored.
+			ptyWrite("$CSI?997;1n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = true))
+			assertThat(state.theme.value).isEqualTo(Dark)
+			ptyWrite("$CSI?997;2n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = false))
+			assertThat(state.theme.value).isEqualTo(Light)
+		}
+
+		// Theme events are left enabled.
+		assertThat(teardown).doesNotContain("$CSI?2031l")
+	}
+
+	@Test fun replyModeResetWithoutThemeReply() = terminalTest {
 		expect("${CSI}0c", reply = "$CSI?62;22c")
 		// Theme events are reset (i.e, not enabled).
 		expect("$CSI?2031\$p", reply = "$CSI?2031;2\$y")
@@ -46,16 +115,52 @@ class TtyTerminalThemeTest {
 
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.themeEvents).isTrue()
+			assertThat(state.theme.value).isEqualTo(Unknown)
 
 			// Enable theme events.
 			assertThat(setup).contains("$CSI?2031h")
+
+			// Write theme events which should be honored.
+			ptyWrite("$CSI?997;1n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = true))
+			assertThat(state.theme.value).isEqualTo(Dark)
+			ptyWrite("$CSI?997;2n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = false))
+			assertThat(state.theme.value).isEqualTo(Light)
 		}
 
 		// Disable theme events.
 		assertThat(teardown).contains("$CSI?2031l")
 	}
 
-	@Test fun replyPermanentlySet() = terminalTest {
+	@Test fun replyModeResetWithThemeReply() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		// Theme events are reset (i.e, not enabled).
+		expect("$CSI?2031\$p", reply = "$CSI?2031;2\$y")
+		expect("$CSI?996n", reply = "$CSI?997;2n")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			assertThat(capabilities.themeEvents).isTrue()
+			assertThat(state.theme.value).isEqualTo(Light)
+
+			// Enable theme events.
+			assertThat(setup).contains("$CSI?2031h")
+
+			// Write theme events which should be honored.
+			ptyWrite("$CSI?997;1n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = true))
+			assertThat(state.theme.value).isEqualTo(Dark)
+			ptyWrite("$CSI?997;2n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = false))
+			assertThat(state.theme.value).isEqualTo(Light)
+		}
+
+		// Disable theme events.
+		assertThat(teardown).contains("$CSI?2031l")
+	}
+
+	@Test fun replyModePermanentlySetWithoutThemeReply() = terminalTest {
 		expect("${CSI}0c", reply = "$CSI?62;22c")
 		// Theme events are permanently set (i.e, always enabled).
 		expect("$CSI?2031\$p", reply = "$CSI?2031;3\$y")
@@ -63,16 +168,52 @@ class TtyTerminalThemeTest {
 
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.themeEvents).isTrue()
+			assertThat(state.theme.value).isEqualTo(Unknown)
 
 			// No attempt to enable theme events.
 			assertThat(setup).doesNotContain("$CSI?2031h")
+
+			// Write theme events which should be honored.
+			ptyWrite("$CSI?997;1n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = true))
+			assertThat(state.theme.value).isEqualTo(Dark)
+			ptyWrite("$CSI?997;2n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = false))
+			assertThat(state.theme.value).isEqualTo(Light)
 		}
 
 		// No attempt to disable theme events.
 		assertThat(teardown).doesNotContain("$CSI?2031l")
 	}
 
-	@Test fun replyPermanentlyReset() = terminalTest {
+	@Test fun replyModePermanentlySetWithThemeReply() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		// Theme events are permanently set (i.e, always enabled).
+		expect("$CSI?2031\$p", reply = "$CSI?2031;3\$y")
+		expect("$CSI?996n", reply = "$CSI?997;2n")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			assertThat(capabilities.themeEvents).isTrue()
+			assertThat(state.theme.value).isEqualTo(Light)
+
+			// No attempt to enable theme events.
+			assertThat(setup).doesNotContain("$CSI?2031h")
+
+			// Write theme events which should be honored.
+			ptyWrite("$CSI?997;1n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = true))
+			assertThat(state.theme.value).isEqualTo(Dark)
+			ptyWrite("$CSI?997;2n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = false))
+			assertThat(state.theme.value).isEqualTo(Light)
+		}
+
+		// No attempt to disable theme events.
+		assertThat(teardown).doesNotContain("$CSI?2031l")
+	}
+
+	@Test fun replyModePermanentlyResetWithoutThemeReply() = terminalTest {
 		expect("${CSI}0c", reply = "$CSI?62;22c")
 		// Theme events are permanently reset (i.e, not supported).
 		expect("$CSI?2031\$p", reply = "$CSI?2031;4\$y")
@@ -80,9 +221,39 @@ class TtyTerminalThemeTest {
 
 		val teardown = withTerminal { setup ->
 			assertThat(capabilities.themeEvents).isFalse()
+			assertThat(state.theme.value).isEqualTo(Unknown)
 
 			// No attempt to enable theme events.
 			assertThat(setup).doesNotContain("$CSI?2031h")
+
+			// Write an unsolicited theme=dark event which should be ignored.
+			ptyWrite("$CSI?997;1n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = true))
+			assertThat(state.theme.value).isEqualTo(Unknown)
+		}
+
+		// No attempt to disable theme events.
+		assertThat(teardown).doesNotContain("$CSI?2031l")
+	}
+
+	@Test fun replyModePermanentlyResetWithThemeReply() = terminalTest {
+		expect("${CSI}0c", reply = "$CSI?62;22c")
+		// Theme events are permanently reset (i.e, not supported).
+		expect("$CSI?2031\$p", reply = "$CSI?2031;4\$y")
+		expect("$CSI?996n", reply = "$CSI?997;2n")
+		expect("${CSI}5n", reply = "${CSI}0n")
+
+		val teardown = withTerminal { setup ->
+			assertThat(capabilities.themeEvents).isFalse()
+			assertThat(state.theme.value).isEqualTo(Light)
+
+			// No attempt to enable theme events.
+			assertThat(setup).doesNotContain("$CSI?2031h")
+
+			// Write an unsolicited theme=dark event which should be ignored.
+			ptyWrite("$CSI?997;1n")
+			assertThat(events.receive()).isEqualTo(SystemThemeEvent(isDark = true))
+			assertThat(state.theme.value).isEqualTo(Light)
 		}
 
 		// No attempt to disable theme events.


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
