### PR TITLE
Run final status only if not canceled

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -241,7 +241,7 @@ jobs:
         shell: bash
 
   final-status:
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-slim
     needs:
       - docs


### PR DESCRIPTION
It doesn't matter in practice, but I don't want to keep copying around `always()`.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
