### PR TITLE
Add macOS 26 Intel runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,12 +45,14 @@ jobs:
         platform:
           - os: macos-14
             target: macosArm64
-          - os: macos-15-intel
-            target: macosX64
           - os: macos-15
             target: macosArm64
+          - os: macos-15-intel
+            target: macosX64
           - os: macos-26
             target: macosArm64
+          - os: macos-26-intel
+            target: macosX64
           - os: ubuntu-22.04
             target: linuxX64
           - os: ubuntu-22.04-arm


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
