### PR TITLE
Close TTY at the end of the `runMosaic*` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changed:
 
 Fixed:
 - Clear the set of states which were read during layout and draw passes before each pass. Previously these sets grew infinitely, which was both a memory leak and a performance problem.
+- Close the underlying TTY at the end of the `runMosaic*` family of functions.
 
 
 ## [0.18.0] - 2025-08-21

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/terminal.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/terminal.kt
@@ -20,21 +20,24 @@ internal suspend fun withTerminal(
 	onNonInteractive: NonInteractivePolicy,
 	block: suspend (Terminal) -> Unit,
 ): Boolean = coroutineScope {
-	val terminal = if (onNonInteractive != AssumeAndIgnore) {
+	val tty = if (onNonInteractive != AssumeAndIgnore) {
 		Tty.tryBind()
-			?.asTerminalIn(this)
 			?: when (onNonInteractive) {
 				Exit -> nonInteractiveExit()
 				Throw -> throw IllegalStateException(NonInteractiveMessage)
 				Return -> return@coroutineScope false
-				Ignore -> NonInteractiveTerminal
+				Ignore -> null
 				AssumeAndIgnore -> throw AssertionError()
 			}
 	} else {
-		NonInteractiveTerminal
+		null
 	}
 
-	terminal.use { block(it) }
+	tty.use {
+		val terminal = tty?.asTerminalIn(this) ?: NonInteractiveTerminal
+		terminal.use { block(it) }
+	}
+
 	true
 }
 


### PR DESCRIPTION
Previsouly we only reset the state when the `Terminal` was closed, but did not close the underlying TTY.

Closes #1098. Closes #1099.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
