### PR TITLE
Use new macOS 15 Intel runners for x86 coverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,10 +43,10 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - os: macOS-13
-            target: macosX64
           - os: macOS-14
             target: macosArm64
+          - os: macos-15-intel
+            target: macosX64
           - os: macOS-15
             target: macosArm64
           - os: macOS-26


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
