### PR TITLE
handle non-ascii unicode input without throwing an exception

### DIFF
--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/compat.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/compat.kt
@@ -26,10 +26,11 @@ internal fun KeyboardEvent.toKeyEventOrNull(): KeyEvent? {
 			57356 -> "Home"
 			57357 -> "End"
 			in 57364..57398 -> "F" + (codepoint - 57363)
-			else -> throw UnsupportedOperationException(toString())
+			else -> null
 		},
 		alt = alt,
 		ctrl = ctrl,
 		shift = shift,
+		codepoint = codepoint
 	)
 }

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/KeyModifier.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/layout/KeyModifier.kt
@@ -24,10 +24,11 @@ public interface KeyModifier : Modifier.Element {
 
 @[Immutable Poko]
 public class KeyEvent(
-	public val key: String,
+	public val key: String?,
 	public val alt: Boolean = false,
 	public val ctrl: Boolean = false,
 	public val shift: Boolean = false,
+	public val codepoint: Int,
 )
 
 /**

--- a/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
+++ b/mosaic-runtime/src/commonMain/kotlin/com/jakewharton/mosaic/mosaic.kt
@@ -279,7 +279,7 @@ internal class MosaicComposition(
 
 	private fun startFrameListener() {
 		scope.launch(start = UNDISPATCHED) {
-			val ctrlC = KeyEvent("c", ctrl = true)
+			fun KeyEvent.isCtrlC() = this.key == "c" && this.ctrl == true
 
 			do {
 				externalClock.withFrameNanos { nanos ->
@@ -289,7 +289,7 @@ internal class MosaicComposition(
 						if (event !is KeyboardEvent) continue
 						val keyEvent = event.toKeyEventOrNull() ?: continue
 						val keyHandled = rootNode.sendKeyEvent(keyEvent)
-						if (!keyHandled && keyEvent == ctrlC) {
+						if (!keyHandled && keyEvent.isCtrlC()) {
 							job.cancel()
 							return@withFrameNanos
 						}


### PR DESCRIPTION
This pull request updates the handling of keyboard events in the runtime, making key event processing more flexible by allowing for unknown keys and tracking the raw codepoint. The changes also refactor the detection of "Ctrl+C" to improve clarity and maintainability.

These changes allow users to safely handle custom key parsing instead of throwing an exception, providing a functional fallback until a more robust solution is implemented as discussed.

### Key event handling improvements

* The `KeyEvent` class in `layout/KeyModifier.kt` now allows `key` to be nullable and includes a new `codepoint` property, enabling better support for unknown or unmapped keys.
* The `toKeyEventOrNull` function in `compat.kt` now returns KeyEvent with "key = null" instead of throwing an exception for unknown key codes, preventing unnecessary errors and improving resilience.
* The detection of "Ctrl+C" in `mosaic.kt` is refactored from a fixed `KeyEvent` instance to a local dedicated `isCtrlC()` extension function, making the intent clearer and the code easier to maintain with new codepoint property in KeyEvent (removing the need to assign a codepoint to a Ctrl+C KeyEvent instance and compare it directly). [[1]](diffhunk://#diff-7cf46f284d882f2de10249da87d8c93d9feb6cd2c6765f72dcb8d5b73fb5b898L282-R282) [[2]](diffhunk://#diff-7cf46f284d882f2de10249da87d8c93d9feb6cd2c6765f72dcb8d5b73fb5b898L292-R292)