### PR TITLE
Add Ubuntu 26.04 runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,6 +57,10 @@ jobs:
             target: linuxX64
           - os: ubuntu-24.04-arm
             target: linuxArm64
+          - os: ubuntu-26.04
+            target: linuxX64
+          - os: ubuntu-26.04-arm
+            target: linuxArm64
           - os: windows-2022
             target: mingwX64
           - os: windows-2025


### PR DESCRIPTION
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
