### PR TITLE
Remove Windows 2019 runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,8 +90,6 @@ jobs:
             target: linuxX64
           - os: ubuntu-24.04-arm
             target: linuxArm64
-          - os: windows-2019
-            target: mingwX64
           - os: windows-2022
             target: mingwX64
           - os: windows-2025


### PR DESCRIPTION
Closes #863

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
