### PR TITLE
Add s390x architecture support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 [Unreleased]: https://github.com/JakeWharton/mosaic/compare/0.18.0...HEAD
 
 New:
-- JVM support for RISC-V!
+- JVM support for RISC-V and s390x!
 
 Changed:
 - Use the AndroidX versions of the Compose runtime and lifecycle dependencies which are now fully multiplatform. Dependency constraints to the corresponding JetBrains artifacts (which are now empty) are present to prevent symbol duplication.

--- a/mosaic-tty/build.zig
+++ b/mosaic-tty/build.zig
@@ -13,6 +13,7 @@ pub fn build(b: *std.Build) !void {
 
 	setupMosaicTarget(b, &deleteLib.step, javaHeaders, .linux, .aarch64, "com/jakewharton/mosaic/tty/jni/aarch64");
 	setupMosaicTarget(b, &deleteLib.step, javaHeaders, .linux, .riscv64, "com/jakewharton/mosaic/tty/jni/riscv64");
+	setupMosaicTarget(b, &deleteLib.step, javaHeaders, .linux, .s390x, "com/jakewharton/mosaic/tty/jni/s390x");
 	setupMosaicTarget(b, &deleteLib.step, javaHeaders, .linux, .x86_64, "com/jakewharton/mosaic/tty/jni/amd64");
 	setupMosaicTarget(b, &deleteLib.step, javaHeaders, .macos, .aarch64, "com/jakewharton/mosaic/tty/jni/aarch64");
 	setupMosaicTarget(b, &deleteLib.step, javaHeaders, .macos, .x86_64, "com/jakewharton/mosaic/tty/jni/x86_64");


### PR DESCRIPTION
<img width="1328" height="802" alt="Screenshot 2026-09-04 at 11 13 53 PM" src="https://github.com/user-attachments/assets/bd3144fc-a28f-4833-84c2-7882bc6ee111" />


---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
