### PR TITLE
Add `TestTty.readWithTimeout`

### DIFF
--- a/mosaic-tty/api/mosaic-tty.api
+++ b/mosaic-tty/api/mosaic-tty.api
@@ -25,6 +25,7 @@ public final class com/jakewharton/mosaic/tty/TestTty : java/lang/AutoCloseable 
 	public final fun getTty ()Lcom/jakewharton/mosaic/tty/Tty;
 	public final fun interruptRead ()V
 	public final fun read ([BII)I
+	public final fun readWithTimeout ([BIII)I
 	public final fun resize (IIII)V
 	public final fun sendFocusEvent (Z)V
 	public final fun sendKeyEvent ()V

--- a/mosaic-tty/api/mosaic-tty.klib.api
+++ b/mosaic-tty/api/mosaic-tty.klib.api
@@ -35,6 +35,7 @@ final class com.jakewharton.mosaic.tty/TestTty : kotlin/AutoCloseable { // com.j
     final fun close() // com.jakewharton.mosaic.tty/TestTty.close|close(){}[0]
     final fun interruptRead() // com.jakewharton.mosaic.tty/TestTty.interruptRead|interruptRead(){}[0]
     final fun read(kotlin/ByteArray, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/TestTty.read|read(kotlin.ByteArray;kotlin.Int;kotlin.Int){}[0]
+    final fun readWithTimeout(kotlin/ByteArray, kotlin/Int, kotlin/Int, kotlin/Int): kotlin/Int // com.jakewharton.mosaic.tty/TestTty.readWithTimeout|readWithTimeout(kotlin.ByteArray;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
     final fun resize(kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int) // com.jakewharton.mosaic.tty/TestTty.resize|resize(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
     final fun sendFocusEvent(kotlin/Boolean) // com.jakewharton.mosaic.tty/TestTty.sendFocusEvent|sendFocusEvent(kotlin.Boolean){}[0]
     final fun sendKeyEvent() // com.jakewharton.mosaic.tty/TestTty.sendKeyEvent|sendKeyEvent(){}[0]

--- a/mosaic-tty/src/commonMain/c/mosaic-test-tty-posix.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-test-tty-posix.c
@@ -135,6 +135,14 @@ MosaicIoResult testTty_read(MosaicTestTty *testTty, uint8_t *buffer, int count) 
 	return tty_readInternal(testTty->parent_fd, testTty->parent_fd_interrupt_reader, buffer, count, NULL);
 }
 
+MosaicIoResult testTty_readWithTimeout(MosaicTestTty *testTty, uint8_t *buffer, int count, int timeoutMillis) {
+	struct timeval timeout;
+	timeout.tv_sec = 0;
+	timeout.tv_usec = timeoutMillis * 1000;
+
+	return tty_readInternal(testTty->parent_fd, testTty->parent_fd_interrupt_reader, buffer, count, &timeout);
+}
+
 uint32_t testTty_interruptRead(MosaicTestTty *testTty) {
 	uint8_t space = ' ';
 	MosaicIoResult result = tty_writeInternal(testTty->parent_fd_interrupt_writer, &space, 1);

--- a/mosaic-tty/src/commonMain/c/mosaic-test-tty-windows.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-test-tty-windows.c
@@ -158,7 +158,13 @@ MOSAIC_EXPORT MosaicIoResult testTty_write(MosaicTestTty *testTty, uint8_t *buff
 }
 
 MOSAIC_EXPORT MosaicIoResult testTty_read(MosaicTestTty *testTty, uint8_t *buffer, int count) {
+	return testTty_readWithTimeout(testTty, buffer, count, INFINITE);
+}
+
+MOSAIC_EXPORT MosaicIoResult testTty_readWithTimeout(MosaicTestTty *testTty, uint8_t *buffer, int count, int timeoutMillis) {
 	MosaicIoResult result = {};
+
+	ULONGLONG startMillis = GetTickCount64();
 
 	// Perform a spin loop to check for data or interrupt. We can't do a normal wait because pipes
 	// do not signal properly. Since this is only for testing, the busy wait isn't a huge deal.
@@ -177,6 +183,11 @@ MOSAIC_EXPORT MosaicIoResult testTty_read(MosaicTestTty *testTty, uint8_t *buffe
 		}
 		if (atomic_load(&testTty->conout_interrupt)) {
 			atomic_store(&testTty->conout_interrupt, false);
+			// result.count will be 0
+			break;
+		}
+		ULONGLONG elapsedMillis = GetTickCount64() - startMillis;
+		if (elapsedMillis >= (ULONGLONG) timeoutMillis) {
 			// result.count will be 0
 			break;
 		}

--- a/mosaic-tty/src/commonMain/c/mosaic-test-tty.h
+++ b/mosaic-tty/src/commonMain/c/mosaic-test-tty.h
@@ -22,6 +22,7 @@ MOSAIC_EXPORT MosaicStreams *testTty_getStreams(MosaicTestTty *testTty);
 MOSAIC_EXPORT MosaicIoResult testTty_write(MosaicTestTty *testTty, uint8_t *buffer, int count);
 
 MOSAIC_EXPORT MosaicIoResult testTty_read(MosaicTestTty *testTty, uint8_t *buffer, int count);
+MOSAIC_EXPORT MosaicIoResult testTty_readWithTimeout(MosaicTestTty *testTty, uint8_t *buffer, int count, int timeoutMillis);
 MOSAIC_EXPORT uint32_t testTty_interruptRead(MosaicTestTty *testTty);
 
 MOSAIC_EXPORT uint32_t testTty_resize(MosaicTestTty *testTty, int columns, int rows, int width, int height);

--- a/mosaic-tty/src/commonMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
+++ b/mosaic-tty/src/commonMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
@@ -35,11 +35,26 @@ public expect class TestTty : AutoCloseable {
 
 	/**
 	 * Read up to [count] bytes into [buffer] at [offset] from the PTY.
-	 * The number of bytes read will be returned.
+	 * The number of bytes read will be returned. 0 will be returned if [interruptRead] is called
+	 * while waiting for data.
 	 *
+	 * @see readWithTimeout
 	 * @see Tty.write
 	 */
 	public fun read(buffer: ByteArray, offset: Int, count: Int): Int
+
+	/**
+	 * Read up to [count] bytes into [buffer] at [offset] from the PTY.
+	 * The number of bytes read will be returned. 0 will be returned if [interruptRead] is called
+	 * while waiting for data, or if at least [timeoutMillis] have passed without data.
+	 *
+	 * @param timeoutMillis A value of 0 will perform a non-blocking read. Otherwise, valid values
+	 * are 1 to 999 which represent a maximum time (in milliseconds) to wait for data. Note: This
+	 * value is not validated.
+	 * @see read
+	 * @see Tty.write
+	 */
+	public fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int
 
 	/** Signal blocking calls to [read] to wake up and return 0. */
 	public fun interruptRead()

--- a/mosaic-tty/src/commonMain/kotlin/com/jakewharton/mosaic/tty/Tty.kt
+++ b/mosaic-tty/src/commonMain/kotlin/com/jakewharton/mosaic/tty/Tty.kt
@@ -25,7 +25,7 @@ public expect class Tty : AutoCloseable {
 	/**
 	 * Read up to [count] bytes into [buffer] at [offset] from the TTY.
 	 * The number of bytes read will be returned. 0 will be returned if [interruptRead] is called
-	 * while waiting for input. -1 will be returned if the TTY is not interactive.
+	 * while waiting for data. -1 will be returned if the TTY is not interactive.
 	 *
 	 * @see readWithTimeout
 	 */
@@ -34,7 +34,7 @@ public expect class Tty : AutoCloseable {
 	/**
 	 * Read up to [count] bytes into [buffer] at [offset] from the TTY.
 	 * The number of bytes read will be returned. 0 will be returned if [interruptRead] is called
-	 * while waiting for input, or if at least [timeoutMillis] have passed without data.
+	 * while waiting for data, or if at least [timeoutMillis] have passed without data.
 	 * -1 will be returned if the TTY is not interactive.
 	 *
 	 * @param timeoutMillis A value of 0 will perform a non-blocking read. Otherwise, valid values

--- a/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/ReadWriteTest.kt
+++ b/mosaic-tty/src/commonTest/kotlin/com/jakewharton/mosaic/tty/ReadWriteTest.kt
@@ -86,8 +86,6 @@ class ReadWriteTest(
 	}
 
 	@Test fun readWithTimeoutReturnsZeroOnTimeout() {
-		if (readerAndWriter == ReaderAndWriter.TestAndTty) return // Unsupported
-
 		// Windows appears to be happy to return a few milliseconds early, so we just validate a
 		// conservative lower bound which indicates that there was at least _some_ waiting.
 
@@ -199,7 +197,7 @@ class ReadWriteTest(
 				}
 
 				override fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int {
-					throw UnsupportedOperationException()
+					return testTty.readWithTimeout(buffer, offset, count, timeoutMillis)
 				}
 
 				override fun interruptRead() {

--- a/mosaic-tty/src/jvmJdk22/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
+++ b/mosaic-tty/src/jvmJdk22/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
@@ -6,6 +6,7 @@ import com.jakewharton.mosaic.tty.Libmosaic.testTty_getTty
 import com.jakewharton.mosaic.tty.Libmosaic.testTty_init
 import com.jakewharton.mosaic.tty.Libmosaic.testTty_interruptRead
 import com.jakewharton.mosaic.tty.Libmosaic.testTty_read
+import com.jakewharton.mosaic.tty.Libmosaic.testTty_readWithTimeout
 import com.jakewharton.mosaic.tty.Libmosaic.testTty_resize
 import com.jakewharton.mosaic.tty.Libmosaic.testTty_sendFocusEvent
 import com.jakewharton.mosaic.tty.Libmosaic.testTty_sendKeyEvent
@@ -63,6 +64,18 @@ public class TestTty private constructor(
 	public fun read(buffer: ByteArray, offset: Int, count: Int): Int {
 		val segment = Libmosaic.LIBRARY_ARENA.allocate(count.toLong())
 		val result = testTty_read(Arena.global(), ptr, segment, count)
+		val error = MosaicIoResult.error(result)
+		if (error == 0) {
+			val read = MosaicIoResult.count(result)
+			MemorySegment.copy(segment, ValueLayout.JAVA_BYTE, 0L, buffer, offset, read)
+			return read
+		}
+		throwIoe(error)
+	}
+
+	public fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int {
+		val segment = Libmosaic.LIBRARY_ARENA.allocate(count.toLong())
+		val result = testTty_readWithTimeout(Arena.global(), ptr, segment, count, timeoutMillis)
 		val error = MosaicIoResult.error(result)
 		if (error == 0) {
 			val read = MosaicIoResult.count(result)

--- a/mosaic-tty/src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c
+++ b/mosaic-tty/src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c
@@ -517,6 +517,36 @@ Java_com_jakewharton_mosaic_tty_Jni_testTtyRead(
 	return -1;
 }
 
+JNIEXPORT jint JNICALL
+Java_com_jakewharton_mosaic_tty_Jni_testTtyReadWithTimeout(
+	JNIEnv *env,
+	jclass type UNUSED,
+	jlong testTtyOpaque,
+	jbyteArray buffer,
+	jint offset,
+	jint count,
+	jint timeoutMillis
+) {
+	jbyte *bufferElements = (*env)->GetByteArrayElements(env, buffer, NULL);
+	jbyte *bufferElementsAtOffset = bufferElements + offset;
+	// Reinterpret JVM signed bytes as unsigned.
+	uint8_t *nativeBufferAtOffset = (uint8_t *) bufferElementsAtOffset;
+
+	MosaicTestTty *testTty = (MosaicTestTty *) testTtyOpaque;
+	MosaicIoResult result = testTty_readWithTimeout(testTty, nativeBufferAtOffset, count, timeoutMillis);
+
+	(*env)->ReleaseByteArrayElements(env, buffer, bufferElements, 0);
+
+	if (likely(!result.error)) {
+		return result.count;
+	}
+
+	// This throw can fail, but the only condition that should cause that is OOM. Return -1 (EOF)
+	// and should cause the program to try and exit cleanly.
+	throwIoe(env, result.error);
+	return -1;
+}
+
 JNIEXPORT void JNICALL
 Java_com_jakewharton_mosaic_tty_Jni_testTtyInterruptRead(
 	JNIEnv *env,

--- a/mosaic-tty/src/jvmMain/java/com/jakewharton/mosaic/tty/Jni.java
+++ b/mosaic-tty/src/jvmMain/java/com/jakewharton/mosaic/tty/Jni.java
@@ -102,6 +102,8 @@ final class Jni {
 
 	static native int testTtyRead(long testTtyPtr, byte[] buffer, int offset, int count);
 
+	static native int testTtyReadWithTimeout(long testTtyPtr, byte[] buffer, int offset, int count, int timeoutMillis);
+
 	static native void testTtyInterruptRead(long testTtyPtr);
 
 	static native void testTtyResize(

--- a/mosaic-tty/src/jvmMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
+++ b/mosaic-tty/src/jvmMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
@@ -37,6 +37,11 @@ public actual class TestTty private constructor(
 	}
 
 	@Throws(IOException::class)
+	public actual fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int {
+		return Jni.testTtyReadWithTimeout(testTtyPtr, buffer, offset, count, timeoutMillis)
+	}
+
+	@Throws(IOException::class)
 	public actual fun interruptRead() {
 		Jni.testTtyInterruptRead(testTtyPtr)
 	}

--- a/mosaic-tty/src/nativeMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
+++ b/mosaic-tty/src/nativeMain/kotlin/com/jakewharton/mosaic/tty/TestTty.kt
@@ -58,6 +58,17 @@ public actual class TestTty private constructor(
 		}
 	}
 
+	public actual fun readWithTimeout(buffer: ByteArray, offset: Int, count: Int, timeoutMillis: Int): Int {
+		buffer.asUByteArray().usePinned {
+			testTty_readWithTimeout(ptr, it.addressOf(offset), count, timeoutMillis).useContents {
+				if (error == 0U) {
+					return this.count
+				}
+				throwIoe(error)
+			}
+		}
+	}
+
 	public actual fun interruptRead() {
 		val error = testTty_interruptRead(ptr)
 		if (error != 0U) {


### PR DESCRIPTION
Mostly for symmetry and because we can easily.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
