### PR TITLE
Add support for RISC-V on the JVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 [Unreleased]: https://github.com/JakeWharton/mosaic/compare/0.18.0...HEAD
 
 New:
-- Nothing yet
+- JVM support for RISC-V!
 
 Changed:
 - Use the AndroidX Compose runtime which is now fully multiplatform. A dependency constraint to the JetBrains Compose runtime version 1.9.0 has been added, which is the first version that is empty and itself now points to AndroidX.

--- a/mosaic-tty/build.zig
+++ b/mosaic-tty/build.zig
@@ -12,6 +12,7 @@ pub fn build(b: *std.Build) !void {
 	b.getInstallStep().dependOn(&deleteLib.step);
 
 	setupMosaicTarget(b, &deleteLib.step, javaHeaders, .linux, .aarch64, "com/jakewharton/mosaic/tty/jni/aarch64");
+	setupMosaicTarget(b, &deleteLib.step, javaHeaders, .linux, .riscv64, "com/jakewharton/mosaic/tty/jni/riscv64");
 	setupMosaicTarget(b, &deleteLib.step, javaHeaders, .linux, .x86_64, "com/jakewharton/mosaic/tty/jni/amd64");
 	setupMosaicTarget(b, &deleteLib.step, javaHeaders, .macos, .aarch64, "com/jakewharton/mosaic/tty/jni/aarch64");
 	setupMosaicTarget(b, &deleteLib.step, javaHeaders, .macos, .x86_64, "com/jakewharton/mosaic/tty/jni/x86_64");


### PR DESCRIPTION
<img width="846" height="557" alt="Screenshot 2026-01-12 at 9 25 18 PM" src="https://github.com/user-attachments/assets/dca1592a-fdf9-416c-9c54-8545959b3fa4" />

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
