### PR TITLE
Specify a test timeout

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,6 +103,7 @@ jobs:
               version: latest
 
     runs-on: ${{ matrix.platform.os }}
+    timeout-minutes: 5
 
     steps:
       ### NATIVE


### PR DESCRIPTION
These should always be fast, but if we screw something up we don't want 60 runners hanging for 6 hours.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
