### PR TITLE
AndroidX lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ New:
 - JVM support for RISC-V!
 
 Changed:
-- Use the AndroidX Compose runtime which is now fully multiplatform. A dependency constraint to the JetBrains Compose runtime version 1.9.0 has been added, which is the first version that is empty and itself now points to AndroidX.
+- Use the AndroidX versions of the Compose runtime and lifecycle dependencies which are now fully multiplatform. Dependency constraints to the corresponding JetBrains artifacts (which are now empty) are present to prevent symbol duplication.
 
 Fixed:
 - Clear the set of states which were read during layout and draw passes before each pass. Previously these sets grew infinitely, which was both a memory leak and a performance problem.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinx-io-core = "org.jetbrains.kotlinx:kotlinx-io-core:0.8.2"
 androidx-annotation = "androidx.annotation:annotation:1.9.1"
 androidx-collection = "androidx.collection:collection:1.5.0"
 androidx-compose-runtime = "androidx.compose.runtime:runtime:1.10.0"
-androidx-lifecycle-compose = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.6"
+androidx-lifecycle-compose = "androidx.lifecycle:lifecycle-runtime-compose:2.10.0"
 
 mavenPublishGradlePlugin = "com.vanniktech:gradle-maven-publish-plugin:0.35.0"
 dokkaGradlePlugin = "org.jetbrains.dokka:dokka-gradle-plugin:2.1.0"


### PR DESCRIPTION
Closes #968 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
