### PR TITLE
Some `TestTty` renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Changed:
 - Terminal theme is now always queried for an initial value regardless of whether the terminal supports sending theme changes.
 - Java 11 is now the minimum-supported JVM version.
 
+Fixed:
+- Windows now reports the terminal size correctly. Previously it reported the buffer size instead of the window size.
+
 
 ## [0.17.0] - 2025-04-11
 [0.17.0]: https://github.com/JakeWharton/mosaic/releases/tag/0.17.0

--- a/mosaic-tty/api/mosaic-tty.api
+++ b/mosaic-tty/api/mosaic-tty.api
@@ -3,13 +3,13 @@ public final class com/jakewharton/mosaic/tty/TestTty : java/lang/AutoCloseable 
 	public synthetic fun <init> (JLcom/jakewharton/mosaic/tty/Tty;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun bind ()Lcom/jakewharton/mosaic/tty/TestTty;
 	public fun close ()V
-	public final fun focusEvent (Z)V
 	public final fun getTty ()Lcom/jakewharton/mosaic/tty/Tty;
 	public final fun interruptRead ()V
-	public final fun keyEvent ()V
-	public final fun mouseEvent ()V
 	public final fun read ([BII)I
-	public final fun resizeEvent (IIII)V
+	public final fun resize (IIII)V
+	public final fun sendFocusEvent (Z)V
+	public final fun sendKeyEvent ()V
+	public final fun sendMouseEvent ()V
 	public final fun write ([BII)I
 }
 

--- a/mosaic-tty/api/mosaic-tty.klib.api
+++ b/mosaic-tty/api/mosaic-tty.klib.api
@@ -15,12 +15,12 @@ final class com.jakewharton.mosaic.tty/TestTty : kotlin/AutoCloseable { // com.j
         final fun <get-tty>(): com.jakewharton.mosaic.tty/Tty // com.jakewharton.mosaic.tty/TestTty.tty.<get-tty>|<get-tty>(){}[0]
 
     final fun close() // com.jakewharton.mosaic.tty/TestTty.close|close(){}[0]
-    final fun focusEvent(kotlin/Boolean) // com.jakewharton.mosaic.tty/TestTty.focusEvent|focusEvent(kotlin.Boolean){}[0]
     final fun interruptRead() // com.jakewharton.mosaic.tty/TestTty.interruptRead|interruptRead(){}[0]
-    final fun keyEvent() // com.jakewharton.mosaic.tty/TestTty.keyEvent|keyEvent(){}[0]
-    final fun mouseEvent() // com.jakewharton.mosaic.tty/TestTty.mouseEvent|mouseEvent(){}[0]
     final fun read(kotlin/ByteArray, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/TestTty.read|read(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
-    final fun resizeEvent(kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int) // com.jakewharton.mosaic.tty/TestTty.resizeEvent|resizeEvent(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+    final fun resize(kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int) // com.jakewharton.mosaic.tty/TestTty.resize|resize(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+    final fun sendFocusEvent(kotlin/Boolean) // com.jakewharton.mosaic.tty/TestTty.sendFocusEvent|sendFocusEvent(kotlin.Boolean){}[0]
+    final fun sendKeyEvent() // com.jakewharton.mosaic.tty/TestTty.sendKeyEvent|sendKeyEvent(){}[0]
+    final fun sendMouseEvent() // com.jakewharton.mosaic.tty/TestTty.sendMouseEvent|sendMouseEvent(){}[0]
     final fun write(kotlin/ByteArray, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/TestTty.write|write(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
 
     final object Companion { // com.jakewharton.mosaic.tty/TestTty.Companion|null[0]

--- a/mosaic-tty/src/commonMain/c/mosaic-test-tty-posix.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-test-tty-posix.c
@@ -120,22 +120,7 @@ uint32_t testTty_interruptRead(MosaicTestTty *testTty) {
 	return result.error;
 }
 
-uint32_t testTty_focusEvent(MosaicTestTty *testTty UNUSED, bool focused UNUSED) {
-	// Focus events are delivered through VT sequences.
-	return 0;
-}
-
-uint32_t testTty_keyEvent(MosaicTestTty *testTty UNUSED) {
-	// Key events are delivered through VT sequences.
-	return 0;
-}
-
-uint32_t testTty_mouseEvent(MosaicTestTty *testTty UNUSED) {
-	// Mouse events are delivered through VT sequences.
-	return 0;
-}
-
-uint32_t testTty_resizeEvent(MosaicTestTty *testTty, int columns, int rows, int width, int height) {
+uint32_t testTty_resize(MosaicTestTty *testTty, int columns, int rows, int width, int height) {
 	uint32_t sizeResult = testTty_resizeInternal(testTty->fd, columns, rows, width, height);
 	if (unlikely(sizeResult)) {
 		return sizeResult;
@@ -146,6 +131,21 @@ uint32_t testTty_resizeEvent(MosaicTestTty *testTty, int columns, int rows, int 
 		return errno;
 	}
 
+	return 0;
+}
+
+uint32_t testTty_sendFocusEvent(MosaicTestTty *testTty UNUSED, bool focused UNUSED) {
+	// Focus events are delivered through VT sequences.
+	return 0;
+}
+
+uint32_t testTty_sendKeyEvent(MosaicTestTty *testTty UNUSED) {
+	// Key events are delivered through VT sequences.
+	return 0;
+}
+
+uint32_t testTty_sendMouseEvent(MosaicTestTty *testTty UNUSED) {
+	// Mouse events are delivered through VT sequences.
 	return 0;
 }
 

--- a/mosaic-tty/src/commonMain/c/mosaic-test-tty-windows.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-test-tty-windows.c
@@ -188,24 +188,7 @@ static uint32_t writeRecord(HANDLE h, INPUT_RECORD *record) {
 	return GetLastError();
 }
 
-uint32_t testTty_focusEvent(MosaicTestTty *testTty, bool focused) {
-	INPUT_RECORD record;
-	record.EventType = FOCUS_EVENT;
-	record.Event.FocusEvent.bSetFocus = focused;
-	return writeRecord(testTty->tty->conin, &record);
-}
-
-uint32_t testTty_keyEvent(MosaicTestTty *testTty UNUSED) {
-	// TODO
-	return 0;
-}
-
-uint32_t testTty_mouseEvent(MosaicTestTty *testTty UNUSED) {
-	// TODO
-	return 0;
-}
-
-uint32_t testTty_resizeEvent(MosaicTestTty *testTty, int columns, int rows, int width UNUSED, int height UNUSED) {
+uint32_t testTty_resize(MosaicTestTty *testTty, int columns, int rows, int width UNUSED, int height UNUSED) {
 	uint32_t sizeResult = testTty_resizeInternal(testTty->tty->conout_for_size, columns, rows);
 	if (unlikely(sizeResult)) {
 		return sizeResult;
@@ -216,6 +199,23 @@ uint32_t testTty_resizeEvent(MosaicTestTty *testTty, int columns, int rows, int 
 	record.Event.WindowBufferSizeEvent.dwSize.X = columns;
 	record.Event.WindowBufferSizeEvent.dwSize.Y = rows;
 	return writeRecord(testTty->tty->conin, &record);
+}
+
+uint32_t testTty_sendFocusEvent(MosaicTestTty *testTty, bool focused) {
+	INPUT_RECORD record;
+	record.EventType = FOCUS_EVENT;
+	record.Event.FocusEvent.bSetFocus = focused;
+	return writeRecord(testTty->tty->conin, &record);
+}
+
+uint32_t testTty_sendKeyEvent(MosaicTestTty *testTty UNUSED) {
+	// TODO
+	return 0;
+}
+
+uint32_t testTty_sendMouseEvent(MosaicTestTty *testTty UNUSED) {
+	// TODO
+	return 0;
 }
 
 uint32_t testTty_free(MosaicTestTty *testTty) {

--- a/mosaic-tty/src/commonMain/c/mosaic-test-tty.h
+++ b/mosaic-tty/src/commonMain/c/mosaic-test-tty.h
@@ -18,10 +18,10 @@ MosaicTty *testTty_getTty(MosaicTestTty *testTty);
 MosaicTtyIoResult testTty_write(MosaicTestTty *testTty, uint8_t *buffer, int count);
 MosaicTtyIoResult testTty_read(MosaicTestTty *testTty, uint8_t *buffer, int count);
 uint32_t testTty_interruptRead(MosaicTestTty *testTty);
-uint32_t testTty_focusEvent(MosaicTestTty *testTty, bool focused);
-uint32_t testTty_keyEvent(MosaicTestTty *testTty);
-uint32_t testTty_mouseEvent(MosaicTestTty *testTty);
-uint32_t testTty_resizeEvent(MosaicTestTty *testTty, int columns, int rows, int width, int height);
+uint32_t testTty_resize(MosaicTestTty *testTty, int columns, int rows, int width, int height);
+uint32_t testTty_sendFocusEvent(MosaicTestTty *testTty, bool focused);
+uint32_t testTty_sendKeyEvent(MosaicTestTty *testTty);
+uint32_t testTty_sendMouseEvent(MosaicTestTty *testTty);
 uint32_t testTty_free(MosaicTestTty *testTty);
 
 #endif // MOSAIC_TEST_TTY_H

--- a/mosaic-tty/src/commonMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
+++ b/mosaic-tty/src/commonMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
@@ -37,12 +37,21 @@ public expect class TestTty : AutoCloseable {
 	public fun interruptRead()
 
 	/**
+	 * Resize the TTY.
+	 *
+	 * This will change the value returned by [Tty.currentSize].
+	 * If [Tty.enableWindowResizeEvents] was enabled, this will also cause [Tty.Callback.onResize]
+	 * to be invoked.
+	 */
+	public fun resize(columns: Int, rows: Int, width: Int, height: Int)
+
+	/**
 	 * Send a focus event to [tty]'s callback.
 	 *
 	 * On Windows this event can only be observed by during calls to [Tty.read] or
 	 * [Tty.readWithTimeout]. This event is not supported on other platforms.
 	 */
-	public fun focusEvent(focused: Boolean)
+	public fun sendFocusEvent(focused: Boolean)
 
 	/**
 	 * Send a key event to [tty]'s callback.
@@ -52,7 +61,7 @@ public expect class TestTty : AutoCloseable {
 	 * On Windows this event can only be observed by during calls to [Tty.read] or
 	 * [Tty.readWithTimeout]. This event is not supported on other platforms.
 	 */
-	public fun keyEvent()
+	public fun sendKeyEvent()
 
 	/**
 	 * Send a mouse event to [tty]'s callback.
@@ -62,15 +71,7 @@ public expect class TestTty : AutoCloseable {
 	 * On Windows this event can only be observed by during calls to [Tty.read] or
 	 * [Tty.readWithTimeout]. This event is not supported on other platforms.
 	 */
-	public fun mouseEvent()
-
-	/**
-	 * Send a resize event to [tty]'s callback.
-	 *
-	 * On Windows this event can only be observed by during calls to [Tty.read] or
-	 * [Tty.readWithTimeout]. On other platforms this is delivered to the callback synchronously.
-	 */
-	public fun resizeEvent(columns: Int, rows: Int, width: Int, height: Int)
+	public fun sendMouseEvent()
 
 	override fun close()
 }

--- a/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TtyTest.kt
+++ b/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TtyTest.kt
@@ -118,7 +118,7 @@ class TtyTest {
 	}
 
 	@Test fun focusEventNoCallback() {
-		testTty.focusEvent(true)
+		testTty.sendFocusEvent(true)
 	}
 
 	@Test fun focusEventCallbackDeliveredOnWindows() = runTest {
@@ -126,7 +126,7 @@ class TtyTest {
 
 		tty.setCallback(MyCallback())
 
-		testTty.focusEvent(true)
+		testTty.sendFocusEvent(true)
 		doWriteReadRoundtrip()
 
 		assertThat(events.receive()).isEqualTo("hey! onFocus true")
@@ -137,13 +137,13 @@ class TtyTest {
 
 		tty.setCallback(MyCallback())
 
-		testTty.focusEvent(true)
+		testTty.sendFocusEvent(true)
 
 		assertEventsEmpty()
 	}
 
 	@Test fun keyEventNoCallback() {
-		testTty.keyEvent()
+		testTty.sendKeyEvent()
 	}
 
 	@Ignore // Event not delivered yet.
@@ -152,7 +152,7 @@ class TtyTest {
 
 		tty.setCallback(MyCallback())
 
-		testTty.keyEvent()
+		testTty.sendKeyEvent()
 		doWriteReadRoundtrip()
 
 		assertThat(events.receive()).isEqualTo("hey! onKey")
@@ -163,13 +163,13 @@ class TtyTest {
 
 		tty.setCallback(MyCallback())
 
-		testTty.keyEvent()
+		testTty.sendKeyEvent()
 
 		assertEventsEmpty()
 	}
 
 	@Test fun mouseEventNoCallback() {
-		testTty.mouseEvent()
+		testTty.sendMouseEvent()
 	}
 
 	@Ignore // Event not delivered yet.
@@ -178,7 +178,7 @@ class TtyTest {
 
 		tty.setCallback(MyCallback())
 
-		testTty.mouseEvent()
+		testTty.sendMouseEvent()
 		doWriteReadRoundtrip()
 
 		assertThat(events.receive()).isEqualTo("hey! onMouse")
@@ -189,20 +189,20 @@ class TtyTest {
 
 		tty.setCallback(MyCallback())
 
-		testTty.mouseEvent()
+		testTty.sendMouseEvent()
 
 		assertEventsEmpty()
 	}
 
-	@Test fun resizeEventNoCallback() {
-		testTty.resizeEvent(1, 2, 3, 4)
+	@Test fun resizeNoCallback() {
+		testTty.resize(1, 2, 3, 4)
 	}
 
-	@Test fun resizeEventCallback() = runTest {
+	@Test fun resizeCallback() = runTest {
 		tty.enableWindowResizeEvents()
 		tty.setCallback(MyCallback())
 
-		testTty.resizeEvent(1, 2, 3, 4)
+		testTty.resize(1, 2, 3, 4)
 		doWriteReadRoundtrip()
 
 		val expected = if (isWindows()) {
@@ -217,7 +217,7 @@ class TtyTest {
 		tty.setCallback(MyCallback())
 		tty.setCallback(null)
 
-		testTty.resizeEvent(1, 2, 3, 4)
+		testTty.resize(1, 2, 3, 4)
 		doWriteReadRoundtrip()
 
 		assertEventsEmpty()
@@ -228,7 +228,7 @@ class TtyTest {
 		tty.setCallback(MyCallback())
 		tty.setCallback(MyCallback("hello!"))
 
-		testTty.resizeEvent(1, 2, 0, 0)
+		testTty.resize(1, 2, 0, 0)
 		doWriteReadRoundtrip()
 
 		assertThat(events.receive()).isEqualTo("hello! onResize 1 2 0 0")
@@ -259,10 +259,12 @@ class TtyTest {
 		callbackRef.assertGc()
 	}
 
-	@Test fun sizeAndResize() {
+	@Test fun defaultSize() {
 		assertThat(tty.currentSize()).isEqualTo(intArrayOf(80, 24, 0, 0))
+	}
 
-		testTty.resizeEvent(90, 30, 0, 0)
+	@Test fun resizeAffectsSize() {
+		testTty.resize(90, 30, 0, 0)
 		assertThat(tty.currentSize()).isEqualTo(intArrayOf(90, 30, 0, 0))
 	}
 

--- a/mosaic-tty/src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c
+++ b/mosaic-tty/src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c
@@ -448,47 +448,47 @@ Java_com_jakewharton_mosaic_tty_Jni_testTtyInterruptRead(
 }
 
 JNIEXPORT void JNICALL
-Java_com_jakewharton_mosaic_tty_Jni_testTtyFocusEvent(
+Java_com_jakewharton_mosaic_tty_Jni_testTtySendFocusEvent(
 	JNIEnv *env,
 	jclass type UNUSED,
 	jlong testTtyOpaque,
 	jboolean focused
 ) {
 	MosaicTestTty *testTty = (MosaicTestTty *) testTtyOpaque;
-	uint32_t error = testTty_focusEvent(testTty, focused);
+	uint32_t error = testTty_sendFocusEvent(testTty, focused);
 	if (unlikely(error)) {
 		throwIoe(env, error);
 	}
 }
 
 JNIEXPORT void JNICALL
-Java_com_jakewharton_mosaic_tty_Jni_testTtyKeyEvent(
+Java_com_jakewharton_mosaic_tty_Jni_testTtySendKeyEvent(
 	JNIEnv *env,
 	jclass type UNUSED,
 	jlong testTtyOpaque
 ) {
 	MosaicTestTty *testTty = (MosaicTestTty *) testTtyOpaque;
-	uint32_t error = testTty_keyEvent(testTty);
+	uint32_t error = testTty_sendKeyEvent(testTty);
 	if (unlikely(error)) {
 		throwIoe(env, error);
 	}
 }
 
 JNIEXPORT void JNICALL
-Java_com_jakewharton_mosaic_tty_Jni_testTtyMouseEvent(
+Java_com_jakewharton_mosaic_tty_Jni_testTtySendMouseEvent(
 	JNIEnv *env,
 	jclass type UNUSED,
 	jlong testTtyOpaque
 ) {
 	MosaicTestTty *testTty = (MosaicTestTty *) testTtyOpaque;
-	uint32_t error = testTty_mouseEvent(testTty);
+	uint32_t error = testTty_sendMouseEvent(testTty);
 	if (unlikely(error)) {
 		throwIoe(env, error);
 	}
 }
 
 JNIEXPORT void JNICALL
-Java_com_jakewharton_mosaic_tty_Jni_testTtyResizeEvent(
+Java_com_jakewharton_mosaic_tty_Jni_testTtyResize(
 	JNIEnv *env,
 	jclass type UNUSED,
 	jlong testTtyOpaque,
@@ -498,7 +498,7 @@ Java_com_jakewharton_mosaic_tty_Jni_testTtyResizeEvent(
 	jint height
 ) {
 	MosaicTestTty *testTty = (MosaicTestTty *) testTtyOpaque;
-	uint32_t error = testTty_resizeEvent(testTty, columns, rows, width, height);
+	uint32_t error = testTty_resize(testTty, columns, rows, width, height);
 	if (unlikely(error)) {
 		throwIoe(env, error);
 	}

--- a/mosaic-tty/src/jvmMain/java/com/jakewharton/mosaic/tty/Jni.java
+++ b/mosaic-tty/src/jvmMain/java/com/jakewharton/mosaic/tty/Jni.java
@@ -114,19 +114,19 @@ final class Jni {
 
 	static native void testTtyInterruptRead(long testTtyPtr);
 
-	static native void testTtyFocusEvent(long testTtyPtr, boolean focused);
-
-	static native void testTtyKeyEvent(long testTtyPtr);
-
-	static native void testTtyMouseEvent(long testTtyPtr);
-
-	static native void testTtyResizeEvent(
+	static native void testTtyResize(
 		long testTtyPtr,
 		int columns,
 		int rows,
 		int width,
 		int height
 	);
+
+	static native void testTtySendFocusEvent(long testTtyPtr, boolean focused);
+
+	static native void testTtySendKeyEvent(long testTtyPtr);
+
+	static native void testTtySendMouseEvent(long testTtyPtr);
 
 	static native void testTtyFree(long testTtyPtr);
 

--- a/mosaic-tty/src/jvmMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
+++ b/mosaic-tty/src/jvmMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
@@ -34,23 +34,23 @@ public actual class TestTty private constructor(
 	}
 
 	@Throws(IOException::class)
-	public actual fun focusEvent(focused: Boolean) {
-		Jni.testTtyFocusEvent(testTtyPtr, focused)
+	public actual fun resize(columns: Int, rows: Int, width: Int, height: Int) {
+		Jni.testTtyResize(testTtyPtr, columns, rows, width, height)
 	}
 
 	@Throws(IOException::class)
-	public actual fun keyEvent() {
-		Jni.testTtyKeyEvent(testTtyPtr)
+	public actual fun sendFocusEvent(focused: Boolean) {
+		Jni.testTtySendFocusEvent(testTtyPtr, focused)
 	}
 
 	@Throws(IOException::class)
-	public actual fun mouseEvent() {
-		Jni.testTtyMouseEvent(testTtyPtr)
+	public actual fun sendKeyEvent() {
+		Jni.testTtySendKeyEvent(testTtyPtr)
 	}
 
 	@Throws(IOException::class)
-	public actual fun resizeEvent(columns: Int, rows: Int, width: Int, height: Int) {
-		Jni.testTtyResizeEvent(testTtyPtr, columns, rows, width, height)
+	public actual fun sendMouseEvent() {
+		Jni.testTtySendMouseEvent(testTtyPtr)
 	}
 
 	@Throws(IOException::class)

--- a/mosaic-tty/src/nativeMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
+++ b/mosaic-tty/src/nativeMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
@@ -58,29 +58,29 @@ public actual class TestTty private constructor(
 		}
 	}
 
-	public actual fun focusEvent(focused: Boolean) {
-		val error = testTty_focusEvent(ptr, focused)
+	public actual fun resize(columns: Int, rows: Int, width: Int, height: Int) {
+		val error = testTty_resize(ptr, columns, rows, width, height)
 		if (error != 0U) {
 			throwIoe(error)
 		}
 	}
 
-	public actual fun keyEvent() {
-		val error = testTty_keyEvent(ptr)
+	public actual fun sendFocusEvent(focused: Boolean) {
+		val error = testTty_sendFocusEvent(ptr, focused)
 		if (error != 0U) {
 			throwIoe(error)
 		}
 	}
 
-	public actual fun mouseEvent() {
-		val error = testTty_mouseEvent(ptr)
+	public actual fun sendKeyEvent() {
+		val error = testTty_sendKeyEvent(ptr)
 		if (error != 0U) {
 			throwIoe(error)
 		}
 	}
 
-	public actual fun resizeEvent(columns: Int, rows: Int, width: Int, height: Int) {
-		val error = testTty_resizeEvent(ptr, columns, rows, width, height)
+	public actual fun sendMouseEvent() {
+		val error = testTty_sendMouseEvent(ptr)
 		if (error != 0U) {
 			throwIoe(error)
 		}


### PR DESCRIPTION
Resize is not just for sending events on Windows, so give it a distinct name.

Add 'send' verb for the Windows-specific, event-based callback helpers.

Update change log for window size fix.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
