### PR TITLE
fix crashing on common Latin language characters in input outside the unicode range 32..126

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/Codepoint.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/Codepoint.kt
@@ -1,0 +1,89 @@
+package com.jakewharton.mosaic
+
+import kotlin.jvm.JvmInline
+
+internal object UnicodeBlocks {
+
+	// region Latin
+
+	val LatinBasic = Codepoint("U+0000")..Codepoint("U+007F")
+	val Latin1Supplement = Codepoint("U+00A0")..Codepoint("U+00FF")
+	val LatinExtendedA = Codepoint("U+0100")..Codepoint("U+017F")
+	val LatinExtendedB = Codepoint("U+0180")..Codepoint("U+024F")
+	val LatinExtendedC = Codepoint("U+2C60")..Codepoint("U+2C7F")
+	val LatinExtendedD = Codepoint("U+A720")..Codepoint("U+A7FF")
+	val LatinExtendedE = Codepoint("U+AB30")..Codepoint("U+AB6F")
+	val LatinExtendedF = Codepoint("U+10780")..Codepoint("U+107BF")
+	val LatinExtendedG = Codepoint("U+1DF00")..Codepoint("U+1DFFF")
+	val LatinExtendedAdditional = Codepoint("U+1E00")..Codepoint("U+1EFF")
+
+	val LatinIpaExtensions = Codepoint("U+0250")..Codepoint("U+02AF")
+	val PhoneticExtensions = Codepoint("U+1D00")..Codepoint("U+1D7F")
+	val PhoneticExtensionsSupplement = Codepoint("U+1D80")..Codepoint("U+1DBF")
+
+	val SpacingModifierLetters = Codepoint("U+02B0")..Codepoint("U+02FF")
+	val CombiningMarks = Codepoint("U+0300")..Codepoint("U+036F")
+
+	val latin = listOf(
+		LatinBasic,
+		Latin1Supplement,
+		LatinExtendedA, LatinExtendedB, LatinExtendedC,
+		LatinExtendedD, LatinExtendedE, LatinExtendedF,
+		LatinExtendedG,
+		LatinExtendedAdditional,
+		LatinIpaExtensions, PhoneticExtensions, PhoneticExtensionsSupplement,
+		SpacingModifierLetters, CombiningMarks
+	)
+	// endregion
+
+	// TODO: Greek, Cyrillic, ...
+}
+
+@JvmInline
+internal value class Codepoint constructor(val dec: Int) {
+
+	constructor(unicode: String) : this(unicode.removePrefix(PREFIX).toInt(16))
+
+	val hex: String get() = dec.toString(16).uppercase()
+	val unicode: String get() = PREFIX + hex
+
+	companion object {
+		const val PREFIX = "U+"
+	}
+
+	fun toChar(): Char = dec.toChar()
+
+	override fun toString(): String = buildString {
+		if (dec <= 0xFFFF) {
+			// simple BMP code point:
+			append(toChar())
+		} else {
+			// surrogate pair calculation:
+			// https://en.wikipedia.org/wiki/Plane_(Unicode)#Surrogate_pairs
+			val high = ((dec - 0x10000) shr 10) + 0xD800
+			val low = ((dec - 0x10000) and 0x3FF) + 0xDC00
+			append(high.toChar())
+			append(low.toChar())
+		}
+	}
+
+	operator fun rangeTo(other: Codepoint) = UnicodeBlock(start = this, endInclusive = other)
+}
+
+internal data class UnicodeBlock(val start: Codepoint, val endInclusive: Codepoint) {
+
+	operator fun contains(codepoint: Codepoint): Boolean {
+		return codepoint.dec in this.toIntRange()
+	}
+
+	fun toIntRange() = IntRange(start.dec, endInclusive.dec)
+}
+
+internal fun IntRange.toUnicodeBlock(): UnicodeBlock {
+	return UnicodeBlock(
+		start = Codepoint(start), endInclusive = Codepoint(endInclusive)
+	)
+}
+
+internal fun Int.toCodepoint() = Codepoint(this)
+internal fun String.toCodepoint() = Codepoint(this)

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/compat.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/compat.kt
@@ -13,7 +13,6 @@ internal fun KeyboardEvent.toKeyEventOrNull(): KeyEvent? {
 			9 -> "Tab"
 			13 -> "Enter"
 			27 -> "Escape"
-			in 32..126 -> codepoint.toChar().toString()
 			127 -> "Backspace"
 			57350 -> "ArrowLeft"
 			57351 -> "ArrowRight"
@@ -26,7 +25,15 @@ internal fun KeyboardEvent.toKeyEventOrNull(): KeyEvent? {
 			57356 -> "Home"
 			57357 -> "End"
 			in 57364..57398 -> "F" + (codepoint - 57363)
-			else -> throw UnsupportedOperationException(toString())
+			else -> {
+				val codepoint = codepoint.toCodepoint()
+
+				if (UnicodeBlocks.latin.any { codepoint in it }) {
+					codepoint.toChar().toString()
+				} else {
+					throw UnsupportedOperationException(toString())
+				}
+			}
 		},
 		alt = alt,
 		ctrl = ctrl,


### PR DESCRIPTION
This PR fixes an issue in KeyboardEvent.toKeyEventOrNull() where pressing a key with a Unicode codepoint outside the range 32..126 would throw an UnsupportedOperationException, causing the TUI to crash.
I kept the exception throwing and added support for all Latin characters, with expansion friendly object for known Unicode blocks.
---

Changes:
	- Updated toKeyEventOrNull() to support all european Latin characters instead of throwing exception
	- Introduced a more robust Unicode codepoint conversion with toCodepoint() and UnicodeBlock utilities.
	- Added support for extended Latin ranges to cover common key inputs.

Impact:
	- Improves stability for interactive Mosaic TUI applications.
	- Preserves existing behavior for standard keys (Enter, Backspace, Arrow keys, function keys).
	- Future-proofing for additional Unicode blocks (Greek, Cyrillic, etc.) can be added easily.

Testing:
	- Verified that keypresses outside standard Latin ranges no longer throw exceptions.
	- Confirmed that normal key inputs and control keys (Enter, Backspace, arrows) continue to function correctly.

Next Steps / Recommendations:
	- Consider extending UnicodeBlocks to include Greek, Cyrillic, and other commonly used scripts for broader TUI support.
	- Optional: log or ignore unknown codepoints instead of throwing exceptions to further improve robustness.
