### PR TITLE
Use AndroidX Compose runtime

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,4 +23,12 @@
 			extractVersionTemplate: '^(?<version>\\d+)',
 		},
 	],
+	packageRules: [
+		{
+			packagePatterns: [
+				'^org.jetbrains.compose.runtime:runtime:',
+			],
+			enabled: false,
+		},
+	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ New:
 - Nothing yet
 
 Changed:
-- Nothing yet
+- Use the AndroidX Compose runtime which is now fully multiplatform. A dependency constraint to the JetBrains Compose runtime version 1.9.0 has been added, which is the first version that is empty and itself now points to AndroidX.
 
 Fixed:
 - Nothing yet

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,8 +16,8 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-io-core = "org.jetbrains.kotlinx:kotlinx-io-core:0.8.0"
 
 androidx-annotation = "androidx.annotation:annotation:1.9.1"
-androidx-collection = { module = "org.jetbrains.compose.collection-internal:collection", version.ref = "jetbrains-compose" }
-androidx-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jetbrains-compose" }
+androidx-collection = "androidx.collection:collection:1.5.0"
+androidx-compose-runtime = "androidx.compose.runtime:runtime:1.9.1"
 androidx-lifecycle-compose = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.3"
 
 mavenPublishGradlePlugin = "com.vanniktech:gradle-maven-publish-plugin:0.34.0"

--- a/mosaic-runtime/build.gradle
+++ b/mosaic-runtime/build.gradle
@@ -42,3 +42,11 @@ kotlin {
 	compilerOptions.freeCompilerArgs.add('-Xnon-local-break-continue')
 	compilerOptions.freeCompilerArgs.add('-Xwhen-guards')
 }
+
+dependencies {
+	constraints {
+		commonMainApi("org.jetbrains.compose.runtime:runtime:1.9.0") {
+			because('AndroidX publishes multiplatform runtime. The JetBrains artifact is now empty.')
+		}
+	}
+}


### PR DESCRIPTION
Closes #946

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
