### PR TITLE
Write to the stdout interrupter, ensure native is initialized in FFM `StandardStreams`

### DIFF
--- a/mosaic-tty/src/commonMain/c/mosaic-streams-posix.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-streams-posix.c
@@ -323,7 +323,7 @@ MosaicIoResult mosaic_streams_read_intercepted_output_with_timeout(MosaicStreams
 
 uint32_t mosaic_streams_interrupt_intercepted_output_read(MosaicStreams *streams) {
 	uint8_t space = ' ';
-	MosaicIoResult result = mosaic_utils_write(streams->interrupt_intercepted_stderr_writer, &space, 1);
+	MosaicIoResult result = mosaic_utils_write(streams->interrupt_intercepted_stdout_writer, &space, 1);
 	return result.error;
 }
 

--- a/mosaic-tty/src/jvmJdk22/kotlin/com/jakewharton/mosaic/tty/StandardStreams.kt
+++ b/mosaic-tty/src/jvmJdk22/kotlin/com/jakewharton/mosaic/tty/StandardStreams.kt
@@ -28,6 +28,8 @@ public class StandardStreams internal constructor(
 	public companion object {
 		@JvmStatic
 		public fun bind(): StandardStreams {
+			NativeLibrary.ensureLoaded()
+
 			val result = mosaic_streams_init.makeInvoker().apply(Arena.global())
 			val ptr = MosaicStreamsInitResult.streams(result)
 			if (ptr != MemorySegment.NULL) {


### PR DESCRIPTION


---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
