### PR TITLE
Rename `TestTty` to `TestTerminal` in structs

### DIFF
--- a/mosaic-tty/src/commonMain/c/mosaic-test-posix.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-test-posix.c
@@ -15,7 +15,7 @@
 #include <termios.h>
 #include <unistd.h>
 
-typedef struct MosaicTestTtyImpl {
+typedef struct MosaicTestTerminalImpl {
 	MosaicStreams *streams;
 	MosaicTty *tty;
 
@@ -35,7 +35,7 @@ typedef struct MosaicTestTtyImpl {
 	int stderr_reader_fd;
 	int stderr_interrupt_reader_fd;
 	int stderr_interrupt_writer_fd;
-} MosaicTestTtyImpl;
+} MosaicTestTerminalImpl;
 
 static uint32_t mosaic_test_resize_internal(int parentFd, int columns, int rows, int width, int height) {
 	struct winsize size = {};
@@ -49,10 +49,10 @@ static uint32_t mosaic_test_resize_internal(int parentFd, int columns, int rows,
 	return errno;
 }
 
-MosaicTestTtyInitResult mosaic_test_init(bool stdinIsTty, bool stdoutIsTty, bool stderrIsTty) {
-	MosaicTestTtyInitResult result = {};
+MosaicTestTerminalInitResult mosaic_test_init(bool stdinIsTty, bool stdoutIsTty, bool stderrIsTty) {
+	MosaicTestTerminalInitResult result = {};
 
-	MosaicTestTtyImpl *testTty = calloc(1, sizeof(MosaicTestTtyImpl));
+	MosaicTestTerminalImpl *testTty = calloc(1, sizeof(MosaicTestTerminalImpl));
 	if (unlikely(testTty == NULL)) {
 		// result.writer is set to 0 which will trigger OOM.
 		goto ret;

--- a/mosaic-tty/src/commonMain/c/mosaic-test-windows.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-test-windows.c
@@ -8,7 +8,7 @@
 #include <stdatomic.h>
 #include <windows.h>
 
-typedef struct MosaicTestTtyImpl {
+typedef struct MosaicTestTerminalImpl {
 	MosaicStreams *streams;
 	MosaicTty *tty;
 	HANDLE conin;
@@ -27,7 +27,7 @@ typedef struct MosaicTestTtyImpl {
 	HANDLE stderr_pipe_write;
 	HANDLE stderr_overlapped_event;
 	HANDLE stderr_interrupt_event;
-} MosaicTestTtyImpl;
+} MosaicTestTerminalImpl;
 
 static atomic_flag globalTestTty = ATOMIC_FLAG_INIT;
 
@@ -43,10 +43,10 @@ static uint32_t mosaic_test_resize_internal(HANDLE conout, int columns, int rows
 	return GetLastError();
 }
 
-MOSAIC_EXPORT MosaicTestTtyInitResult mosaic_test_init(bool stdinIsTty, bool stdoutIsTty, bool stderrIsTty) {
-	MosaicTestTtyInitResult result = {};
+MOSAIC_EXPORT MosaicTestTerminalInitResult mosaic_test_init(bool stdinIsTty, bool stdoutIsTty, bool stderrIsTty) {
+	MosaicTestTerminalInitResult result = {};
 
-	MosaicTestTtyImpl *testTty = calloc(1, sizeof(MosaicTestTtyImpl));
+	MosaicTestTerminalImpl *testTty = calloc(1, sizeof(MosaicTestTerminalImpl));
 	if (unlikely(testTty == NULL)) {
 		// result.testTty is set to 0 which will trigger OOM.
 		goto ret;

--- a/mosaic-tty/src/commonMain/c/mosaic-test.h
+++ b/mosaic-tty/src/commonMain/c/mosaic-test.h
@@ -7,15 +7,15 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef struct MosaicTestTtyImpl MosaicTestTty;
+typedef struct MosaicTestTerminalImpl MosaicTestTty;
 
-typedef struct MosaicTestTtyInitResult {
+typedef struct MosaicTestTerminalInitResult {
 	MosaicTestTty *testTty;
 	uint32_t error;
 	bool already_bound;
-} MosaicTestTtyInitResult;
+} MosaicTestTerminalInitResult;
 
-MOSAIC_EXPORT MosaicTestTtyInitResult mosaic_test_init(bool stdinIsTty, bool stdoutIsTty, bool stderrIsTty);
+MOSAIC_EXPORT MosaicTestTerminalInitResult mosaic_test_init(bool stdinIsTty, bool stdoutIsTty, bool stderrIsTty);
 MOSAIC_EXPORT MosaicTty *mosaic_test_get_tty(MosaicTestTty *testTty);
 MOSAIC_EXPORT MosaicStreams *mosaic_test_get_streams(MosaicTestTty *testTty);
 

--- a/mosaic-tty/src/jvmJdk22/kotlin/com/jakewharton/mosaic/tty/TestTerminal.kt
+++ b/mosaic-tty/src/jvmJdk22/kotlin/com/jakewharton/mosaic/tty/TestTerminal.kt
@@ -39,7 +39,7 @@ public class TestTerminal private constructor(
 			NativeLibrary.ensureLoaded()
 
 			val result = mosaic_test_init(Arena.global(), stdinIsTty, stdoutIsTty, stderrIsTty)
-			val ptr = MosaicTestTtyInitResult.testTty(result)
+			val ptr = MosaicTestTerminalInitResult.testTty(result)
 			if (ptr != MemorySegment.NULL) {
 				val streamsPtr = mosaic_test_get_streams(ptr)
 				val streams = StandardStreams(streamsPtr)
@@ -47,10 +47,10 @@ public class TestTerminal private constructor(
 				val tty = Tty(ttyPtr)
 				return TestTerminal(ptr, streams, tty)
 			}
-			if (MosaicTestTtyInitResult.already_bound(result)) {
+			if (MosaicTestTerminalInitResult.already_bound(result)) {
 				throw IllegalStateException("TestTerminal or Tty already bound")
 			}
-			val error = MosaicTestTtyInitResult.error(result)
+			val error = MosaicTestTerminalInitResult.error(result)
 			if (error != 0) {
 				throwIoe(error)
 			}

--- a/mosaic-tty/src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c
+++ b/mosaic-tty/src/jvmMain/c/com_jakewharton_mosaic_tty_Jni.c
@@ -759,7 +759,7 @@ Java_com_jakewharton_mosaic_tty_Jni_testInit(
 	jboolean stdoutIsTty,
 	jboolean stderrIsTty
 ) {
-	MosaicTestTtyInitResult result = mosaic_test_init(stdinIsTty, stdoutIsTty, stderrIsTty);
+	MosaicTestTerminalInitResult result = mosaic_test_init(stdinIsTty, stdoutIsTty, stderrIsTty);
 	if (likely(result.testTty)) {
 		return (jlong) result.testTty;
 	}


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
