### PR TITLE
Unify the read/write tests

### DIFF
--- a/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/ReadWriteTest.kt
+++ b/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/ReadWriteTest.kt
@@ -1,0 +1,214 @@
+package com.jakewharton.mosaic.tty
+
+import app.cash.burst.Burst
+import app.cash.burst.InterceptTest
+import app.cash.burst.TestFunction
+import app.cash.burst.TestInterceptor
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isZero
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.measureTime
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Burst
+@OptIn(DelicateCoroutinesApi::class) // For simple fire-and-forget parallelism.
+class ReadWriteTest(
+	private val readerAndWriter: ReaderAndWriter,
+) {
+	@InterceptTest
+	private val rw = readerAndWriter.interceptor
+
+	@Test fun readWhatWasWritten() {
+		val buffer = ByteArray(10) { 'x'.code.toByte() }
+
+		rw.write("hello")
+		val readA = rw.read(buffer, 0, 10)
+		assertThat(readA, "readA").isEqualTo(5)
+		assertThat(buffer.decodeToString()).isEqualTo("helloxxxxx")
+
+		rw.write("world")
+		val readB = rw.read(buffer, 0, 10)
+		assertThat(readB, "readB").isEqualTo(5)
+		assertThat(buffer.decodeToString()).isEqualTo("worldxxxxx")
+	}
+
+	@Test fun readOnlyUpToCount() {
+		val buffer = ByteArray(10) { 'x'.code.toByte() }
+
+		rw.write("abcdefghij")
+		val read = rw.read(buffer, 0, 5)
+		assertThat(read).isEqualTo(5)
+		assertThat(buffer.decodeToString()).isEqualTo("abcdexxxxx")
+
+		// Drain the buffer, otherwise resetting raw mode will hang on its flush.
+		rw.read(buffer, 0, 5)
+	}
+
+	@Test fun readUnderflow() {
+		val buffer = ByteArray(10) { 'x'.code.toByte() }
+
+		rw.write("hello")
+		val read = rw.read(buffer, 0, 10)
+		assertThat(read).isEqualTo(5)
+		assertThat(buffer.decodeToString()).isEqualTo("helloxxxxx")
+	}
+
+	@Test fun readAtOffset() {
+		val buffer = ByteArray(10) { 'x'.code.toByte() }
+
+		rw.write("hello")
+		val read = rw.read(buffer, 5, 5)
+		assertThat(read).isEqualTo(5)
+		assertThat(buffer.decodeToString()).isEqualTo("xxxxxhello")
+	}
+
+	@Test fun readCanBeInterrupted() {
+		GlobalScope.launch(Dispatchers.Default) {
+			delay(150.milliseconds)
+			rw.interruptRead()
+		}
+		val readA = rw.read(ByteArray(10), 0, 10)
+		assertThat(readA).isZero()
+
+		GlobalScope.launch(Dispatchers.Default) {
+			delay(150.milliseconds)
+			rw.interruptRead()
+		}
+		val readB = rw.read(ByteArray(10), 0, 10)
+		assertThat(readB).isZero()
+	}
+
+	@Test fun readWithTimeoutReturnsZeroOnTimeout() {
+		if (readerAndWriter == ReaderAndWriter.TestAndTty) return // Unsupported
+
+		// Windows appears to be happy to return a few milliseconds early, so we just validate a
+		// conservative lower bound which indicates that there was at least _some_ waiting.
+
+		val readA: Int
+		val tookA = measureTime {
+			readA = rw.readWithTimeout(ByteArray(10), 0, 10, 100)
+		}
+		assertThat(readA).isZero()
+		assertThat(tookA).isGreaterThan(50.milliseconds)
+
+		val readB: Int
+		val tookB = measureTime {
+			readB = rw.readWithTimeout(ByteArray(10), 0, 10, 100)
+		}
+		assertThat(readB).isZero()
+		assertThat(tookB).isGreaterThan(50.milliseconds)
+	}
+
+	@Test fun writeOnlyUpToCount() {
+		val written = rw.write("abcdefghij".encodeToByteArray(), 0, 5)
+		assertThat(written).isEqualTo(5)
+
+		val buffer = ByteArray(10) { 'x'.code.toByte() }
+		val read = rw.read(buffer, 0, 10)
+		assertThat(read).isEqualTo(5)
+		assertThat(buffer.decodeToString()).isEqualTo("abcdexxxxx")
+	}
+
+	@Test fun writeAtOffset() {
+		val written = rw.write("abcdefghij".encodeToByteArray(), 5, 5)
+		assertThat(written).isEqualTo(5)
+
+		val buffer = ByteArray(10) { 'x'.code.toByte() }
+		val read = rw.read(buffer, 0, 10)
+		assertThat(read).isEqualTo(5)
+		assertThat(buffer.decodeToString()).isEqualTo("fghijxxxxx")
+	}
+
+	interface ReadWrite : TestInterceptor {
+		fun write(message: String)
+		fun write(buffer: ByteArray, offset: Int, count: Int): Int
+		fun read(buffer: ByteArray, offset: Int, count: Int): Int
+		fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int
+		fun interruptRead()
+	}
+
+	enum class ReaderAndWriter {
+		TtyAndTest {
+			override val interceptor get() = object : ReadWrite {
+				private lateinit var testTty: TestTty
+				private lateinit var tty: Tty
+
+				override fun intercept(testFunction: TestFunction) {
+					TestTty.bind().use { testTty ->
+						this.testTty = testTty
+						tty = testTty.tty
+						tty.enableRawMode()
+
+						testFunction()
+					}
+				}
+
+				override fun write(message: String) {
+					testTty.write(message)
+				}
+
+				override fun write(buffer: ByteArray, offset: Int, count: Int): Int {
+					return testTty.write(buffer, offset, count)
+				}
+
+				override fun read(buffer: ByteArray, offset: Int, count: Int): Int {
+					return tty.read(buffer, offset, count)
+				}
+
+				override fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int {
+					return tty.readWithTimeout(buffer, offset, count, timeoutMillis)
+				}
+
+				override fun interruptRead() {
+					tty.interruptRead()
+				}
+			}
+		},
+		TestAndTty {
+			override val interceptor get() = object : ReadWrite {
+				private lateinit var testTty: TestTty
+				private lateinit var tty: Tty
+
+				override fun intercept(testFunction: TestFunction) {
+					TestTty.bind().use { testTty ->
+						this.testTty = testTty
+						tty = testTty.tty
+						tty.enableRawMode()
+
+						testFunction()
+					}
+				}
+
+				override fun write(message: String) {
+					tty.write(message)
+				}
+
+				override fun write(buffer: ByteArray, offset: Int, count: Int): Int {
+					return tty.write(buffer, offset, count)
+				}
+
+				override fun read(buffer: ByteArray, offset: Int, count: Int): Int {
+					return testTty.read(buffer, offset, count)
+				}
+
+				override fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int {
+					throw UnsupportedOperationException()
+				}
+
+				override fun interruptRead() {
+					testTty.interruptRead()
+				}
+			}
+		},
+		;
+
+		abstract val interceptor: ReadWrite
+	}
+}

--- a/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TestTtyTest.kt
+++ b/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TestTtyTest.kt
@@ -6,14 +6,8 @@ import assertk.assertThat
 import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
-import assertk.assertions.isZero
 import kotlin.test.AfterTest
 import kotlin.test.Test
-import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runTest
 
 @Burst
 class TestTtyTest {
@@ -52,88 +46,6 @@ class TestTtyTest {
 			tty.reset()
 			tty.enableRawMode()
 		}
-	}
-
-	@Test fun readWhatWasWritten() {
-		tty.write("hello")
-
-		val bufferA = ByteArray(10) { 'x'.code.toByte() }
-		val readA = testTty.read(bufferA, 0, 10)
-		assertThat(readA, "readA").isEqualTo(5)
-		assertThat(bufferA.decodeToString()).isEqualTo("helloxxxxx")
-
-		tty.write("world")
-
-		val bufferB = ByteArray(10) { 'x'.code.toByte() }
-		val readB = testTty.read(bufferB, 0, 10)
-		assertThat(readB, "readB").isEqualTo(5)
-		assertThat(bufferB.decodeToString()).isEqualTo("worldxxxxx")
-	}
-
-	@Test fun readOnlyUpToCount() {
-		tty.write("abcdefghij")
-
-		val buffer = ByteArray(10) { 'x'.code.toByte() }
-		val read = testTty.read(buffer, 0, 5)
-		assertThat(read).isEqualTo(5)
-		assertThat(buffer.decodeToString()).isEqualTo("abcdexxxxx")
-
-		// Drain the TTY output buffer, otherwise resetting raw mode will hang on its flush.
-		testTty.read(5)
-	}
-
-	@Test fun readUnderflow() {
-		tty.write("hello")
-
-		val buffer = ByteArray(10) { 'x'.code.toByte() }
-		val read = testTty.read(buffer, 0, 10)
-		assertThat(read).isEqualTo(5)
-		assertThat(buffer.decodeToString()).isEqualTo("helloxxxxx")
-	}
-
-	@Test fun readAtOffset() {
-		tty.write("hello")
-
-		val buffer = ByteArray(10) { 'x'.code.toByte() }
-		val read = testTty.read(buffer, 5, 5)
-		assertThat(read).isEqualTo(5)
-		assertThat(buffer.decodeToString()).isEqualTo("xxxxxhello")
-	}
-
-	@Test fun readCanBeInterrupted() = runTest {
-		backgroundScope.launch(Dispatchers.Default) {
-			delay(150.milliseconds)
-			testTty.interruptRead()
-		}
-		val readA = testTty.read(ByteArray(10), 0, 10)
-		assertThat(readA).isZero()
-
-		backgroundScope.launch(Dispatchers.Default) {
-			delay(150.milliseconds)
-			testTty.interruptRead()
-		}
-		val readB = testTty.read(ByteArray(10), 0, 10)
-		assertThat(readB).isZero()
-	}
-
-	@Test fun writeOnlyUpToCount() {
-		val written = testTty.write("abcdefghij".encodeToByteArray(), 0, 5)
-		assertThat(written).isEqualTo(5)
-
-		val buffer = ByteArray(10) { 'x'.code.toByte() }
-		val read = tty.read(buffer, 0, 10)
-		assertThat(read).isEqualTo(5)
-		assertThat(buffer.decodeToString()).isEqualTo("abcdexxxxx")
-	}
-
-	@Test fun writeAtOffset() {
-		val written = testTty.write("abcdefghij".encodeToByteArray(), 5, 5)
-		assertThat(written).isEqualTo(5)
-
-		val buffer = ByteArray(10) { 'x'.code.toByte() }
-		val read = tty.read(buffer, 0, 10)
-		assertThat(read).isEqualTo(5)
-		assertThat(buffer.decodeToString()).isEqualTo("fghijxxxxx")
 	}
 
 	@Test fun stdinIsTtySetting(value: Boolean) {

--- a/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TtyTest.kt
+++ b/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/TtyTest.kt
@@ -2,21 +2,14 @@ package com.jakewharton.mosaic.tty
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import assertk.assertions.isGreaterThan
 import assertk.assertions.isTrue
-import assertk.assertions.isZero
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.measureTime
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -39,82 +32,6 @@ class TtyTest {
 
 	private fun assertEventsEmpty() {
 		assertThat(events.isEmpty, name = "events empty").isTrue()
-	}
-
-	@Test fun readWhatWasWritten() {
-		val buffer = ByteArray(10) { 'x'.code.toByte() }
-
-		testTty.write("hello")
-		val readA = tty.read(buffer, 0, 10)
-		assertThat(readA, "readA").isEqualTo(5)
-		assertThat(buffer.decodeToString()).isEqualTo("helloxxxxx")
-
-		testTty.write("world")
-		val readB = tty.read(buffer, 0, 10)
-		assertThat(readB, "readB").isEqualTo(5)
-		assertThat(buffer.decodeToString()).isEqualTo("worldxxxxx")
-	}
-
-	@Test fun readOnlyUpToCount() {
-		val buffer = ByteArray(10) { 'x'.code.toByte() }
-
-		testTty.write("hello")
-		val read = tty.read(buffer, 0, 4)
-		assertThat(read).isEqualTo(4)
-		assertThat(buffer.decodeToString()).isEqualTo("hellxxxxxx")
-	}
-
-	@Test fun readUnderflow() {
-		val buffer = ByteArray(10) { 'x'.code.toByte() }
-
-		testTty.write("hello")
-		val read = tty.read(buffer, 0, 10)
-		assertThat(read).isEqualTo(5)
-		assertThat(buffer.decodeToString()).isEqualTo("helloxxxxx")
-	}
-
-	@Test fun readAtOffset() {
-		val buffer = ByteArray(10) { 'x'.code.toByte() }
-
-		testTty.write("hello")
-		val read = tty.read(buffer, 5, 5)
-		assertThat(read).isEqualTo(5)
-		assertThat(buffer.decodeToString()).isEqualTo("xxxxxhello")
-	}
-
-	@Test fun readCanBeInterrupted() = runTest {
-		backgroundScope.launch(Dispatchers.Default) {
-			delay(150.milliseconds)
-			tty.interruptRead()
-		}
-		val readA = tty.read(ByteArray(10), 0, 10)
-		assertThat(readA).isZero()
-
-		backgroundScope.launch(Dispatchers.Default) {
-			delay(150.milliseconds)
-			tty.interruptRead()
-		}
-		val readB = tty.read(ByteArray(10), 0, 10)
-		assertThat(readB).isZero()
-	}
-
-	@Test fun readWithTimeoutReturnsZeroOnTimeout() {
-		// Windows appears to be happy to return a few milliseconds early, so we just validate a
-		// conservative lower bound which indicates that there was at least _some_ waiting.
-
-		val readA: Int
-		val tookA = measureTime {
-			readA = tty.readWithTimeout(ByteArray(10), 0, 10, 100)
-		}
-		assertThat(readA).isZero()
-		assertThat(tookA).isGreaterThan(50.milliseconds)
-
-		val readB: Int
-		val tookB = measureTime {
-			readB = tty.readWithTimeout(ByteArray(10), 0, 10, 100)
-		}
-		assertThat(readB).isZero()
-		assertThat(tookB).isGreaterThan(50.milliseconds)
 	}
 
 	@Test fun focusEventNoCallback() {

--- a/mosaic-tty/src/jvmTest/resources/META-INF/proguard/com.jakewharton.mosaic-tty-tests.pro
+++ b/mosaic-tty/src/jvmTest/resources/META-INF/proguard/com.jakewharton.mosaic-tty-tests.pro
@@ -3,6 +3,12 @@
 	@org.junit.* public void *(...);
 }
 
+# Burst appends class-parameters to test name after an underscore.
+-keep class **.*Test_* {
+	public <init>();
+	@org.junit.* public void *(...);
+}
+
 # Gradle does A LOT of reflection to invoke JUnit. Just keep it all.
 -keep,includedescriptorclasses class org.junit.** {
 	*** *(...);


### PR DESCRIPTION
This ensures we're testing the same thing from both directions, and can reuse it for testing stdin, stdout, and stderr manipulation in the future.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
