### PR TITLE
Try ubuntu-slim

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -245,7 +245,7 @@ jobs:
 
   final-status:
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs:
       - docs
       - tty-tests


### PR DESCRIPTION
https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
