### PR TITLE
Improve samples build and run

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,31 +95,35 @@ Snapshot documentation is available at [jakewharton.github.io/mosaic/docs/latest
 
 ## Samples
 
-Run `./gradlew installDist` to build the sample binaries.
+All samples can be built and run using the `./samples/runner.sh` script.
 
- * [Counter](samples/counter): A simple increasing number from 0 until 20.
+To build and run the Counter sample (defaults to `jvm` target):
 
-   `./samples/counter/build/install/counter/bin/counter`
+```sh
+$ ./samples/runner.sh counter
+```
 
- * [Demo](samples/demo): A playground for demonstrating many features of Mosaic.
+To specify a target (`jvm` or `native`):
 
-   `./samples/demo/build/install/demo/bin/demo`
+```sh
+$ ./samples/runner.sh counter native
+```
 
- * [Jest](samples/jest): Example output of a test framework (such as JS's 'Jest').
+The script also supports explicit `build` and `run` commands:
 
-   `./samples/jest/build/install/jest/bin/jest`
+```sh
+$ ./samples/runner.sh counter build
+$ ./samples/runner.sh counter run
+```
 
- * [Robot](samples/robot): An interactive, game-like program with keyboard control.
+The available samples are:
 
-   `./samples/robot/build/install/robot/bin/robot`
-
- * [rrtop](samples/rrtop): An example inspired by [rrtop](https://github.com/wojciech-zurek/rrtop).
-
-   `./samples/rrtop/build/install/rrtop/bin/rrtop`
-
- * [snake](samples/snake): Snake game.
-
-   `./samples/snake/build/install/snake/bin/snake`
+* [Counter](samples/counter): A simple increasing number from 0 until 20.
+* [Demo](samples/demo): A playground for demonstrating many features of Mosaic.
+* [Jest](samples/jest): Example output of a test framework (such as JS's 'Jest').
+* [Robot](samples/robot): An interactive, game-like program with keyboard control.
+* [rrtop](samples/rrtop): An example inspired by [rrtop](https://github.com/wojciech-zurek/rrtop).
+* [Snake](samples/snake): Snake game.
 
 ## FAQ
 

--- a/mosaic-tty/build.gradle
+++ b/mosaic-tty/build.gradle
@@ -95,40 +95,46 @@ kotlin {
 			main.defaultSourceSet.resources.srcDir(jniTask)
 		}
 
-		def jdk22Compilation = target.compilations.create('jdk22') {
-			// I can't find a way to add a Java srcDir, so we have to add it both to Kotlin task so its
-			// sources can link and to Java task so the files are actually compiled to classes.
-			def mosaicFfmJava = tasks.named('mosaicJextractGenerateBindings')
-			defaultSourceSet.kotlin.srcDir(mosaicFfmJava)
-			compileJavaTaskProvider.configure { task ->
-				task.source(mosaicFfmJava)
+		if (JavaVersion.current().majorVersion.toInteger() < 22) {
+			project.logger.warn('JDK < 22. The resulting artifact will not contain the FFM implementation.')
+		} else {
+			def jdk22Compilation = target.compilations.create('jdk22') {
+				// I can't find a way to add a Java srcDir, so we have to add it both to Kotlin task so its
+				// sources can link and to Java task so the files are actually compiled to classes.
+				def mosaicFfmJava = tasks.named('mosaicJextractGenerateBindings')
+				defaultSourceSet.kotlin.srcDir(mosaicFfmJava)
+				compileJavaTaskProvider.configure { task ->
+					task.source(mosaicFfmJava)
+				}
+
+				compileTaskProvider.configure { task ->
+					task.compilerOptions { options ->
+						options.jvmTarget = JvmTarget.JVM_22
+						options.freeCompilerArgs.add('-Xexplicit-api=strict')
+					}
+				}
+				compileJavaTaskProvider.configure { task ->
+					task.sourceCompatibility = '22'
+					task.targetCompatibility = '22'
+				}
+				associateWith(mainCompilation.get())
 			}
 
-			compileTaskProvider.configure { task ->
-				task.compilerOptions { options ->
-					options.jvmTarget = JvmTarget.JVM_22
-					options.freeCompilerArgs.add('-Xexplicit-api=strict')
+			tasks.named(target.artifactsTaskName, Jar).configure {
+				from(jdk22Compilation.output) {
+					into('META-INF/versions/22')
+					// Don't add a nested .kotlin_module file.
+					exclude('META-INF')
+					// Empty class noise produced by jextract.
+					exclude('**/_*.class')
+				}
+				manifest {
+					attributes(['Multi-Release': 'true'])
 				}
 			}
-			compileJavaTaskProvider.configure { task ->
-				task.sourceCompatibility = '22'
-				task.targetCompatibility = '22'
-			}
-			associateWith(mainCompilation.get())
 		}
 
-		def mainJarTask = tasks.named(target.artifactsTaskName, Jar) {
-			from(jdk22Compilation.output) {
-				into('META-INF/versions/22')
-				// Don't add a nested .kotlin_module file.
-				exclude('META-INF')
-				// Empty class noise produced by jextract.
-				exclude('**/_*.class')
-			}
-			manifest {
-				attributes(['Multi-Release': 'true'])
-			}
-		}
+		def mainJarTask = tasks.named(target.artifactsTaskName, Jar)
 
 		def mainJar = mainJarTask.flatMap { it.archiveFile }
 		def testJar = tasks.register("${target.name}TestJar", Jar) {
@@ -156,7 +162,7 @@ kotlin {
 
 			doFirst {
 				// Defer resolving this until execution time since JavaExec lacks provider-based args.
-				testDependencyFiles.get().files.findAll {it.isFile() }.forEach {
+				testDependencyFiles.get().files.findAll { it.isFile() }.forEach {
 					args += it.absolutePath
 				}
 				args += mainJar.get().asFile.absolutePath
@@ -186,7 +192,7 @@ kotlin {
 			]
 			doFirst {
 				// Defer resolving this until execution time since JavaExec lacks provider-based args.
-				testDependencyFiles.get().files.findAll {it.isFile() }.forEach {
+				testDependencyFiles.get().files.findAll { it.isFile() }.forEach {
 					args += it.absolutePath
 				}
 				args += mainJar.get().asFile.absolutePath

--- a/samples/runner.sh
+++ b/samples/runner.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+set -e
+
+JVM_ONLY_SAMPLES=("java-tty")
+
+usage() {
+  echo "Usage: $0 <sample_name> [command] [target]"
+  echo ""
+  echo "Builds and/or runs a sample."
+  echo ""
+  echo "Commands:"
+  echo "  build       Build the sample"
+  echo "  run         Run the sample"
+  echo "  buildAndRun Build, then run the sample (default)"
+  echo ""
+  echo "Targets:"
+  echo "  jvm         Build/Run for JVM (default)"
+  echo "  native      Build/Run for native"
+  echo ""
+  echo "Examples:"
+  echo "  $0 counter              # Build and run for JVM"
+  echo "  $0 counter native       # Build and run for native"
+  echo "  $0 counter build        # Just build for JVM"
+  echo "  $0 counter run native   # Just run the native build"
+  exit 1
+}
+
+build_sample() {
+    if [ "$TARGET" == "jvm" ]; then
+      if [ "$is_jvm_only" -eq 1 ]; then
+        ./gradlew ":samples:$SAMPLE_NAME:installDist"
+      else
+        ./gradlew ":samples:$SAMPLE_NAME:installJvmDist"
+      fi
+    elif [ "$TARGET" == "native" ]; then
+      ./gradlew ":samples:$SAMPLE_NAME:$NATIVE_BUILD_TASK"
+    fi
+}
+
+run_sample() {
+    if [ "$TARGET" == "jvm" ]; then
+      if [ "$is_jvm_only" -eq 1 ]; then
+        "./samples/$SAMPLE_NAME/build/install/$SAMPLE_NAME/bin/$SAMPLE_NAME"
+      else
+        "./samples/$SAMPLE_NAME/build/install/$SAMPLE_NAME-jvm/bin/$SAMPLE_NAME"
+      fi
+    elif [ "$TARGET" == "native" ]; then
+      "$EXE_PATH"
+    fi
+}
+
+if [ "$#" -lt 1 ]; then
+  usage
+fi
+
+SAMPLE_NAME=$1
+COMMAND=""
+TARGET=""
+
+if [[ "$2" == "build" || "$2" == "run" || "$2" == "buildAndRun" ]]; then
+  COMMAND=$2
+  TARGET=${3:-jvm}
+elif [[ "$2" == "jvm" || "$2" == "native" ]]; then
+  COMMAND="buildAndRun"
+  TARGET=$2
+elif [ -z "$2" ]; then
+  COMMAND="buildAndRun"
+  TARGET="jvm"
+else
+  echo "Invalid command or target: $2"
+  usage
+fi
+
+is_jvm_only=0
+for s in "${JVM_ONLY_SAMPLES[@]}"; do
+  if [ "$s" == "$SAMPLE_NAME" ]; then
+    is_jvm_only=1
+    break
+  fi
+done
+
+if [ "$is_jvm_only" -eq 1 ] && [ "$TARGET" == "native" ]; then
+  echo "Error: The '$SAMPLE_NAME' sample is JVM-only and does not support the 'native' target." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR/.."
+
+if [ "$TARGET" == "native" ]; then
+  UNAME_S=$(uname -s)
+  UNAME_M=$(uname -m)
+  case "${UNAME_S}" in
+    Linux*)
+      case "${UNAME_M}" in
+        x86_64)  TARGET_NAME="linuxX64" ;;
+        aarch64) TARGET_NAME="linuxArm64" ;;
+        *) >&2 echo "Unsupported Linux architecture: ${UNAME_M}"; exit 1 ;;
+      esac
+      ;;
+    Darwin*)
+      case "${UNAME_M}" in
+        x86_64)  TARGET_NAME="macosX64" ;;
+        arm64)   TARGET_NAME="macosArm64" ;;
+        *) >&2 echo "Unsupported macOS architecture: ${UNAME_M}"; exit 1 ;;
+      esac
+      ;;
+    CYGWIN*|MINGW*|MSYS*)
+      case "${UNAME_M}" in
+        x86_64)  TARGET_NAME="mingwX64" ;;
+        *) >&2 echo "Unsupported Windows architecture: ${UNAME_M}"; exit 1 ;;
+      esac
+      ;;
+    *) >&2 echo "Unsupported OS: ${UNAME_S}"; exit 1 ;;
+  esac
+
+  FIRST_CHAR=$(printf "%.1s" "$TARGET_NAME" | tr '[:lower:]' '[:upper:]')
+  REMAINING_CHARS="${TARGET_NAME:1}"
+  C_TARGET_NAME="${FIRST_CHAR}${REMAINING_CHARS}"
+  NATIVE_BUILD_TASK="linkReleaseExecutable${C_TARGET_NAME}"
+  
+  EXE_PATH="./samples/$SAMPLE_NAME/build/bin/${TARGET_NAME}/releaseExecutable/$SAMPLE_NAME"
+  if [[ "$TARGET_NAME" == "mingw"* ]]; then
+    EXE_PATH="${EXE_PATH}.exe"
+  else
+    EXE_PATH="${EXE_PATH}.kexe"
+  fi
+fi
+
+case "$COMMAND" in
+  build)
+    build_sample
+    ;;
+  run)
+    run_sample
+    ;;
+  buildAndRun)
+    if ! OUTPUT=$(build_sample 2>&1); then
+      echo "$OUTPUT"
+      exit 1
+    fi
+    run_sample
+    ;;
+  *)
+    echo "Internal error: Unknown command '$COMMAND'"
+    usage
+    ;;
+esac


### PR DESCRIPTION
- Add a script to build and/or run samples by name and target.
- Update README.md with current instructions, as the previous version was made obsolete by the migration to Kotlin Multiplatform.
- Adjust the build configuration to be compatible with JDK 21 and lower, making the project setup easier.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
