### PR TITLE
Fix path issues in Zig and Gradle scripts

### DIFF
--- a/mosaic-tty/build.gradle
+++ b/mosaic-tty/build.gradle
@@ -65,7 +65,7 @@ kotlin {
 					if (files.size() != 6) {
 						throw new RuntimeException("""Native library mismatch!
 							|
-							|Run `zig build -p $jniDir`.
+							|Run `zig build -p ${jniDir.parentFile}`.
 							|
 							|Expected 6 files, found:
 							|- """.stripMargin() + files.collect { jniDir.relativePath(it) }.sort().join('\n -'))

--- a/mosaic-tty/build.zig
+++ b/mosaic-tty/build.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) !void {
 	// The Windows builds create a .lib file in the lib/ directory which we don't need.
-	const deleteLib = b.addRemoveDirTree(b.path(b.getInstallPath(.prefix, "lib")));
+	const deleteLib = b.addRemoveDirTree(.{ .cwd_relative = b.getInstallPath(.prefix, "lib") });
 	b.getInstallStep().dependOn(&deleteLib.step);
 
 	setupMosaicTarget(b, &deleteLib.step, .linux, .aarch64, "com/jakewharton/mosaic/tty/jni/aarch64");


### PR DESCRIPTION
I have two issues related to the zig build script.

First, I had a issue with zig prefix build path being presented in the build script error message. Original path was the jni path and I needed to run the zig build command from the jni parent. Updated gradle script to ouput jni parent path in the error message.

Second issue was a command in zig build script. I have zig version 0.14.0 and I think it's more strict about build paths. I updated zig build script to use `.cwd_relative` option for the install path removal step. Not sure if this works on older versions of zig

