### PR TITLE
Clear observation set before observing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changed:
 - Use the AndroidX Compose runtime which is now fully multiplatform. A dependency constraint to the JetBrains Compose runtime version 1.9.0 has been added, which is the first version that is empty and itself now points to AndroidX.
 
 Fixed:
-- Nothing yet
+- Clear the set of states which were read during layout and draw passes before each pass. Previously these sets grew infinitely, which was both a memory leak and a performance problem.
 
 
 ## [0.18.0] - 2025-08-21

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -168,11 +168,11 @@ internal class MosaicComposition(
 
 	private val applyObserverHandle: ObserverHandle
 
-	private val readingStatesOnLayout = mutableScatterSetOf<Any>()
-	private val readingStatesOnDraw = mutableScatterSetOf<Any>()
+	private val readStatesOnLayout = mutableScatterSetOf<Any>()
+	private val readStatesOnLayoutObserver: (Any) -> Unit = readStatesOnLayout::add
 
-	private val layoutBlockStateReadObserver: (Any) -> Unit = readingStatesOnLayout::add
-	private val drawBlockStateReadObserver: (Any) -> Unit = readingStatesOnDraw::add
+	private val readStatesOnDraw = mutableScatterSetOf<Any>()
+	private val readStatesOnDrawObserver: (Any) -> Unit = readStatesOnDraw::add
 
 	@Volatile
 	private var needLayout = false
@@ -189,9 +189,12 @@ internal class MosaicComposition(
 
 	private fun performLayout() {
 		needLayout = false
-		Snapshot.observe(readObserver = layoutBlockStateReadObserver) {
+
+		readStatesOnLayout.clear()
+		Snapshot.observe(readObserver = readStatesOnLayoutObserver) {
 			rootNode.measureAndPlace()
 		}
+
 		performDraw()
 	}
 
@@ -201,7 +204,8 @@ internal class MosaicComposition(
 	}
 
 	override fun draw(): TextCanvas {
-		return Snapshot.observe(readObserver = drawBlockStateReadObserver) {
+		readStatesOnDraw.clear()
+		return Snapshot.observe(readObserver = readStatesOnDrawObserver) {
 			rootNode.draw()
 		}
 	}
@@ -248,14 +252,14 @@ internal class MosaicComposition(
 			if (!needLayout) {
 				var setDraw = needDraw
 				for (state in changedStates) {
-					if (state in readingStatesOnLayout) {
+					if (state in readStatesOnLayout) {
 						needLayout = true
 						break
 					}
 					if (setDraw) {
 						continue
 					}
-					if (state in readingStatesOnDraw) {
+					if (state in readStatesOnDraw) {
 						setDraw = true
 						needDraw = true
 					}


### PR DESCRIPTION
Otherwise we basically only ever grow, even as states are removed from layout or draw.

Closes #962 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
