### PR TITLE
Change C signatures from `foo()` to `foo(void)`

### DIFF
--- a/mosaic-tty/src/commonMain/c/mosaic-streams-posix.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-streams-posix.c
@@ -68,7 +68,7 @@ MosaicStreamsInitResult mosaic_streams_init_internal(int stdin, int stdout, int 
 	goto ret;
 }
 
-MosaicStreamsInitResult mosaic_streams_init() {
+MosaicStreamsInitResult mosaic_streams_init(void) {
 	return mosaic_streams_init_internal(STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO, false);
 }
 

--- a/mosaic-tty/src/commonMain/c/mosaic-streams-windows.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-streams-windows.c
@@ -108,7 +108,7 @@ MosaicStreamsInitResult mosaic_streams_init_internal(
 	goto ret;
 }
 
-MOSAIC_EXPORT MosaicStreamsInitResult mosaic_streams_init() {
+MOSAIC_EXPORT MosaicStreamsInitResult mosaic_streams_init(void) {
 	HANDLE stdin = GetStdHandle(STD_INPUT_HANDLE);
 	if (unlikely(stdin == INVALID_HANDLE_VALUE)) {
 		goto err;

--- a/mosaic-tty/src/commonMain/c/mosaic-streams.h
+++ b/mosaic-tty/src/commonMain/c/mosaic-streams.h
@@ -24,7 +24,7 @@ typedef struct MosaicStreamsInterceptResult {
 	uint32_t error;
 } MosaicStreamsInterceptResult;
 
-MOSAIC_EXPORT MosaicStreamsInitResult mosaic_streams_init();
+MOSAIC_EXPORT MosaicStreamsInitResult mosaic_streams_init(void);
 MOSAIC_EXPORT uint32_t mosaic_streams_free(MosaicStreams *streams);
 
 MOSAIC_EXPORT MosaicStreamsTtyResult mosaic_streams_is_stdin_tty(MosaicStreams *streams);

--- a/mosaic-tty/src/commonMain/c/mosaic-tty-posix.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-tty-posix.c
@@ -52,7 +52,7 @@ MosaicTtyInitResult mosaic_tty_init_with_fd(int fd) {
 	goto ret;
 }
 
-MosaicTtyInitResult mosaic_tty_init() {
+MosaicTtyInitResult mosaic_tty_init(void) {
 	int fd = open("/dev/tty", O_RDWR);
 	if (likely(fd != -1)) {
 		return mosaic_tty_init_with_fd(fd);

--- a/mosaic-tty/src/commonMain/c/mosaic-tty-windows.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-tty-windows.c
@@ -45,7 +45,7 @@ MosaicTtyInitResult mosaic_tty_init_with_handles(
 
 static _Atomic(MosaicTty *) globalTty;
 
-MOSAIC_EXPORT MosaicTtyInitResult mosaic_tty_init() {
+MOSAIC_EXPORT MosaicTtyInitResult mosaic_tty_init(void) {
 	MosaicTtyInitResult result = {};
 
 	HANDLE conin = CreateFile(TEXT("CONIN$"), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, 0, OPEN_EXISTING, 0, 0);

--- a/mosaic-tty/src/commonMain/c/mosaic-tty.h
+++ b/mosaic-tty/src/commonMain/c/mosaic-tty.h
@@ -36,7 +36,7 @@ typedef struct MosaicTtyTerminalSizeResult {
 	uint32_t error;
 } MosaicTtyTerminalSizeResult;
 
-MOSAIC_EXPORT MosaicTtyInitResult mosaic_tty_init();
+MOSAIC_EXPORT MosaicTtyInitResult mosaic_tty_init(void);
 
 MOSAIC_EXPORT void mosaic_tty_set_callback(MosaicTty *tty, MosaicTtyCallback *callback);
 

--- a/mosaic-tty/src/jvmJdk22/kotlin/com/jakewharton/mosaic/tty/StandardStreams.kt
+++ b/mosaic-tty/src/jvmJdk22/kotlin/com/jakewharton/mosaic/tty/StandardStreams.kt
@@ -31,16 +31,18 @@ public class StandardStreams internal constructor(
 		public fun bind(): StandardStreams {
 			NativeLibrary.ensureLoaded()
 
-			val result = mosaic_streams_init.makeInvoker().apply(Arena.global())
-			val ptr = MosaicStreamsInitResult.streams(result)
-			if (ptr != MemorySegment.NULL) {
-				return StandardStreams(ptr)
+			Arena.ofConfined().use { arena ->
+				val result = mosaic_streams_init(arena)
+				val ptr = MosaicStreamsInitResult.streams(result)
+				if (ptr != MemorySegment.NULL) {
+					return StandardStreams(ptr)
+				}
+				val error = MosaicStreamsInitResult.error(result)
+				if (error != 0) {
+					throwIoe(error)
+				}
+				throw OutOfMemoryError()
 			}
-			val error = MosaicStreamsInitResult.error(result)
-			if (error != 0) {
-				throwIoe(error)
-			}
-			throw OutOfMemoryError()
 		}
 	}
 

--- a/mosaic-tty/src/jvmJdk22/kotlin/com/jakewharton/mosaic/tty/TestTerminal.kt
+++ b/mosaic-tty/src/jvmJdk22/kotlin/com/jakewharton/mosaic/tty/TestTerminal.kt
@@ -38,23 +38,25 @@ public class TestTerminal private constructor(
 		): TestTerminal {
 			NativeLibrary.ensureLoaded()
 
-			val result = mosaic_test_init(Arena.global(), stdinIsTty, stdoutIsTty, stderrIsTty)
-			val ptr = MosaicTestTerminalInitResult.testTty(result)
-			if (ptr != MemorySegment.NULL) {
-				val streamsPtr = mosaic_test_get_streams(ptr)
-				val streams = StandardStreams(streamsPtr)
-				val ttyPtr = mosaic_test_get_tty(ptr)
-				val tty = Tty(ttyPtr)
-				return TestTerminal(ptr, streams, tty)
+			Arena.ofConfined().use { arena ->
+				val result = mosaic_test_init(arena, stdinIsTty, stdoutIsTty, stderrIsTty)
+				val ptr = MosaicTestTerminalInitResult.testTty(result)
+				if (ptr != MemorySegment.NULL) {
+					val streamsPtr = mosaic_test_get_streams(ptr)
+					val streams = StandardStreams(streamsPtr)
+					val ttyPtr = mosaic_test_get_tty(ptr)
+					val tty = Tty(ttyPtr)
+					return TestTerminal(ptr, streams, tty)
+				}
+				if (MosaicTestTerminalInitResult.already_bound(result)) {
+					throw IllegalStateException("TestTerminal or Tty already bound")
+				}
+				val error = MosaicTestTerminalInitResult.error(result)
+				if (error != 0) {
+					throwIoe(error)
+				}
+				throw OutOfMemoryError()
 			}
-			if (MosaicTestTerminalInitResult.already_bound(result)) {
-				throw IllegalStateException("TestTerminal or Tty already bound")
-			}
-			val error = MosaicTestTerminalInitResult.error(result)
-			if (error != 0) {
-				throwIoe(error)
-			}
-			throw OutOfMemoryError()
 		}
 	}
 

--- a/mosaic-tty/src/jvmJdk22/kotlin/com/jakewharton/mosaic/tty/Tty.kt
+++ b/mosaic-tty/src/jvmJdk22/kotlin/com/jakewharton/mosaic/tty/Tty.kt
@@ -26,22 +26,24 @@ public class Tty internal constructor(
 		public fun tryBind(): Tty? {
 			NativeLibrary.ensureLoaded()
 
-			val result = mosaic_tty_init.makeInvoker().apply(Arena.global())
-			val ptr = MosaicTtyInitResult.tty(result)
-			if (ptr != MemorySegment.NULL) {
-				return Tty(ptr)
+			Arena.ofConfined().use { arena ->
+				val result = mosaic_tty_init(arena)
+				val ptr = MosaicTtyInitResult.tty(result)
+				if (ptr != MemorySegment.NULL) {
+					return Tty(ptr)
+				}
+				if (MosaicTtyInitResult.no_tty(result)) {
+					return null
+				}
+				if (MosaicTtyInitResult.already_bound(result)) {
+					throw IllegalStateException("Tty already bound")
+				}
+				val error = MosaicTtyInitResult.error(result)
+				if (error != 0) {
+					throwIoe(error)
+				}
+				throw OutOfMemoryError()
 			}
-			if (MosaicTtyInitResult.no_tty(result)) {
-				return null
-			}
-			if (MosaicTtyInitResult.already_bound(result)) {
-				throw IllegalStateException("Tty already bound")
-			}
-			val error = MosaicTtyInitResult.error(result)
-			if (error != 0) {
-				throwIoe(error)
-			}
-			throw OutOfMemoryError()
 		}
 	}
 


### PR DESCRIPTION
This correctly indicates a parameterless function as opposed to a variadic function, which jextract was pedantically honoring before.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
