### PR TITLE
 feat: Support Unicode wide characters in layout, rendering, and input…

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/compat.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/compat.kt
@@ -2,32 +2,35 @@ package com.jakewharton.mosaic
 
 import com.jakewharton.mosaic.layout.KeyEvent
 import com.jakewharton.mosaic.terminal.KeyboardEvent
+import de.cketti.codepoints.appendCodePoint
 
 internal fun KeyboardEvent.toKeyEventOrNull(): KeyEvent? {
 	if (eventType != KeyboardEvent.EventTypePress) {
 		return null
 	}
 
+	val key = text ?: when (val codepoint = codepoint) {
+		9 -> "Tab"
+		13 -> "Enter"
+		27 -> "Escape"
+		in 32..126 -> codepoint.toChar().toString()
+		127 -> "Backspace"
+		57350 -> "ArrowLeft"
+		57351 -> "ArrowRight"
+		57352 -> "ArrowUp"
+		57353 -> "ArrowDown"
+		57348 -> "Insert"
+		57349 -> "Delete"
+		57354 -> "PageUp"
+		57355 -> "PageDown"
+		57356 -> "Home"
+		57357 -> "End"
+		in 57364..57398 -> "F" + (codepoint - 57363)
+		else -> buildString { appendCodePoint(codepoint) }
+	}
+
 	return KeyEvent(
-		key = when (val codepoint = codepoint) {
-			9 -> "Tab"
-			13 -> "Enter"
-			27 -> "Escape"
-			in 32..126 -> codepoint.toChar().toString()
-			127 -> "Backspace"
-			57350 -> "ArrowLeft"
-			57351 -> "ArrowRight"
-			57352 -> "ArrowUp"
-			57353 -> "ArrowDown"
-			57348 -> "Insert"
-			57349 -> "Delete"
-			57354 -> "PageUp"
-			57355 -> "PageDown"
-			57356 -> "Home"
-			57357 -> "End"
-			in 57364..57398 -> "F" + (codepoint - 57363)
-			else -> throw UnsupportedOperationException(toString())
-		},
+		key = key,
 		alt = alt,
 		ctrl = ctrl,
 		shift = shift,

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawScope.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/DrawScope.kt
@@ -25,6 +25,7 @@ import com.jakewharton.mosaic.isSpecifiedCodePoint
 import com.jakewharton.mosaic.isUnspecifiedCodePoint
 import com.jakewharton.mosaic.text.AnnotatedString
 import com.jakewharton.mosaic.text.SpanStyle
+import com.jakewharton.mosaic.text.charWidth
 import com.jakewharton.mosaic.text.getLocalRawSpanStyles
 import com.jakewharton.mosaic.ui.Color
 import com.jakewharton.mosaic.ui.TextStyle
@@ -220,8 +221,12 @@ internal open class TextCanvasDrawScope(
 		topLeft: IntOffset,
 		size: IntSize,
 	) {
-		for (y in topLeft.y until topLeft.y + size.height) {
-			for (x in topLeft.x until topLeft.x + size.width) {
+		val xStart = topLeft.x.coerceAtLeast(0)
+		val xEnd = (topLeft.x + size.width).coerceAtMost(width)
+		val yStart = topLeft.y.coerceAtLeast(0)
+		val yEnd = (topLeft.y + size.height).coerceAtMost(height)
+		for (y in yStart until yEnd) {
+			for (x in xStart until xEnd) {
 				drawTextPixel(x, y, codePoint, foreground, background, textStyle)
 			}
 		}
@@ -269,7 +274,10 @@ internal open class TextCanvasDrawScope(
 		var pixelIndex = 0
 		var characterColumn = column
 		while (pixelIndex < text.length) {
-			val character = canvas[row, characterColumn++]
+			val cp = text.codePointAt(pixelIndex)
+			val w = charWidth(cp)
+
+			val character = canvas[row, characterColumn]
 
 			val pixelEnd = if (text[pixelIndex].isHighSurrogate()) {
 				pixelIndex + 2
@@ -277,11 +285,22 @@ internal open class TextCanvasDrawScope(
 				pixelIndex + 1
 			}
 
-			character.updateTextPixel(text.codePointAt(pixelIndex), foreground, background, textStyle, underlineStyle, underlineColor)
+			character.updateTextPixel(cp, foreground, background, textStyle, underlineStyle, underlineColor)
 			spanStylesProvider?.invoke(pixelIndex, pixelEnd)?.forEach {
 				character.updateTextPixel(UnspecifiedCodePoint, it.color, it.background, it.textStyle, it.underlineStyle, it.underlineColor)
 			}
 
+			// Mark continuation cells for wide characters (e.g. CJK, fullwidth)
+			if (w > 1) {
+				for (offset in 1 until w) {
+					val continuationCol = characterColumn + offset
+					if (continuationCol < width) {
+						canvas[row, continuationCol].isWideContinuation = true
+					}
+				}
+			}
+
+			characterColumn += w
 			pixelIndex = pixelEnd
 		}
 	}
@@ -309,6 +328,7 @@ internal open class TextCanvasDrawScope(
 	) {
 		if (codePoint.isSpecifiedCodePoint) {
 			this.codePoint = codePoint
+			isWideContinuation = false
 		}
 		if (foreground.isSpecifiedColor) {
 			this.foreground = foreground

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/surface.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/surface.kt
@@ -63,8 +63,14 @@ internal class TextSurface(
 		}
 
 		var lastPixel = blankPixel
-		for (columnIndex in rowStart until rowStop) {
+		var columnIndex = rowStart
+		while (columnIndex < rowStop) {
 			val pixel = cells[columnIndex]
+
+			if (pixel.isWideContinuation) {
+				columnIndex++
+				continue
+			}
 
 			if (ansiLevel != AnsiLevel.NONE) {
 				if (pixel.foreground != lastPixel.foreground) {
@@ -136,6 +142,7 @@ internal class TextSurface(
 
 			appendable.appendCodePoint(pixel.codePoint)
 			lastPixel = pixel
+			columnIndex++
 		}
 
 		if (
@@ -210,6 +217,7 @@ internal class TextPixel(var codePoint: Int) {
 	var textStyle: TextStyle = TextStyle.Empty
 	var underlineStyle: UnderlineStyle = UnderlineStyle.Unspecified
 	var underlineColor: Color = Color.Unspecified
+	var isWideContinuation: Boolean = false
 
 	fun isEmpty(): Boolean {
 		return codePoint == SpaceCharCodePoint &&

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/CharWidth.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/CharWidth.kt
@@ -1,0 +1,107 @@
+package com.jakewharton.mosaic.text
+
+/**
+ * Returns the number of terminal columns a Unicode code point occupies.
+ * This follows the wcwidth() convention: 2 for wide characters, 0 for combining/zero-width, 1 otherwise.
+ */
+internal fun charWidth(codepoint: Int): Int {
+	if (codepoint in zeroWidthSorted) return 0
+	if (codepoint in wideSorted) return 2
+	return 1
+}
+
+private val zeroWidthRanges = listOf(
+	0x0300..0x036F, // Combining Diacritical Marks
+	0x0483..0x0489, // Cyrillic combining marks
+	0x0591..0x05BD, // Hebrew combining marks
+	0x05BF..0x05BF,
+	0x05C1..0x05C2,
+	0x05C4..0x05C5,
+	0x05C7..0x05C7,
+	0x0610..0x061A, // Arabic combining marks
+	0x064B..0x065F,
+	0x0670..0x0670,
+	0x06D6..0x06DC,
+	0x06DF..0x06E4,
+	0x06E7..0x06E8,
+	0x06EA..0x06ED,
+	0x0711..0x0711, // Syriac combining mark
+	0x0730..0x074A, // Syriac combining marks
+	0x07A6..0x07B0, // Thaana combining marks
+	0x0901..0x0903, // Devanagari combining marks
+	0x093C..0x093C,
+	0x093E..0x094D,
+	0x0951..0x0954,
+	0x0E31..0x0E3A, // Thai combining marks
+	0x0E47..0x0E4E,
+	0x0F18..0x0F19, // Tibetan combining marks
+	0x0F35..0x0F35,
+	0x0F37..0x0F37,
+	0x0F39..0x0F39,
+	0x0F71..0x0F84,
+	0x0F86..0x0F87,
+	0x0F8D..0x0FBC,
+	0x0FC6..0x0FC6,
+	0x17B4..0x17B5, // Khmer combining marks
+	0x17B7..0x17BD,
+	0x17C6..0x17C6,
+	0x17C9..0x17D3,
+	0x17DD..0x17DD,
+	0x180B..0x180D, // Mongolian free variation selectors
+	0x200B..0x200F, // Zero-width space, ZWNJ, ZWJ, LRM, RLM
+	0x2028..0x202E, // Line/paragraph separator, directional overrides
+	0x2060..0x2069, // Word joiner, etc.
+	0xFE00..0xFE0F, // Variation Selectors
+	0xFE20..0xFE2F, // Combining Half Marks
+	0xE0100..0xE01EF, // Variation Selectors Supplement
+)
+
+private val wideRanges = listOf(
+	0x1100..0x115F, // Hangul Jamo
+	0x2E80..0x303E, // CJK Radicals, Kangxi, Symbols
+	0x3040..0x309F, // Hiragana
+	0x30A0..0x30FF, // Katakana
+	0x3100..0x312F, // Bopomofo
+	0x3130..0x318F, // Hangul Compatibility Jamo
+	0x3190..0x33FF, // CJK Strokes, Enclosed CJK
+	0x3400..0x4DBF, // CJK Unified Ext A
+	0x4E00..0x9FFF, // CJK Unified Ideographs
+	0xA000..0xA4CF, // Yi
+	0xAC00..0xD7AF, // Hangul Syllables
+	0xF900..0xFAFF, // CJK Compatibility Ideographs
+	0xFE10..0xFE1F, // Vertical Forms
+	0xFE30..0xFE6F, // CJK Compatibility Forms
+	0xFF01..0xFF60, // Fullwidth Forms
+	0xFFE0..0xFFE6, // Fullwidth Signs
+	0x1B000..0x1B12F, // Kana Supplement/Extended-A
+	0x1F1E6..0x1F1FF, // Regional Indicators (flags)
+	0x1F200..0x1F2FF, // Enclosed Ideographic Supplement
+	0x20000..0x3FFFF, // CJK Ext B–I
+
+	// Emoji ranges (consistently wide in modern terminals)
+	0x1F300..0x1F5FF, // Misc Symbols and Pictographs
+	0x1F600..0x1F64F, // Emoticons
+	0x1F680..0x1F6FF, // Transport and Map Symbols
+	0x1F900..0x1F9FF, // Supplemental Symbols and Pictographs
+	0x1FA00..0x1FAFF, // Chess + Symbols Extended-A
+)
+
+private val zeroWidthSorted = zeroWidthRanges.sortedBy { it.first }
+private val wideSorted = wideRanges.sortedBy { it.first }
+
+private operator fun List<IntRange>.contains(codepoint: Int): Boolean {
+	var low = 0
+	var high = size - 1
+	while (low <= high) {
+		val mid = (low + high) ushr 1
+		val range = get(mid)
+		if (codepoint < range.first) {
+			high = mid - 1
+		} else if (codepoint > range.last) {
+			low = mid + 1
+		} else {
+			return true
+		}
+	}
+	return false
+}

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/TextLayout.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/text/TextLayout.kt
@@ -1,6 +1,6 @@
 package com.jakewharton.mosaic.text
 
-import de.cketti.codepoints.codePointCount
+import de.cketti.codepoints.codePointAt
 
 internal abstract class TextLayout<T : CharSequence>(initialValue: T) {
 
@@ -39,7 +39,16 @@ internal abstract class TextLayout<T : CharSequence>(initialValue: T) {
 		if (!dirty) return
 
 		val lines = value.splitByLines()
-		width = lines.maxOf { it.codePointCount(0, it.length) }
+		width = lines.maxOf { line ->
+			var w = 0
+			var i = 0
+			while (i < line.length) {
+				val cp = line.codePointAt(i)
+				w += charWidth(cp)
+				i += if (line[i].isHighSurrogate()) 2 else 1
+			}
+			w
+		}
 		height = lines.size
 		this.lines = lines
 		dirty = false

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/AnsiRenderingTest.kt
@@ -304,4 +304,42 @@ class AnsiRenderingTest {
 			)
 		}
 	}
+
+	@Test fun unicodeWideTextIsMeasuredCorrectly() = runTest {
+		runMosaicTest(DumpSnapshots) {
+			setContent {
+				Column {
+					Text("ABC")
+					Text("A中B")
+				}
+			}
+
+			assertThat(awaitSnapshot()).isEqualTo(
+				"""
+				|Column(arrangement=Arrangement#Top, alignment=Horizontal(bias=-1)) x=0 y=0 w=4 h=2
+				|  Text("ABC") x=0 y=0 w=3 h=1 DrawBehind
+				|  Text("A中B") x=0 y=1 w=4 h=1 DrawBehind
+				""".trimMargin(),
+			)
+		}
+	}
+
+	@Test fun unicodeWideTextRendersCorrectly() = runTest {
+		runMosaicTest(RenderingSnapshots(rendering)) {
+			setContent {
+				Column {
+					Text("ABC")
+					Text("A中B")
+				}
+			}
+
+			assertThat(awaitSnapshot()).isEqualTo(
+				"""
+				|ABC
+				|A中B
+				|
+				""".trimMargin().wrapWithAnsiSynchronizedUpdate().replaceLineEndingsWithCRLF(),
+			)
+		}
+	}
 }

--- a/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/text/CharWidthTest.kt
+++ b/mosaic-runtime/src/commonTest/kotlin/com/jakewharton/mosaic/text/CharWidthTest.kt
@@ -1,0 +1,171 @@
+package com.jakewharton.mosaic.text
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CharWidthTest {
+
+	@Test fun asciiCharacters() {
+		assertEquals(1, charWidth('A'.code))
+		assertEquals(1, charWidth('z'.code))
+		assertEquals(1, charWidth('0'.code))
+		assertEquals(1, charWidth(' '.code))
+		assertEquals(1, charWidth('~'.code))
+	}
+
+	@Test fun latinSupplement() {
+		assertEquals(1, charWidth('é'.code))
+		assertEquals(1, charWidth('ü'.code))
+		assertEquals(1, charWidth('ñ'.code))
+	}
+
+	@Test fun cjkIdeographs() {
+		assertEquals(2, charWidth('你'.code))
+		assertEquals(2, charWidth('好'.code))
+		assertEquals(2, charWidth(0x4E2D)) // 中
+		assertEquals(2, charWidth(0x56FD)) // 国
+		assertEquals(2, charWidth(0x4E00)) // First CJK
+		assertEquals(2, charWidth(0x9FFF)) // Last CJK
+	}
+
+	@Test fun cjkExtensionA() {
+		assertEquals(2, charWidth(0x3400))
+		assertEquals(2, charWidth(0x4DBF))
+	}
+
+	@Test fun cjkExtensionB() {
+		assertEquals(2, charWidth(0x20000))
+		assertEquals(2, charWidth(0x2FFFF))
+	}
+
+	@Test fun fullwidthForms() {
+		assertEquals(2, charWidth(0xFF01)) // ！
+		assertEquals(2, charWidth(0xFF60))
+		assertEquals(2, charWidth(0xFFE0)) // ¢ (fullwidth)
+		assertEquals(2, charWidth(0xFFE6))
+	}
+
+	@Test fun hiragana() {
+		assertEquals(2, charWidth(0x3041)) // あ
+		assertEquals(2, charWidth(0x309F))
+	}
+
+	@Test fun katakana() {
+		assertEquals(2, charWidth(0x30A1)) // ア
+		assertEquals(2, charWidth(0x30FF))
+	}
+
+	@Test fun hangul() {
+		assertEquals(2, charWidth(0xAC00)) // 가
+		assertEquals(2, charWidth(0xD7AF))
+	}
+
+	@Test fun combiningMarksAreZeroWidth() {
+		assertEquals(0, charWidth(0x0300)) // Combining grave accent
+		assertEquals(0, charWidth(0x0301)) // Combining acute accent
+		assertEquals(0, charWidth(0x036F)) // Last combining diacritical
+	}
+
+	@Test fun variationSelectorsAreZeroWidth() {
+		assertEquals(0, charWidth(0xFE00))
+		assertEquals(0, charWidth(0xFE0F))
+		assertEquals(0, charWidth(0xE0100))
+		assertEquals(0, charWidth(0xE01EF))
+	}
+
+	@Test fun zeroWidthSpace() {
+		assertEquals(0, charWidth(0x200B)) // ZWSP
+		assertEquals(0, charWidth(0x200C)) // ZWNJ
+		assertEquals(0, charWidth(0x200D)) // ZWJ
+	}
+
+	@Test fun cjkRadicalsAndKangxi() {
+		assertEquals(2, charWidth(0x2E80))
+		assertEquals(2, charWidth(0x2F00))
+		assertEquals(2, charWidth(0x303E))
+	}
+
+	@Test fun emoticonsAreWide() {
+		assertEquals(2, charWidth(0x1F600)) // 😀
+		assertEquals(2, charWidth(0x1F603)) // 😃
+		assertEquals(2, charWidth(0x1F615)) // 😕
+		assertEquals(2, charWidth(0x1F64F)) // 🙏
+	}
+
+	@Test fun miscSymbolsAndPictographsAreWide() {
+		assertEquals(2, charWidth(0x1F300)) // 🌀
+		assertEquals(2, charWidth(0x1F4A9)) // 💩
+		assertEquals(2, charWidth(0x1F5FF)) // 🗿
+	}
+
+	@Test fun transportSymbolsAreWide() {
+		assertEquals(2, charWidth(0x1F680)) // 🚀
+		assertEquals(2, charWidth(0x1F697)) // 🚗
+		assertEquals(2, charWidth(0x1F6FF))
+	}
+
+	@Test fun supplementalSymbolsAreWide() {
+		assertEquals(2, charWidth(0x1F900)) // 🤀
+		assertEquals(2, charWidth(0x1F9E6)) // 🧦
+		assertEquals(2, charWidth(0x1F9FF)) // 🧿
+	}
+
+	@Test fun extendedSymbolsAreWide() {
+		assertEquals(2, charWidth(0x1FA70)) // 🩰
+		assertEquals(2, charWidth(0x1FA80)) // 🪀
+		assertEquals(2, charWidth(0x1FAFF))
+	}
+
+	@Test fun chessSymbolsAreWide() {
+		assertEquals(2, charWidth(0x1FA00))
+		assertEquals(2, charWidth(0x1FA60))
+		assertEquals(2, charWidth(0x1FA6F))
+	}
+
+	@Test fun regionalIndicatorsAreWide() {
+		assertEquals(2, charWidth(0x1F1E6)) // 🇦
+		assertEquals(2, charWidth(0x1F1E8)) // 🇨
+		assertEquals(2, charWidth(0x1F1FF)) // 🇿
+	}
+
+	@Test fun enclosedIdeographicSupplement() {
+		assertEquals(2, charWidth(0x1F200)) // 🈀
+		assertEquals(2, charWidth(0x1F2FF))
+	}
+
+	@Test fun bopomofo() {
+		assertEquals(2, charWidth(0x3100))
+		assertEquals(2, charWidth(0x312F))
+	}
+
+	@Test fun enclosedCjk() {
+		assertEquals(2, charWidth(0x3200))
+		assertEquals(2, charWidth(0x33FF))
+	}
+
+	@Test fun cjkCompatibilityIdeographs() {
+		assertEquals(2, charWidth(0xF900))
+		assertEquals(2, charWidth(0xFAFF))
+	}
+
+	@Test fun cjkCompatibilityForms() {
+		assertEquals(2, charWidth(0xFE30))
+		assertEquals(2, charWidth(0xFE6F))
+	}
+
+	@Test fun kanaSupplement() {
+		assertEquals(2, charWidth(0x1B000))
+		assertEquals(2, charWidth(0x1B12F))
+	}
+
+	@Test fun yiSyllables() {
+		assertEquals(2, charWidth(0xA000))
+		assertEquals(2, charWidth(0xA4CF))
+	}
+
+	@Test fun hangulJamo() {
+		assertEquals(2, charWidth(0x1100))
+		assertEquals(2, charWidth(0x115F))
+	}
+
+}

--- a/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/bytes.kt
+++ b/mosaic-tty-terminal/src/commonMain/kotlin/com/jakewharton/mosaic/tty/terminal/bytes.kt
@@ -139,44 +139,60 @@ internal inline fun ByteArray.parseUtf8(
 	contract {
 		callsInPlace(onSuccess, EXACTLY_ONCE)
 	}
-	// TODO validate continuation bytes?
 
 	if (start == limit) onUnderflow()
-	val b1 = this[start].toInt()
+	val b1 = this[start].toInt() and 0xFF
 	val b2Index = start + 1
 
 	val codepoint: Int
 	val nextIndex: Int
 	when {
-		b1 and 0b10000000 == 0 -> {
+		b1 < 0x80 -> {
 			nextIndex = b2Index
 			codepoint = b1
 		}
 
-		b1 and 0b11100000 == 0b11000000 -> {
+		b1 in 0xC0..0xDF -> {
 			if (b2Index == limit) onUnderflow()
+			val b2 = this[b2Index].toInt() and 0xFF
+			if (b2 and 0b11000000 != 0b10000000) onError()
 			nextIndex = start + 2
 			codepoint = b1.and(0b00011111).shl(6) or
-				this[b2Index].toInt().and(0b00111111)
+				b2.and(0b00111111)
+			if (codepoint < 0x80) onError()
 		}
 
-		b1 and 0b11110000 == 0b11100000 -> {
+		b1 in 0xE0..0xEF -> {
 			val b3Index = start + 2
 			if (b3Index >= limit) onUnderflow()
+			val b2 = this[b2Index].toInt() and 0xFF
+			val b3 = this[b3Index].toInt() and 0xFF
+			if (b2 and 0b11000000 != 0b10000000) onError()
+			if (b3 and 0b11000000 != 0b10000000) onError()
 			nextIndex = start + 3
 			codepoint = b1.and(0b00001111).shl(12) or
-				this[b2Index].toInt().and(0b00111111).shl(6) or
-				this[b3Index].toInt().and(0b00111111)
+				b2.and(0b00111111).shl(6) or
+				b3.and(0b00111111)
+			if (codepoint < 0x800) onError()
+			if (codepoint in 0xD800..0xDFFF) onError()
 		}
 
-		b1 and 0b11111000 == 0b11110000 -> {
+		b1 in 0xF0..0xF7 -> {
 			val b4Index = start + 3
 			if (b4Index >= limit) onUnderflow()
+			val b2 = this[b2Index].toInt() and 0xFF
+			val b3 = this[start + 2].toInt() and 0xFF
+			val b4 = this[b4Index].toInt() and 0xFF
+			if (b2 and 0b11000000 != 0b10000000) onError()
+			if (b3 and 0b11000000 != 0b10000000) onError()
+			if (b4 and 0b11000000 != 0b10000000) onError()
 			nextIndex = start + 4
 			codepoint = b1.and(0b00000111).shl(18) or
-				this[b2Index].toInt().and(0b00111111).shl(12) or
-				this[start + 2].toInt().and(0b00111111).shl(6) or
-				this[b4Index].toInt().and(0b00111111)
+				b2.and(0b00111111).shl(12) or
+				b3.and(0b00111111).shl(6) or
+				b4.and(0b00111111)
+			if (codepoint < 0x10000) onError()
+			if (codepoint > 0x10FFFF) onError()
 		}
 
 		else -> onError()

--- a/mosaic-tty/src/commonMain/c/mosaic-tty-windows.c
+++ b/mosaic-tty/src/commonMain/c/mosaic-tty-windows.c
@@ -115,52 +115,67 @@ MOSAIC_EXPORT MosaicIoResult mosaic_tty_read_with_timeout(
 	loop:
 	waitResult = WaitForMultipleObjects(2, waitHandles, FALSE, timeoutMillis);
 	if (likely(waitResult == WAIT_OBJECT_0)) {
+		// Peek at pending events without consuming them, so that ReadFile
+		// can later consume keyboard/mouse INPUT_RECORDs as VT sequences.
+		// FOCUS_EVENT and WINDOW_BUFFER_SIZE_EVENT only exist as INPUT_RECORDs
+		// and are handled via callbacks.
 		INPUT_RECORD *records = tty->records;
-		int recordRequest = recordsCount > count ? count : recordsCount;
 		DWORD recordsRead = 0;
-		if (unlikely(!ReadConsoleInputW(tty->conin, records, recordRequest, &recordsRead))) {
+		if (unlikely(!PeekConsoleInputW(tty->conin, records, recordsCount, &recordsRead))) {
 			goto err;
 		}
 
 		MosaicTtyCallback *callback = tty->callback;
-		int nextBufferIndex = 0;
-		for (int i = 0; i < (int) recordsRead; i++) {
-			INPUT_RECORD record = records[i];
-			if (record.EventType == KEY_EVENT) {
-				if (record.Event.KeyEvent.wVirtualKeyCode == 0) {
-					buffer[nextBufferIndex++] = record.Event.KeyEvent.uChar.AsciiChar;
-				}
-				// TODO else other key shit
-			} else if (record.EventType == MOUSE_EVENT) {
-				// TODO mouse shit
-			} else if (record.EventType == FOCUS_EVENT) {
+		bool hadKeyboardEvents = false;
+
+		for (DWORD i = 0; i < recordsRead; i++) {
+			INPUT_RECORD *rec = &records[i];
+
+			switch (rec->EventType) {
+			case KEY_EVENT:
+			case MOUSE_EVENT:
+				hadKeyboardEvents = true;
+				break;
+
+			case FOCUS_EVENT:
 				if (callback) {
-					callback->onFocus(callback->opaque, record.Event.FocusEvent.bSetFocus);
+					callback->onFocus(callback->opaque, rec->Event.FocusEvent.bSetFocus);
 				}
-			} else if (record.EventType == WINDOW_BUFFER_SIZE_EVENT && tty->window_resize_events) {
-				if (callback) {
+				break;
+
+			case WINDOW_BUFFER_SIZE_EVENT:
+				if (tty->window_resize_events && callback) {
 					CONSOLE_SCREEN_BUFFER_INFO info;
-					if (unlikely(!GetConsoleScreenBufferInfo(tty->conout_for_size, &info))) {
-						goto err;
+					if (GetConsoleScreenBufferInfo(tty->conout_for_size, &info)) {
+						int columns = info.srWindow.Right - info.srWindow.Left + 1;
+						int rows = info.srWindow.Bottom - info.srWindow.Top + 1;
+						callback->onResize(callback->opaque, columns, rows, 0, 0);
 					}
-					int columns = info.srWindow.Right - info.srWindow.Left + 1;
-					int rows = info.srWindow.Bottom - info.srWindow.Top + 1;
-					callback->onResize(callback->opaque, columns, rows, 0, 0);
 				}
+				break;
 			}
 		}
 
-		// Returning 0 would indicate an interrupt, so loop if we haven't read any raw bytes.
-		if (nextBufferIndex == 0) {
+		if (hadKeyboardEvents) {
+			// Read VT sequences for keyboard input. With ENABLE_VIRTUAL_TERMINAL_INPUT,
+			// the console encodes key and mouse events as VT escape sequences in UTF-8,
+			// including full Unicode support for IME-composed characters.
+			// This call internally consumes the keyboard/mouse INPUT_RECORDs.
+			DWORD bytesRead = 0;
+			BOOL ok = ReadFile(tty->conin, buffer, count, &bytesRead, NULL);
+			if (ok && bytesRead > 0) {
+				result.count = bytesRead;
+			} else if (!ok) {
+				result.error = GetLastError();
+			}
+		}
+
+		if (result.count == 0 && result.error == 0) {
 			goto loop;
 		}
-		result.count = nextBufferIndex;
 	} else if (unlikely(waitResult == WAIT_FAILED)) {
 		goto err;
 	}
-	// Else return a count of 0 because either:
-	// - The interrupt event was selected (which auto resets its state).
-	// - The user-supplied, non-infinite timeout ran out.
 
 	ret:
 	return result;


### PR DESCRIPTION
 Adds proper support for CJK, fullwidth, and emoji characters across the entire Mosaic pipeline.                                                                                                                               
                                                                                                                                                                                                                                   
- Measurement: New charWidth() function (wcwidth-style) replaces naive codePointCount in TextLayout                                                                                                                           
- Rendering: TextPixel.isWideContinuation marks cells occupied by wide chars; rendering and ANSI output skip them                                                                                                             
- Input: toKeyEventOrNull no longer throws on unknown codepoints; UTF-8 parser validates continuation bytes/overlongs/surrogates; Windows TTY uses PeekConsoleInputW + ReadFile                                               
       for proper UTF-8/IME input     
fixes #1141     